### PR TITLE
feat: stuck task error propagation, retry endpoint, no wasted retries

### DIFF
--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -1160,8 +1160,11 @@ func (l *Loop) hasOnlineWorkers() bool {
 }
 
 // addUserToken adds user authentication token to task runtime hints.
+// When server-side workspace staging is enabled (wsStager != nil), the server
+// handles all ws:// operations and workers don't need the token — skip embedding
+// it in task data to avoid storing credentials in the database unnecessarily.
 func (l *Loop) addUserToken(task *model.Task, sub *model.Submission) {
-	if sub.UserToken != "" {
+	if sub.UserToken != "" && l.wsStager == nil {
 		if task.RuntimeHints == nil {
 			task.RuntimeHints = &model.RuntimeHints{}
 		}

--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -1445,13 +1445,23 @@ func (l *Loop) detectStuckTasks(ctx context.Context, affected map[string]bool) e
 		}
 		l.stuck.lastCounts[key] = count
 
-		if l.stuck.staleTicks[key] < l.config.StuckTaskThreshold {
-			continue
-		}
-
 		// Build a synthetic RuntimeHints for canMatchTask from the key.
 		hints := hintsFromRequirementKey(key)
 		canMatch, reason := canMatchTask(caps, hints)
+
+		// Emit an early warning at half the stuck threshold when no worker can match.
+		if l.stuck.staleTicks[key] == l.config.StuckTaskThreshold/2 && !canMatch {
+			l.logger.Warn("tasks approaching stuck threshold: no capable worker",
+				"count", count, "reason", reason,
+				"group", key.WorkerGroup,
+				"prestage", key.PrestageIDs,
+				"stale_ticks", l.stuck.staleTicks[key],
+				"threshold", l.config.StuckTaskThreshold)
+		}
+
+		if l.stuck.staleTicks[key] < l.config.StuckTaskThreshold {
+			continue
+		}
 
 		if !canMatch {
 			l.logger.Error("stuck tasks: no capable worker",
@@ -1475,18 +1485,22 @@ func (l *Loop) detectStuckTasks(ctx context.Context, affected map[string]bool) e
 					oldest = t
 				}
 			}
-			// Only fail if retries remain, so recovery is possible.
-			if oldest.RetryCount < oldest.MaxRetries {
-				now := time.Now().UTC()
-				oldest.State = model.TaskStateFailed
-				oldest.Stderr = fmt.Sprintf("stuck task failed by scheduler: %s", reason)
-				oldest.CompletedAt = &now
-				if err := l.store.UpdateTask(ctx, oldest); err != nil {
-					l.logger.Error("fail stuck task", "task_id", oldest.ID, "error", err)
-				} else {
-					l.logger.Info("failed stuck task", "task_id", oldest.ID, "reason", reason)
-					affected[oldest.SubmissionID] = true
-				}
+
+			// Build a rich error message with task requirements and worker summary.
+			stderrMsg := buildStuckTaskError(key, reason, caps, l.stuck.staleTicks[key])
+
+			now := time.Now().UTC()
+			oldest.State = model.TaskStateFailed
+			oldest.Stderr = stderrMsg
+			oldest.CompletedAt = &now
+			// No capable worker exists — retrying won't help. Exhaust retries
+			// so markRetries does not re-queue this task.
+			oldest.MaxRetries = oldest.RetryCount
+			if err := l.store.UpdateTask(ctx, oldest); err != nil {
+				l.logger.Error("fail stuck task", "task_id", oldest.ID, "error", err)
+			} else {
+				l.logger.Info("failed stuck task", "task_id", oldest.ID, "reason", reason)
+				affected[oldest.SubmissionID] = true
 			}
 		}
 	}
@@ -1535,6 +1549,71 @@ func hintsFromRequirementKey(key taskRequirementKey) *model.RuntimeHints {
 		}
 	}
 	return hints
