### PR TITLE
Fix duplicated default expansion in conformance_dir

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -398,7 +398,7 @@ run_cwl_runner() {
     start_time=$(get_time)
 
     local runner="$PROJECT_DIR/bin/cwl-runner"
-    local conformance_dir="${GOWE_CONFORMANCE_DIR:-${GOWE_CONFORMANCE_DIR:-$PROJECT_DIR/testdata/cwl-v1.2}}"
+    local conformance_dir="${GOWE_CONFORMANCE_DIR:-$PROJECT_DIR/testdata/cwl-v1.2}"
     local output_file="$PROJECT_DIR/conformance-${mode_name}-results.txt"
 
     # Build if needed


### PR DESCRIPTION
## Summary
- Remove redundant nested `${GOWE_CONFORMANCE_DIR:-${GOWE_CONFORMANCE_DIR:-...}}` expansion (copy/paste bug)

Fixes #62

## Test plan
- [x] `bash -n` syntax check passes
- [x] No other instances of this pattern in scripts/

🤖 Generated with [Claude Code](https://claude.com/claude-code)