### PR TITLE
fix: skip Apptainer resource flags without cgroups v2

### DIFF
--- a/internal/cwltool/cwltool.go
+++ b/internal/cwltool/cwltool.go
@@ -32,6 +32,7 @@ type Config struct {
 	GPU                  toolexec.GPUConfig // GPU configuration
 	MaxCPUs              int                // Worker max CPUs (0 = no limit)
 	MaxMemMB             int64              // Worker max memory in MiB (0 = no limit)
+	ApptainerCgroups     bool               // System supports cgroups v2 unified
 	DockerHostPathMap    map[string]string  // Container path -> host path for DinD
 	DockerVolume         string             // Named Docker volume shared with tool containers
 	ResolveSecondary     bool               // Resolve secondary files from tool definitions
@@ -91,6 +92,7 @@ func resolveResources(runtime *cwlexpr.RuntimeContext, cfg Config, tool *cwl.Com
 	}
 	// else: no limit, keep runtime default for expressions
 
+	res.ApptainerCgroups = cfg.ApptainerCgroups
 	return res, nil
 }
 

--- a/internal/toolexec/execute.go
+++ b/internal/toolexec/execute.go
@@ -567,12 +567,15 @@ func (e *Executor) executeInApptainer(ctx context.Context, opts *Options) (*Resu
 	}
 
 	// Resource limits for container execution.
-	// Note: requires cgroups v2 support; may error on HPC systems without user cgroups.
-	if opts.Resources.RamMB > 0 {
-		apptainerArgs = append(apptainerArgs, "--memory", fmt.Sprintf("%dM", opts.Resources.RamMB))
-	}
-	if opts.Resources.Cores > 0 {
-		apptainerArgs = append(apptainerArgs, "--cpus", fmt.Sprintf("%d", opts.Resources.Cores))
+	// Apptainer --memory/--cpus require cgroups v2 unified mode.
+	// On systems without it (most HPC), skip these flags silently.
+	if opts.Resources.ApptainerCgroups {
+		if opts.Resources.RamMB > 0 {
+			apptainerArgs = append(apptainerArgs, "--memory", fmt.Sprintf("%dM", opts.Resources.RamMB))
+		}
+		if opts.Resources.Cores > 0 {
+			apptainerArgs = append(apptainerArgs, "--cpus", fmt.Sprintf("%d", opts.Resources.Cores))
+		}
 	}
 
 	// NOTE: Apptainer shares the host network by default and --net requires

--- a/internal/toolexec/executor.go
+++ b/internal/toolexec/executor.go
@@ -41,8 +41,9 @@ type GPUConfig struct {
 
 // ResourceConfig holds resource limits for container execution.
 type ResourceConfig struct {
-	Cores int   // Effective CPU cores for this task
-	RamMB int64 // Effective memory in MiB for this task
+	Cores            int   // Effective CPU cores for this task
+	RamMB            int64 // Effective memory in MiB for this task
+	ApptainerCgroups bool  // System supports cgroups v2 unified (Apptainer --memory/--cpus)
 }
 
 // Options configures a tool execution.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -83,8 +83,9 @@ type GPUWorkerConfig struct {
 
 // ResourceWorkerConfig holds resource limit settings for the worker.
 type ResourceWorkerConfig struct {
-	MaxCPUs  int   // Max CPUs for containers (0 = auto-detect)
-	MaxMemMB int64 // Max memory in MiB for containers (0 = auto-detect)
+	MaxCPUs          int   // Max CPUs for containers (0 = auto-detect)
+	MaxMemMB         int64 // Max memory in MiB for containers (0 = auto-detect)
+	ApptainerCgroups bool  // System supports cgroups v2 unified (detected at startup)
 }
 
 // New creates a Worker from configuration.
@@ -114,9 +115,14 @@ func New(cfg Config, logger *slog.Logger) (*Worker, error) {
 	if cfg.Resources.MaxCPUs == 0 {
 		cfg.Resources.MaxCPUs = runtime.NumCPU()
 	}
+	// Detect cgroups v2 unified mode for Apptainer resource limits.
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err == nil {
+		cfg.Resources.ApptainerCgroups = true
+	}
 	logger.Info("worker resource limits",
 		"max_cpus", cfg.Resources.MaxCPUs,
 		"max_mem_mb", cfg.Resources.MaxMemMB,
+		"apptainer_cgroups", cfg.Resources.ApptainerCgroups,
 	)
 
 	// Build TLS config.
@@ -399,6 +405,7 @@ func (w *Worker) executeWithCWLTool(ctx context.Context, task *model.Task, taskD
 		GPU:                   toolexecGPU(w.gpu),
 		MaxCPUs:               w.resources.MaxCPUs,
 		MaxMemMB:              w.resources.MaxMemMB,
+		ApptainerCgroups:      w.resources.ApptainerCgroups,
 		ResolveSecondary:      true,
 		RemoveDefaultListings: true,
 	}


### PR DESCRIPTION
## Summary

- Detect cgroups v2 unified mode once at worker startup (`/sys/fs/cgroup/cgroup.controllers`)
- Only pass `--memory`/`--cpus` flags to Apptainer when cgroups v2 is available
- Without this fix, auto-detected resource limits cause every Apptainer container to fail with exit 255 on systems without cgroups v2 (most HPC clusters)
- Docker is unaffected (always supports `--memory`/`--cpus`)

Depends on #81.

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] Distributed-apptainer conformance: **375/378** (was 0/378 before fix)
  - Test 227: known Apptainer limitation (network isolation requires root)
  - Tests 237/238: pre-existing distributed mode issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)