+}
+
+// buildStuckTaskError constructs a detailed error message for a stuck task,
+// including what the task required and what workers are currently available.
+func buildStuckTaskError(key taskRequirementKey, reason string, caps *WorkerCapabilities, staleTicks int) string {
+	var b strings.Builder
+	b.WriteString("Task stuck: no capable worker available\n")
+
+	// Required section.
+	b.WriteString("Required:")
+	if key.WorkerGroup != "" {
+		fmt.Fprintf(&b, " worker_group=%s", key.WorkerGroup)
+	}
+	if key.PrestageIDs != "" {
+		fmt.Fprintf(&b, " prestage=[%s]", key.PrestageIDs)
+	}
+	if key.WorkerGroup == "" && key.PrestageIDs == "" {
+		b.WriteString(" (no specific constraints)")
+	}
+	b.WriteString("\n")
+
+	// Available workers section.
+	if caps.OnlineCount == 0 {
+		b.WriteString("Available workers: 0 online\n")
+	} else {
+		// Collect unique groups and runtimes.
+		groupSet := make(map[string]bool)
+		runtimeSet := make(map[string]bool)
+		datasetSet := make(map[string]bool)
+		for _, w := range caps.Workers {
+			g := w.Group
+			if g == "" {
+				g = "default"
+			}
+			groupSet[g] = true
+			runtimeSet[string(w.Runtime)] = true
+			for dsID := range w.Datasets {
+				datasetSet[dsID] = true
+			}
+		}
+		groups := sortedKeys(groupSet)
+		runtimes := sortedKeys(runtimeSet)
+		datasets := sortedKeys(datasetSet)
+
+		fmt.Fprintf(&b, "Available workers: %d online (groups: [%s], runtimes: [%s]",
+			caps.OnlineCount, strings.Join(groups, ", "), strings.Join(runtimes, ", "))
+		if len(datasets) > 0 {
+			fmt.Fprintf(&b, ", datasets: [%s]", strings.Join(datasets, ", "))
+		}
+		b.WriteString(")\n")
+	}
+
+	fmt.Fprintf(&b, "Reason: %s\n", reason)
+	fmt.Fprintf(&b, "Stale ticks: %d", staleTicks)
+	return b.String()
+}
+
+// sortedKeys returns the keys of a map[string]bool in sorted order.
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // advanceSteps checks DISPATCHED/RUNNING StepInstances and completes them

