### PR TITLE
fix: override cwltest exit code when parsed test counts show failures

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -442,24 +442,30 @@ run_cwl_runner() {
 
     # Parse results
     local summary=""
+    local passed=0
+    local failed=0
+    local total=0
     if [ -f "$output_file" ]; then
         # Check for "All tests passed" first
         if grep -q "All tests passed" "$output_file"; then
             # Count total tests from "Test [N/M]" pattern
-            local total
             total=$(grep -oE "Test \[[0-9]+/[0-9]+\]" "$output_file" | tail -1 | grep -oE "/[0-9]+" | tr -d "/" || echo "84")
+            passed=$total
             summary="$total/$total passed"
         else
             # Look for "X tests passed" pattern
-            local passed
             passed=$(grep -oE "[0-9]+ tests? passed" "$output_file" | head -1 | grep -oE "[0-9]+" || echo "0")
-            local failed
             failed=$(grep -oE "[0-9]+ failures?" "$output_file" | head -1 | grep -oE "[0-9]+" || echo "0")
-            local total=$((passed + failed))
+            total=$((passed + failed))
             if [ $total -gt 0 ]; then
                 summary="$passed/$total passed"
             fi
         fi
+    fi
+
+    # Override exit code if parsed test counts show failures
+    if [ $total -gt 0 ] && [ "$passed" -lt "$total" ]; then
+        result=1
     fi
 
     if [ $result -eq 0 ]; then
@@ -557,24 +563,30 @@ run_server_local() {
 
     # Parse results
     local summary=""
+    local passed=0
+    local failed=0
+    local total=0
     if [ -f "$output_file" ]; then
         # Check for "All tests passed" first
         if grep -q "All tests passed" "$output_file"; then
             # Count total tests from "Test [N/M]" pattern
-            local total
             total=$(grep -oE "Test \[[0-9]+/[0-9]+\]" "$output_file" | tail -1 | grep -oE "/[0-9]+" | tr -d "/" || echo "84")
+            passed=$total
             summary="$total/$total passed"
         else
             # Look for "X tests passed" pattern
-            local passed
             passed=$(grep -oE "[0-9]+ tests? passed" "$output_file" | head -1 | grep -oE "[0-9]+" || echo "0")
-            local failed
             failed=$(grep -oE "[0-9]+ failures?" "$output_file" | head -1 | grep -oE "[0-9]+" || echo "0")
-            local total=$((passed + failed))
+            total=$((passed + failed))
             if [ $total -gt 0 ]; then
                 summary="$passed/$total passed"
             fi
         fi
+    fi
+
+    # Override exit code if parsed test counts show failures
+    if [ $total -gt 0 ] && [ "$passed" -lt "$total" ]; then
+        result=1
     fi
 
     if [ $result -eq 0 ]; then
@@ -745,24 +757,30 @@ EOF
 
     # Parse results
     local summary=""
+    local passed=0
+    local failed=0
+    local total=0
     if [ -f "$output_file" ]; then
         # Check for "All tests passed" first
         if grep -q "All tests passed" "$output_file"; then
             # Count total tests from "Test [N/M]" pattern
-            local total
             total=$(grep -oE "Test \[[0-9]+/[0-9]+\]" "$output_file" | tail -1 | grep -oE "/[0-9]+" | tr -d "/" || echo "84")
+            passed=$total
             summary="$total/$total passed"
         else
             # Look for "X tests passed" pattern
-            local passed
             passed=$(grep -oE "[0-9]+ tests? passed" "$output_file" | head -1 | grep -oE "[0-9]+" || echo "0")
-            local failed
             failed=$(grep -oE "[0-9]+ failures?" "$output_file" | head -1 | grep -oE "[0-9]+" || echo "0")
-            local total=$((passed + failed))
+            total=$((passed + failed))
             if [ $total -gt 0 ]; then
                 summary="$passed/$total passed"
             fi
         fi
+    fi
+
+    # Override exit code if parsed test counts show failures
+    if [ $total -gt 0 ] && [ "$passed" -lt "$total" ]; then
+        result=1
     fi
 
     if [ $result -eq 0 ]; then


### PR DESCRIPTION
## Summary
Fixes exit code handling in test result parsing by explicitly checking parsed test counts and overriding the exit code when failures are detected, even if the test runner exits with code 0.

## Changes
- Declare `passed`, `failed`, and `total` variables at function scope in three test runner functions
- Add logic to override exit code when `total > 0` and `passed < total`, ensuring failures are properly reported
- Applied to `run_cwl_runner()`, `run_server_local()`, and server-docker mode sections

## Impact
Improves test result reliability by ensuring the script properly reports test failures based on parsed output rather than relying solely on the test runner's exit code.