### PR TITLE
feat: upload output manifest to workspace after staging

### DIFF
--- a/internal/scheduler/workspace.go
+++ b/internal/scheduler/workspace.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 type wsStagerInterface interface {
 	StageIn(ctx context.Context, location string, destPath string, opts staging.StageOptions) error
 	StageOut(ctx context.Context, srcPath string, taskID string, opts staging.StageOptions) (string, error)
+	UploadContent(ctx context.Context, destPath string, content string, opts staging.StageOptions) (string, error)
 	WithToken(token string) *staging.WorkspaceStager
 }
 
@@ -170,6 +172,12 @@ func (l *Loop) poststageWorkspaceOutputs(ctx context.Context, affected map[strin
 		})
 
 		if allOK {
+			// Upload output manifest with ws:// locations.
+			if err := l.uploadOutputManifest(ctx, stager, sub, baseDest); err != nil {
+				l.logger.Warn("upload output manifest failed (non-fatal)",
+					"submission_id", sub.ID, "error", err)
+			}
+
 			sub.OutputState = "delivered"
 			if err := l.updateSubmission(ctx, sub); err != nil {
 				l.logger.Error("update submission after post-stage",
@@ -186,6 +194,39 @@ func (l *Loop) poststageWorkspaceOutputs(ctx context.Context, affected map[strin
 		affected[sub.ID] = true
 	}
 
+	return nil
+}
+
+// uploadOutputManifest writes the submission outputs as a JSON manifest file
+// to the workspace destination. This gives users a machine-readable record of
+// what each output file represents (workflow output IDs, types, ws:// locations).
+func (l *Loop) uploadOutputManifest(ctx context.Context, stager *staging.WorkspaceStager, sub *model.Submission, baseDest string) error {
+	manifest := map[string]any{
+		"submission_id": sub.ID,
+		"workflow_id":   sub.WorkflowID,
+		"workflow_name": sub.WorkflowName,
+		"state":         string(sub.State),
+		"outputs":       sub.Outputs,
+	}
+	if sub.CompletedAt != nil {
+		manifest["completed_at"] = sub.CompletedAt.Format(time.RFC3339)
+	}
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	destPath := strings.TrimRight(baseDest, "/") + "/_gowe_outputs.json"
+	_, err = stager.UploadContent(ctx, destPath, string(data), staging.StageOptions{})
+	if err != nil {
+		return fmt.Errorf("upload manifest: %w", err)
+	}
+
+	l.logger.Info("uploaded output manifest",
+		"submission_id", sub.ID,
+		"path", destPath,
+	)
 	return nil
 }
 

--- a/internal/server/handler_discovery.go
+++ b/internal/server/handler_discovery.go
@@ -24,6 +24,8 @@ func (s *Server) handleDiscovery(w http.ResponseWriter, r *http.Request) {
 		Endpoints: []endpointInfo{
 			{"/api/v1/workflows", []string{"GET", "POST"}, "Workflow definition management"},
 			{"/api/v1/workflows/{id}", []string{"GET", "PUT", "DELETE"}, "Single Workflow operations"},
+			{"/api/v1/workflows/{id}/inputs", []string{"GET"}, "Get Workflow input definitions"},
+			{"/api/v1/workflows/{id}/outputs", []string{"GET"}, "Get Workflow output definitions"},
 			{"/api/v1/workflows/{id}/validate", []string{"POST"}, "Validate a Workflow without persisting"},
 			{"/api/v1/submissions", []string{"GET", "POST"}, "Submission (run) management. POST accepts ?dry_run=true for validation without execution"},
 			{"/api/v1/submissions/{id}", []string{"GET"}, "Single Submission detail with Tasks"},

--- a/internal/server/handler_workflows.go
+++ b/internal/server/handler_workflows.go
@@ -197,6 +197,40 @@ func (s *Server) handleGetWorkflow(w http.ResponseWriter, r *http.Request) {
 	respondOK(w, reqID, wf)
 }
 
+func (s *Server) handleGetWorkflowInputs(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+	idOrName := chi.URLParam(r, "id")
+
+	wf, err := s.resolveWorkflow(r.Context(), idOrName)
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError,
+			&model.APIError{Code: model.ErrInternal, Message: err.Error()})
+		return
+	}
+	if wf == nil {
+		respondError(w, reqID, http.StatusNotFound, model.NewNotFoundError("workflow", idOrName))
+		return
+	}
+	respondOK(w, reqID, wf.Inputs)
+}
+
+func (s *Server) handleGetWorkflowOutputs(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+	idOrName := chi.URLParam(r, "id")
+
+	wf, err := s.resolveWorkflow(r.Context(), idOrName)
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError,
+			&model.APIError{Code: model.ErrInternal, Message: err.Error()})
+		return
+	}
+	if wf == nil {
+		respondError(w, reqID, http.StatusNotFound, model.NewNotFoundError("workflow", idOrName))
+		return
+	}
+	respondOK(w, reqID, wf.Outputs)
+}
+
 func (s *Server) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 	reqID := RequestIDFromContext(r.Context())
 	id := chi.URLParam(r, "id")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -230,6 +230,8 @@ func (s *Server) routes() {
 				r.Post("/", s.handleCreateWorkflow)
 				r.Route("/{id}", func(r chi.Router) {
 					r.Get("/", s.handleGetWorkflow)
+					r.Get("/inputs", s.handleGetWorkflowInputs)
+					r.Get("/outputs", s.handleGetWorkflowOutputs)
 					r.Put("/", s.handleUpdateWorkflow)
 					r.Delete("/", s.handleDeleteWorkflow)
 					r.Post("/validate", s.handleValidateWorkflow)

--- a/pkg/staging/workspace.go
+++ b/pkg/staging/workspace.go
@@ -243,6 +243,44 @@ func (s *WorkspaceStager) download(ctx context.Context, wsPath string, destPath 
 	return nil
 }
 
+// UploadContent uploads string content directly to a workspace path (no local file needed).
+// Returns the ws:// URI of the created object.
+func (s *WorkspaceStager) UploadContent(ctx context.Context, destPath string, content string, opts StageOptions) (string, error) {
+	token := s.resolveToken(opts)
+	if token == "" {
+		return "", fmt.Errorf("workspace stager: no authentication token available")
+	}
+
+	// Ensure parent directory exists.
+	dir := destPath[:strings.LastIndex(destPath, "/")]
+	if dir != "" {
+		if err := s.ensureDir(ctx, dir, token); err != nil {
+			return "", fmt.Errorf("workspace stager: ensure dir: %w", err)
+		}
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < s.config.MaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(time.Duration(attempt) * time.Second):
+			}
+		}
+
+		err := s.upload(ctx, destPath, content, token)
+		if err == nil {
+			return "ws://" + destPath, nil
+		}
+		lastErr = err
+		s.logger.Warn("workspace upload content attempt failed",
+			"path", destPath, "attempt", attempt+1, "error", err)
+	}
+
+	return "", fmt.Errorf("workspace stager: upload content failed after %d attempts: %w", s.config.MaxRetries, lastErr)
+}
+
 // upload creates/overwrites a file in the workspace.
 func (s *WorkspaceStager) upload(ctx context.Context, wsPath string, content string, token string) error {
 	bvbrcCfg := bvbrc.Config{


### PR DESCRIPTION
## Summary

- Add `UploadContent()` method to `WorkspaceStager` for uploading string content directly to a workspace path (no local file needed)
- After all output files are staged to a `ws://` destination, upload `_gowe_outputs.json` containing submission metadata and the full outputs map with `ws://` locations
- Manifest upload is non-fatal — failure logs a warning but does not fail the submission

This gives users a machine-readable record in their BV-BRC workspace describing what each output file represents (workflow output IDs, types, locations).

Example `_gowe_outputs.json`:
```json
{
  "submission_id": "sub_xyz789",
  "workflow_id": "wf_abc123",
  "workflow_name": "protein-structure-prediction",
  "state": "COMPLETED",
  "completed_at": "2026-04-08T12:00:00Z",
  "outputs": {
    "structures": { "class": "Directory", "location": "ws:///user@bvbrc/home/results/structures" },
    "metrics": { "class": "File", "location": "ws:///user@bvbrc/home/results/metrics.csv" }
  }
}
```

## Test plan

- [x] `go vet` clean
- [x] `go test ./pkg/staging/... ./internal/scheduler/...` pass
- [x] All binaries build
- [ ] End-to-end: submit workflow with `output_destination: ws://...`, verify `_gowe_outputs.json` appears in workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)