--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -1560,7 +1560,6 @@ func buildStuckTaskError(key taskRequirementKey, reason string, caps *WorkerCapa
 	var b strings.Builder
 	b.WriteString("Task stuck: no capable worker available\n")
 
-	// Required section.
 	b.WriteString("Required:")
 	if key.WorkerGroup != "" {
 		fmt.Fprintf(&b, " worker_group=%s", key.WorkerGroup)
@@ -1573,11 +1572,9 @@ func buildStuckTaskError(key taskRequirementKey, reason string, caps *WorkerCapa
 	}
 	b.WriteString("\n")
 
-	// Available workers section.
 	if caps.OnlineCount == 0 {
 		b.WriteString("Available workers: 0 online\n")
 	} else {
-		// Collect unique groups and runtimes.
 		groupSet := make(map[string]bool)
 		runtimeSet := make(map[string]bool)
 		datasetSet := make(map[string]bool)

--- a/internal/scheduler/loop_test.go
+++ b/internal/scheduler/loop_test.go
@@ -1073,7 +1073,7 @@ func TestDetectStuckTasks_FailAction(t *testing.T) {
 	if updated.State != model.TaskStateFailed {
 		t.Errorf("expected task to be FAILED, got %s", updated.State)
 	}
-	if !strings.Contains(updated.Stderr, "stuck task failed") {
+	if !strings.Contains(updated.Stderr, "Task stuck: no capable worker") {
 		t.Errorf("expected stuck task reason in stderr, got: %s", updated.Stderr)
 	}
 }

--- a/internal/server/handler_discovery.go
+++ b/internal/server/handler_discovery.go
@@ -28,6 +28,7 @@ func (s *Server) handleDiscovery(w http.ResponseWriter, r *http.Request) {
 			{"/api/v1/submissions", []string{"GET", "POST"}, "Submission (run) management. POST accepts ?dry_run=true for validation without execution"},
 			{"/api/v1/submissions/{id}", []string{"GET"}, "Single Submission detail with Tasks"},
 			{"/api/v1/submissions/{id}/cancel", []string{"PUT"}, "Cancel a running Submission"},
+			{"/api/v1/submissions/{id}/retry", []string{"PUT"}, "Retry a failed Submission (resets failed steps and tasks)"},
 			{"/api/v1/submissions/{sid}/tasks", []string{"GET"}, "List Tasks in a Submission"},
 			{"/api/v1/submissions/{sid}/tasks/{tid}", []string{"GET"}, "Single Task detail"},
 			{"/api/v1/submissions/{sid}/tasks/{tid}/logs", []string{"GET"}, "Task stdout/stderr logs"},

--- a/internal/server/handler_submissions.go
+++ b/internal/server/handler_submissions.go
@@ -243,6 +243,98 @@ func (s *Server) handleCancelSubmission(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+func (s *Server) handleRetrySubmission(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+	id := chi.URLParam(r, "id")
+
+	sub, err := s.store.GetSubmission(r.Context(), id)
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError,
+			&model.APIError{Code: model.ErrInternal, Message: err.Error()})
+		return
+	}
+	if sub == nil {
+		respondError(w, reqID, http.StatusNotFound, model.NewNotFoundError("submission", id))
+		return
+	}
+
+	if sub.State != model.SubmissionStateFailed {
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code:    model.ErrValidation,
+			Message: "cannot retry submission in state " + string(sub.State) + "; only FAILED submissions can be retried",
+		})
+		return
+	}
+
+	// Reset the submission to RUNNING so the scheduler picks it up.
+	sub.State = model.SubmissionStateRunning
+	sub.Error = nil
+	sub.CompletedAt = nil
+	sub.OutputState = ""
+
+	if err := s.store.UpdateSubmission(r.Context(), sub); err != nil {
+		respondError(w, reqID, http.StatusInternalServerError,
+			&model.APIError{Code: model.ErrInternal, Message: err.Error()})
+		return
+	}
+
+	// Reset FAILED step instances back to WAITING so the scheduler re-evaluates dependencies.
+	stepsReset := 0
+	steps, err := s.store.ListStepsBySubmission(r.Context(), sub.ID)
+	if err != nil {
+		s.logger.Error("retry: list step instances", "submission_id", sub.ID, "error", err)
+	} else {
+		for _, si := range steps {
+			if si.State != model.StepStateFailed {
+				continue
+			}
+			si.State = model.StepStateWaiting
+			si.CompletedAt = nil
+			if err := s.store.UpdateStepInstance(r.Context(), si); err != nil {
+				s.logger.Error("retry: reset step instance", "step_id", si.ID, "error", err)
+				continue
+			}
+			stepsReset++
+		}
+	}
+
+	// Reset FAILED tasks back to PENDING with cleared retry budget and error state.
+	tasksReset := 0
+	tasks, err := s.store.ListTasksBySubmission(r.Context(), sub.ID)
+	if err != nil {
+		s.logger.Error("retry: list tasks", "submission_id", sub.ID, "error", err)
+	} else {
+		for _, task := range tasks {
+			if task.State != model.TaskStateFailed {
+				continue
+			}
+			task.State = model.TaskStatePending
+			task.RetryCount = 0
+			task.CompletedAt = nil
+			task.Stderr = ""
+			task.ExitCode = nil
+			if err := s.store.UpdateTask(r.Context(), task); err != nil {
+				s.logger.Error("retry: reset task", "task_id", task.ID, "error", err)
+				continue
+			}
+			tasksReset++
+		}
+	}
+
+	s.logger.Info("submission retried",
+		"id", sub.ID,
+		"steps_reset", stepsReset,
+		"tasks_reset", tasksReset,
+	)
+
+	respondOK(w, reqID, map[string]any{
+		"id":          sub.ID,
+		"state":       sub.State,
+		"steps_reset": stepsReset,
+		"tasks_reset": tasksReset,
+	})
+}
+
 // buildDryRunReport validates a workflow and inputs without creating a submission.
 func (s *Server) buildDryRunReport(wf *model.Workflow, inputs map[string]any) map[string]any {
 	var errors []map[string]string

--- a/internal/server/handler_submissions.go
+++ b/internal/server/handler_submissions.go
@@ -164,12 +164,29 @@ func (s *Server) handleListSubmissions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Compute task summaries for each submission.
+	for _, sub := range subs {
+		tasks, err := s.store.ListTasksBySubmission(r.Context(), sub.ID)
+		if err == nil {
+			sub.TaskSummary = model.ComputeTaskSummary(tasksToValue(tasks))
+		}
+	}
+
 	respondList(w, reqID, subs, &model.Pagination{
 		Total:   total,
 		Limit:   opts.Limit,
 		Offset:  opts.Offset,
 		HasMore: opts.Offset+opts.Limit < total,
 	})
+}
+
+// tasksToValue converts a slice of task pointers to values for ComputeTaskSummary.
+func tasksToValue(tasks []*model.Task) []model.Task {
+	result := make([]model.Task, len(tasks))
+	for i, t := range tasks {
+		result[i] = *t
+	}
+	return result
 }
 
 func (s *Server) handleGetSubmission(w http.ResponseWriter, r *http.Request) {
@@ -186,6 +203,13 @@ func (s *Server) handleGetSubmission(w http.ResponseWriter, r *http.Request) {
 		respondError(w, reqID, http.StatusNotFound, model.NewNotFoundError("submission", id))
 		return
 	}
+
+	// Compute task summary (not stored, derived from tasks).
+	tasks, err := s.store.ListTasksBySubmission(r.Context(), sub.ID)
+	if err == nil {
+		sub.TaskSummary = model.ComputeTaskSummary(tasksToValue(tasks))
+	}
+
 	respondOK(w, reqID, sub)
 }
 

--- a/internal/server/handler_submissions.go
+++ b/internal/server/handler_submissions.go
@@ -164,11 +164,18 @@ func (s *Server) handleListSubmissions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Compute task summaries for each submission.
-	for _, sub := range subs {
-		tasks, err := s.store.ListTasksBySubmission(r.Context(), sub.ID)
-		if err == nil {
-			sub.TaskSummary = model.ComputeTaskSummary(tasksToValue(tasks))
+	// Compute task summaries in a single batch query.
+	if len(subs) > 0 {
+		ids := make([]string, len(subs))
+		for i, sub := range subs {
+			ids[i] = sub.ID
+		}
+		if summaries, err := s.store.GetTaskSummaries(r.Context(), ids); err == nil {
+			for _, sub := range subs {
+				if ts, ok := summaries[sub.ID]; ok {
+					sub.TaskSummary = ts
+				}
+			}
 		}
 	}
 
@@ -178,15 +185,6 @@ func (s *Server) handleListSubmissions(w http.ResponseWriter, r *http.Request) {
 		Offset:  opts.Offset,
 		HasMore: opts.Offset+opts.Limit < total,
 	})
-}
-
-// tasksToValue converts a slice of task pointers to values for ComputeTaskSummary.
-func tasksToValue(tasks []*model.Task) []model.Task {
-	result := make([]model.Task, len(tasks))
-	for i, t := range tasks {
-		result[i] = *t
-	}
-	return result
 }
 
 func (s *Server) handleGetSubmission(w http.ResponseWriter, r *http.Request) {
@@ -204,10 +202,11 @@ func (s *Server) handleGetSubmission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Compute task summary (not stored, derived from tasks).
-	tasks, err := s.store.ListTasksBySubmission(r.Context(), sub.ID)
-	if err == nil {
-		sub.TaskSummary = model.ComputeTaskSummary(tasksToValue(tasks))
+	// Compute task summary via aggregate query.
+	if summaries, err := s.store.GetTaskSummaries(r.Context(), []string{sub.ID}); err == nil {
+		if ts, ok := summaries[sub.ID]; ok {
+			sub.TaskSummary = ts
+		}
 	}
 
 	respondOK(w, reqID, sub)
@@ -302,47 +301,14 @@ func (s *Server) handleRetrySubmission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reset FAILED step instances back to WAITING so the scheduler re-evaluates dependencies.
-	stepsReset := 0
-	steps, err := s.store.ListStepsBySubmission(r.Context(), sub.ID)
+	// Batch-reset FAILED steps and tasks.
+	stepsReset, err := s.store.ResetFailedSteps(r.Context(), sub.ID)
 	if err != nil {
-		s.logger.Error("retry: list step instances", "submission_id", sub.ID, "error", err)
-	} else {
-		for _, si := range steps {
-			if si.State != model.StepStateFailed {
-				continue
-			}
-			si.State = model.StepStateWaiting
-			si.CompletedAt = nil
-			if err := s.store.UpdateStepInstance(r.Context(), si); err != nil {
-				s.logger.Error("retry: reset step instance", "step_id", si.ID, "error", err)
-				continue
-			}
-			stepsReset++
-		}
+		s.logger.Error("retry: reset failed steps", "submission_id", sub.ID, "error", err)
 	}
-
-	// Reset FAILED tasks back to PENDING with cleared retry budget and error state.
-	tasksReset := 0
-	tasks, err := s.store.ListTasksBySubmission(r.Context(), sub.ID)
+	tasksReset, err := s.store.ResetFailedTasks(r.Context(), sub.ID)
 	if err != nil {
-		s.logger.Error("retry: list tasks", "submission_id", sub.ID, "error", err)
-	} else {
-		for _, task := range tasks {
-			if task.State != model.TaskStateFailed {
-				continue
-			}
-			task.State = model.TaskStatePending
-			task.RetryCount = 0
-			task.CompletedAt = nil
-			task.Stderr = ""
-			task.ExitCode = nil
-			if err := s.store.UpdateTask(r.Context(), task); err != nil {
-				s.logger.Error("retry: reset task", "task_id", task.ID, "error", err)
-				continue
-			}
-			tasksReset++
-		}
+		s.logger.Error("retry: reset failed tasks", "submission_id", sub.ID, "error", err)
 	}
 
 	s.logger.Info("submission retried",

--- a/internal/server/handler_tasks.go
+++ b/internal/server/handler_tasks.go
@@ -19,6 +19,10 @@ func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	for _, t := range tasks {
+		sanitizeTaskCredentials(t)
+	}
+
 	respondList(w, reqID, tasks, &model.Pagination{
 		Total:   total,
 		Limit:   opts.Limit,
@@ -41,7 +45,17 @@ func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
 		respondError(w, reqID, http.StatusNotFound, model.NewNotFoundError("task", tid))
 		return
 	}
+	sanitizeTaskCredentials(task)
 	respondOK(w, reqID, task)
+}
+
+// sanitizeTaskCredentials strips sensitive credentials from task data before
+// returning it in API responses. Workers receive credentials through the
+// checkout endpoint; they must not leak through the public task API.
+func sanitizeTaskCredentials(t *model.Task) {
+	if t.RuntimeHints != nil && t.RuntimeHints.StagerOverrides != nil {
+		t.RuntimeHints.StagerOverrides.HTTPCredential = nil
+	}
 }
 
 func (s *Server) handleGetTaskLogs(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/resolve_refs_test.go
+++ b/internal/server/resolve_refs_test.go
@@ -89,6 +89,11 @@ func (m *mockStore) GetTasksByState(context.Context, model.TaskState) ([]*model.
 func (m *mockStore) CancelNonTerminalTasks(context.Context, string, time.Time) (int, error) {
 	return 0, nil
 }
+func (m *mockStore) GetTaskSummaries(context.Context, []string) (map[string]model.TaskSummary, error) {
+	return nil, nil
+}
+func (m *mockStore) ResetFailedTasks(context.Context, string) (int, error)  { return 0, nil }
+func (m *mockStore) ResetFailedSteps(context.Context, string) (int, error) { return 0, nil }
 
 func (m *mockStore) CreateSession(context.Context, *model.Session) error            { return nil }
 func (m *mockStore) GetSession(context.Context, string) (*model.Session, error)     { return nil, nil }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -243,6 +243,7 @@ func (s *Server) routes() {
 				r.Route("/{id}", func(r chi.Router) {
 					r.Get("/", s.handleGetSubmission)
 					r.Put("/cancel", s.handleCancelSubmission)
+					r.Put("/retry", s.handleRetrySubmission)
 					// Tasks nested under submissions
 					r.Route("/tasks", func(r chi.Router) {
 						r.Get("/", s.handleListTasks)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1263,6 +1263,89 @@ func (s *SQLiteStore) CancelNonTerminalTasks(ctx context.Context, submissionID s
 	return int(n), nil
 }
 
+func (s *SQLiteStore) GetTaskSummaries(ctx context.Context, submissionIDs []string) (map[string]model.TaskSummary, error) {
+	if len(submissionIDs) == 0 {
+		return nil, nil
+	}
+	s.logger.Debug("sql", "op", "get_task_summaries", "count", len(submissionIDs))
+
+	placeholders := make([]string, len(submissionIDs))
+	args := make([]any, len(submissionIDs))
+	for i, id := range submissionIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `SELECT submission_id, state, COUNT(*) FROM tasks
+		WHERE submission_id IN (` + strings.Join(placeholders, ",") + `)
+		GROUP BY submission_id, state`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get task summaries: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]model.TaskSummary)
+	for rows.Next() {
+		var subID, state string
+		var count int
+		if err := rows.Scan(&subID, &state, &count); err != nil {
+			return nil, fmt.Errorf("scan task summary: %w", err)
+		}
+		ts := result[subID]
+		ts.Total += count
+		switch model.TaskState(state) {
+		case model.TaskStatePending:
+			ts.Pending = count
+		case model.TaskStateScheduled:
+			ts.Scheduled = count
+		case model.TaskStateQueued:
+			ts.Queued = count
+		case model.TaskStateRunning:
+			ts.Running = count
+		case model.TaskStateSuccess:
+			ts.Success = count
+		case model.TaskStateFailed:
+			ts.Failed = count
+		case model.TaskStateSkipped:
+			ts.Skipped = count
+		}
+		result[subID] = ts
+	}
+	return result, rows.Err()
+}
+
+func (s *SQLiteStore) ResetFailedTasks(ctx context.Context, submissionID string) (int, error) {
+	s.logger.Debug("sql", "op", "reset_failed_tasks", "submission_id", submissionID)
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE tasks
+		 SET state = ?, retry_count = 0, completed_at = NULL, stderr = '', exit_code = NULL
+		 WHERE submission_id = ? AND state = ?`,
+		string(model.TaskStatePending), submissionID, string(model.TaskStateFailed))
+	if err != nil {
+		return 0, fmt.Errorf("reset failed tasks: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}
+
+func (s *SQLiteStore) ResetFailedSteps(ctx context.Context, submissionID string) (int, error) {
+	s.logger.Debug("sql", "op", "reset_failed_steps", "submission_id", submissionID)
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE step_instances
+		 SET state = ?, completed_at = NULL
+		 WHERE submission_id = ? AND state = ?`,
+		string(model.StepStateWaiting), submissionID, string(model.StepStateFailed))
+	if err != nil {
+		return 0, fmt.Errorf("reset failed steps: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}
+
 // --- scan helpers ---
 
 type scanner interface {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,7 +44,10 @@ type Store interface {
 	ListTasksByStepInstance(ctx context.Context, stepInstanceID string) ([]*model.Task, error)
 	UpdateTask(ctx context.Context, task *model.Task) error
 	GetTasksByState(ctx context.Context, state model.TaskState) ([]*model.Task, error)
+	GetTaskSummaries(ctx context.Context, submissionIDs []string) (map[string]model.TaskSummary, error)
 	CancelNonTerminalTasks(ctx context.Context, submissionID string, completedAt time.Time) (int, error)
+	ResetFailedTasks(ctx context.Context, submissionID string) (int, error)
+	ResetFailedSteps(ctx context.Context, submissionID string) (int, error)
 
 	// Session operations
 	CreateSession(ctx context.Context, sess *model.Session) error

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -51,7 +51,7 @@ var ValidTaskTransitions = map[TaskState][]TaskState{
 	TaskStateScheduled: {TaskStateQueued},
 	TaskStateQueued:    {TaskStateRunning, TaskStateSuccess, TaskStateFailed},
 	TaskStateRunning:   {TaskStateSuccess, TaskStateFailed, TaskStateSkipped},
-	TaskStateFailed:    {TaskStateRetrying},
+	TaskStateFailed:    {TaskStateRetrying, TaskStatePending},
 	TaskStateRetrying:  {TaskStateQueued},
 }
 
@@ -89,6 +89,7 @@ func (s SubmissionState) IsTerminal() bool {
 var ValidSubmissionTransitions = map[SubmissionState][]SubmissionState{
 	SubmissionStatePending: {SubmissionStateRunning, SubmissionStateCancelled},
 	SubmissionStateRunning: {SubmissionStateCompleted, SubmissionStateFailed, SubmissionStateCancelled},
+	SubmissionStateFailed:  {SubmissionStateRunning},
 }
 
 // CanTransitionTo returns true if moving from the current state to next is valid.

--- a/pkg/model/state_test.go
+++ b/pkg/model/state_test.go
@@ -38,6 +38,7 @@ func TestTaskState_CanTransitionTo(t *testing.T) {
 		{TaskStateRunning, TaskStateFailed, true},
 		{TaskStateRunning, TaskStateSkipped, true},
 		{TaskStateFailed, TaskStateRetrying, true},
+		{TaskStateFailed, TaskStatePending, true},
 		{TaskStateRetrying, TaskStateQueued, true},
 
 		// Invalid transitions
@@ -87,10 +88,12 @@ func TestSubmissionState_CanTransitionTo(t *testing.T) {
 		{SubmissionStateRunning, SubmissionStateFailed, true},
 		{SubmissionStateRunning, SubmissionStateCancelled, true},
 
+		// Retry transition
+		{SubmissionStateFailed, SubmissionStateRunning, true},
+
 		// Invalid transitions
 		{SubmissionStatePending, SubmissionStateCompleted, false},
 		{SubmissionStateCompleted, SubmissionStatePending, false},
-		{SubmissionStateFailed, SubmissionStateRunning, false},
 		{SubmissionStateCancelled, SubmissionStateRunning, false},
 	}
 	for _, tt := range tests {

--- a/pkg/model/step_instance.go
+++ b/pkg/model/step_instance.go
@@ -51,6 +51,7 @@ var ValidStepTransitions = map[StepInstanceState][]StepInstanceState{
 	StepStateReady:      {StepStateDispatched, StepStateFailed, StepStateSkipped},
 	StepStateDispatched: {StepStateRunning, StepStateCompleted, StepStateFailed},
 	StepStateRunning:    {StepStateCompleted, StepStateFailed},
+	StepStateFailed:     {StepStateWaiting},
 }
 
 // CanTransitionTo returns true if moving from the current state to next is valid.


### PR DESCRIPTION
## Summary

- **Rich stuck task errors**: When the scheduler fails a task because no capable worker exists, the error now includes required capabilities (worker group, prestage datasets), available worker summary, specific mismatch reason, and stale tick count
- **Early warning**: Log warning at half the stuck threshold before actually failing tasks
- **No wasted retries**: Stuck-no-worker failures exhaust the retry budget immediately instead of burning through 3 retries with the same outcome
- **Submission retry endpoint**: `PUT /api/v1/submissions/{id}/retry` resets a FAILED submission to RUNNING, resets FAILED steps to WAITING and FAILED tasks to PENDING (with cleared retry budget), leaves completed work untouched
- **State machine transitions**: Added FAILED→RUNNING (submission), FAILED→PENDING (task), FAILED→WAITING (step instance)

### Example stuck task error (before vs after)

**Before:**
```
stuck task failed by scheduler: no workers in group "gpu"
```

**After:**
```
Task stuck: no capable worker available
Required: worker_group=gpu prestage=[boltz]
Available workers: 2 online (groups: [default], runtimes: [apptainer], datasets: [alphafold, chai])
Reason: no workers in group "gpu"
Stale ticks: 30
```

### Retry endpoint usage

```bash
curl -X PUT http://localhost:8091/api/v1/submissions/sub_xxx/retry
# → {"id": "sub_xxx", "state": "RUNNING", "steps_reset": 1, "tasks_reset": 1}
```

## Conformance Test Results — `707f5aa`

| Mode | Passed | Failed | Unsupported | Status |
|------|--------|--------|-------------|--------|
| cwl-runner | 378 | 0 | 0 | PASS |
| server-local | 376 | 0 | 2 | PASS |
| server-worker | 376 | 0 | 2 | PASS |

## Test plan

- [x] `go vet` clean
- [x] `go test ./internal/scheduler/... ./internal/server/... ./pkg/model/...` pass
- [x] All binaries build
- [x] Full CWL v1.2 conformance suite (378 tests × 3 modes) — zero regressions
- [ ] Manual: submit job with no capable worker → verify rich error in task stderr
- [ ] Manual: `PUT /submissions/{id}/retry` on failed submission → verify scheduler picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)