### PR TITLE
docs: add worker group routing, secrets, and version tracking

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -313,6 +313,52 @@ bin/gowe-worker \
   --extra-bind /opt/licenses
 ```
 
+### Inject secrets into containers
+
+For tools that need authentication tokens (e.g., HuggingFace):
+
+```bash
+# Create a secrets file (chmod 600)
+cat > /path/to/secrets.env << 'EOF'
+# HuggingFace authentication
+HF_TOKEN=hf_abc123
+HUGGING_FACE_HUB_TOKEN=hf_abc123
+EOF
+chmod 600 /path/to/secrets.env
+
+# Start worker with secrets
+bin/gowe-worker \
+  --server http://localhost:8080 \
+  --runtime apptainer \
+  --image-dir /scout/containers/ \
+  --secret-file /path/to/secrets.env
+```
+
+Secrets are injected into every container but never sent to the server or stored in task data.
+
+### Route tasks to a specific worker group
+
+Use `gowe:Execution.worker_group` in CWL to target a group:
+
+```yaml
+hints:
+  gowe:Execution:
+    worker_group: esmfold
+```
+
+Then start a worker in that group:
+
+```bash
+bin/gowe-worker --server http://localhost:8080 --runtime apptainer \
+  --image-dir /scout/containers/ --group esmfold --gpu --gpu-id 3
+```
+
+Or override the group at submit time:
+
+```bash
+bin/gowe submit workflow.cwl -i job.json --group esmfold
+```
+
 ### Run multiple workers on one machine
 
 ```bash

--- a/docs/cwl-hints.md
+++ b/docs/cwl-hints.md
@@ -35,6 +35,7 @@ hints:
 | Field | Type | Description |
 |-------|------|-------------|
 | `executor` | string | Execution backend: `local`, `worker`, `bvbrc` |
+| `worker_group` | string | Target worker group for task routing (e.g., `gpu`, `esmfold`) |
 | `bvbrc_app_id` | string | BV-BRC application ID (implies `executor: bvbrc`) |
 | `docker_image` | string | Container image override (takes priority over `DockerRequirement.dockerPull`) |
 
@@ -74,6 +75,23 @@ hints:
     executor: bvbrc
     bvbrc_app_id: GenomeAssembly2
 ```
+
+**Route to a specific worker group:**
+
+```yaml
+$namespaces:
+  gowe: https://github.com/wilke/GoWe#
+
+hints:
+  gowe:Execution:
+    worker_group: esmfold
+  DockerRequirement:
+    dockerPull: "esmfold.sif"
+```
+
+Only workers started with `--group esmfold` will pick up this task. Workers in the `default` group will skip it. This can also be combined with `gowe:ResourceData` for dataset affinity.
+
+The `--group` CLI flag on `gowe submit` sets a submission-level fallback: step-level `worker_group` hints take priority over the submission-level group.
 
 **Override container image:**
 
@@ -224,7 +242,7 @@ This tool:
 ```
 CWL hints
   ↓ parser/extractStepHints()
-model.StepHints (BVBRCAppID, ExecutorType, DockerImage, RequiredDatasets)
+model.StepHints (BVBRCAppID, ExecutorType, DockerImage, WorkerGroup, RequiredDatasets)
   ↓ scheduler/createTaskFromStep()
 model.Task.RuntimeHints
   ↓ store/CheckoutTask()

--- a/docs/quickstart-apptainer.md
+++ b/docs/quickstart-apptainer.md
@@ -160,6 +160,8 @@ open http://localhost:8080/submissions
 | `--gpu` | Enable GPU passthrough | |
 | `--gpu-id` | Specific GPU device ID | `0` |
 | `--group` | Worker group for routing | `gpu-workers` |
+| `--secret` | Secret env var for containers (repeatable) | `HF_TOKEN=hf_abc` |
+| `--secret-file` | File with secret env vars | `/path/to/secrets.env` |
 
 ## Multi-Worker Setup
 

--- a/docs/tools/worker.md
+++ b/docs/tools/worker.md
@@ -5,12 +5,18 @@ The GoWe worker is a remote execution agent that polls the GoWe server for tasks
 ## Installation
 
 ```bash
-# From source
-go build -o gowe-worker ./cmd/worker
+# From source (with version tracking)
+COMMIT=$(git rev-parse HEAD)
+go build -ldflags "-X main.Version=$COMMIT" -o gowe-worker ./cmd/worker
+
+# Or via Makefile (automatically embeds git commit hash)
+make build
 
 # Or install globally
 go install github.com/me/gowe/cmd/worker@latest
 ```
+
+The worker reports its build version (git commit hash) during registration. This is visible in the workers UI and API, useful for verifying all workers run the same binary.
 
 ## Usage
 
@@ -77,6 +83,30 @@ gowe-worker --dataset boltz=/data/boltz --dataset chai=/data/chai
 # Comma-separated
 gowe-worker --extra-bind /scratch,/opt/licenses
 gowe-worker --dataset boltz=/data/boltz,chai=/data/chai
+```
+
+#### Secret Environment Variables
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--secret` | `""` | Secret env var `NAME=value` injected into containers (repeatable, never sent to server) |
+| `--secret-file` | `""` | File with secret env vars (`NAME=value` per line, `#` comments) |
+
+Secrets are injected into every container the worker runs. They are never sent to the server, stored in task data, or exposed in the API/UI/logs. Only secret names are logged at startup.
+
+```bash
+# Inline secrets (repeatable)
+gowe-worker --secret HF_TOKEN=hf_abc123 --secret API_KEY=xyz
+
+# From a file (CLI flags override file entries with same name)
+gowe-worker --secret-file /path/to/secrets.env
+```
+
+File format:
+```
+# HuggingFace authentication
+HF_TOKEN=hf_abc123
+HUGGING_FACE_HUB_TOKEN=hf_abc123
 ```
 
 #### TLS Configuration


### PR DESCRIPTION
- cwl-hints.md: add worker_group field to gowe:Execution, with example
- tools/worker.md: add --secret/--secret-file flags, version build instructions
- cookbook.md: add recipes for secrets injection and worker group routing
- quickstart-apptainer.md: add --secret/--secret-file to flag table