### PR TITLE
fix(worker): reconcile orphaned tasks and cancel running tasks via heartbeat

### DIFF
--- a/internal/server/handler_workers.go
+++ b/internal/server/handler_workers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -142,9 +143,40 @@ func (s *Server) handleWorkerHeartbeat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respondOK(w, reqID, map[string]any{
-		"worker_id": worker.ID,
-		"state":     worker.State,
+	// Parse the optional heartbeat body. An empty/missing body is valid and means
+	// the worker is reporting no in-flight tasks (backward compatible).
+	var req model.HeartbeatRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			respondError(w, reqID, http.StatusBadRequest, &model.APIError{
+				Code:    model.ErrValidation,
+				Message: "invalid heartbeat body: " + err.Error(),
+			})
+			return
+		}
+	}
+
+	// Reconcile orphaned tasks: any task the DB still attributes to this worker
+	// (RUNNING) that the worker no longer reports — and that is past the grace
+	// window — is requeued. This recovers tasks orphaned by a server restart.
+	if requeued, err := s.store.ReconcileWorkerTasks(r.Context(), worker.ID, req.RunningTasks, defaultWorkerTimeout); err != nil {
+		s.logger.Error("heartbeat: reconcile worker tasks", "worker_id", worker.ID, "error", err)
+	} else if len(requeued) > 0 {
+		s.logger.Warn("requeued orphaned tasks from heartbeat reconcile",
+			"worker_id", worker.ID, "tasks", requeued)
+	}
+
+	// Tell the worker which of its running tasks have been cancelled so it can
+	// kill the underlying process and free resources.
+	cancelTasks, err := s.store.CancelledTasksForWorker(r.Context(), req.RunningTasks)
+	if err != nil {
+		s.logger.Error("heartbeat: cancelled tasks lookup", "worker_id", worker.ID, "error", err)
+	}
+
+	respondOK(w, reqID, model.HeartbeatResponse{
+		WorkerID:    worker.ID,
+		State:       worker.State,
+		CancelTasks: cancelTasks,
 	})
 }
 

--- a/internal/server/heartbeat_reconcile_test.go
+++ b/internal/server/heartbeat_reconcile_test.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/me/gowe/pkg/model"
+)
+
+// seedRunningWorkerTask attaches a RUNNING worker task to an existing submission,
+// attributed to workerID and started startedAgo in the past.
+func seedRunningWorkerTask(t *testing.T, srv *Server, subID, taskID, workerID string, startedAgo time.Duration) {
+	t.Helper()
+	started := time.Now().UTC().Add(-startedAgo)
+	task := &model.Task{
+		ID:           taskID,
+		SubmissionID: subID,
+		StepID:       "assemble",
+		State:        model.TaskStateRunning,
+		ExecutorType: model.ExecutorTypeWorker,
+		ExternalID:   workerID,
+		Inputs:       map[string]any{},
+		Outputs:      map[string]any{},
+		Job:          map[string]any{},
+		ScatterIndex: -1,
+		StartedAt:    &started,
+	}
+	if err := srv.store.CreateTask(context.Background(), task); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+}
+
+// heartbeatResp is the decoded data field of a heartbeat response.
+type heartbeatResp struct {
+	WorkerID    string   `json:"worker_id"`
+	State       string   `json:"state"`
+	CancelTasks []string `json:"cancel_tasks"`
+}
+
+// A worker that heartbeats without reporting a task the DB still attributes to it
+// (server-restart orphan) gets that task requeued (#118).
+func TestWorkerHeartbeat_ReconcilesOrphan(t *testing.T) {
+	srv := testServer()
+	workerID := registerTestWorker(t, srv)
+	_, subID := createTestSubmission(t, srv)
+	seedRunningWorkerTask(t, srv, subID, "task_orphan", workerID, 10*time.Minute)
+
+	// Heartbeat reporting an empty running set.
+	w, _ := doPut(t, srv, "/api/v1/workers/"+workerID+"/heartbeat", `{"running_tasks":[]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	got, _ := srv.store.GetTask(context.Background(), "task_orphan")
+	if got.State != model.TaskStateQueued {
+		t.Errorf("orphan task state = %s, want QUEUED (requeued)", got.State)
+	}
+	if got.ExternalID != "" {
+		t.Errorf("orphan external_id = %q, want cleared", got.ExternalID)
+	}
+}
+
+// A worker that reports the task as still running keeps it RUNNING.
+func TestWorkerHeartbeat_KeepsReportedTask(t *testing.T) {
+	srv := testServer()
+	workerID := registerTestWorker(t, srv)
+	_, subID := createTestSubmission(t, srv)
+	seedRunningWorkerTask(t, srv, subID, "task_inflight", workerID, 10*time.Minute)
+
+	body := `{"running_tasks":["task_inflight"]}`
+	w, _ := doPut(t, srv, "/api/v1/workers/"+workerID+"/heartbeat", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+
+	got, _ := srv.store.GetTask(context.Background(), "task_inflight")
+	if got.State != model.TaskStateRunning {
+		t.Errorf("state = %s, want RUNNING (worker still reports it)", got.State)
+	}
+}
+
+// When the owning submission is cancelled, the heartbeat tells the worker to kill
+// the task it is running (#113).
+func TestWorkerHeartbeat_ReturnsCancelTasks(t *testing.T) {
+	srv := testServer()
+	workerID := registerTestWorker(t, srv)
+	_, subID := createTestSubmission(t, srv)
+	seedRunningWorkerTask(t, srv, subID, "task_running", workerID, time.Minute)
+
+	// Cancel the submission via the API.
+	req := httptest.NewRequest("PUT", "/api/v1/submissions/"+subID+"/cancel", nil)
+	cw := httptest.NewRecorder()
+	srv.ServeHTTP(cw, req)
+	if cw.Code != http.StatusOK {
+		t.Fatalf("cancel: status=%d, body=%s", cw.Code, cw.Body.String())
+	}
+
+	// Worker heartbeats, reporting the task as still running.
+	_, env := doPut(t, srv, "/api/v1/workers/"+workerID+"/heartbeat", `{"running_tasks":["task_running"]}`)
+	var data heartbeatResp
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("decode heartbeat data: %v", err)
+	}
+	if len(data.CancelTasks) != 1 || data.CancelTasks[0] != "task_running" {
+		t.Fatalf("cancel_tasks = %v, want [task_running]", data.CancelTasks)
+	}
+}
+
+// An empty heartbeat body must still succeed (backward compatibility).
+func TestWorkerHeartbeat_EmptyBodyStillWorks(t *testing.T) {
+	srv := testServer()
+	workerID := registerTestWorker(t, srv)
+
+	w, env := doPut(t, srv, "/api/v1/workers/"+workerID+"/heartbeat", `{}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200, body=%s", w.Code, w.Body.String())
+	}
+	var data heartbeatResp
+	json.Unmarshal(env.Data, &data)
+	if data.WorkerID != workerID {
+		t.Errorf("worker_id = %q, want %q", data.WorkerID, workerID)
+	}
+}

--- a/internal/server/resolve_refs_test.go
+++ b/internal/server/resolve_refs_test.go
@@ -28,14 +28,14 @@ func (m *mockStore) GetWorkflowByHash(_ context.Context, _ string) (*model.Workf
 }
 
 // Stub the rest of the Store interface (unused in these tests).
-func (m *mockStore) CreateWorkflow(context.Context, *model.Workflow) error  { return nil }
+func (m *mockStore) CreateWorkflow(context.Context, *model.Workflow) error { return nil }
 func (m *mockStore) ListWorkflows(context.Context, model.ListOptions) ([]*model.Workflow, int, error) {
 	return nil, 0, nil
 }
 func (m *mockStore) UpdateWorkflow(context.Context, *model.Workflow) error { return nil }
 func (m *mockStore) DeleteWorkflow(context.Context, string) error          { return nil }
 
-func (m *mockStore) CreateSubmission(context.Context, *model.Submission) error  { return nil }
+func (m *mockStore) CreateSubmission(context.Context, *model.Submission) error { return nil }
 func (m *mockStore) GetSubmission(context.Context, string) (*model.Submission, error) {
 	return nil, nil
 }
@@ -53,7 +53,7 @@ func (m *mockStore) CountSubmissionsByState(_ context.Context, _ time.Time, _ st
 	return nil, nil
 }
 
-func (m *mockStore) CreateStepInstance(context.Context, *model.StepInstance) error  { return nil }
+func (m *mockStore) CreateStepInstance(context.Context, *model.StepInstance) error { return nil }
 func (m *mockStore) BatchCreateStepInstances(context.Context, []*model.StepInstance) error {
 	return nil
 }
@@ -71,8 +71,8 @@ func (m *mockStore) CancelNonTerminalSteps(context.Context, string, time.Time) (
 	return 0, nil
 }
 
-func (m *mockStore) CreateTask(context.Context, *model.Task) error           { return nil }
-func (m *mockStore) GetTask(context.Context, string) (*model.Task, error)    { return nil, nil }
+func (m *mockStore) CreateTask(context.Context, *model.Task) error        { return nil }
+func (m *mockStore) GetTask(context.Context, string) (*model.Task, error) { return nil, nil }
 func (m *mockStore) ListTasksBySubmission(context.Context, string) ([]*model.Task, error) {
 	return nil, nil
 }
@@ -82,7 +82,7 @@ func (m *mockStore) ListTasksBySubmissionPaged(context.Context, string, model.Li
 func (m *mockStore) ListTasksByStepInstance(context.Context, string) ([]*model.Task, error) {
 	return nil, nil
 }
-func (m *mockStore) UpdateTask(context.Context, *model.Task) error                         { return nil }
+func (m *mockStore) UpdateTask(context.Context, *model.Task) error { return nil }
 func (m *mockStore) GetTasksByState(context.Context, model.TaskState) ([]*model.Task, error) {
 	return nil, nil
 }
@@ -93,20 +93,20 @@ func (m *mockStore) GetActiveTasks(context.Context) ([]*model.Task, error) { ret
 func (m *mockStore) GetTaskSummaries(context.Context, []string) (map[string]model.TaskSummary, error) {
 	return nil, nil
 }
-func (m *mockStore) ResetFailedTasks(context.Context, string) (int, error)  { return 0, nil }
+func (m *mockStore) ResetFailedTasks(context.Context, string) (int, error) { return 0, nil }
 func (m *mockStore) ResetFailedSteps(context.Context, string) (int, error) { return 0, nil }
 
-func (m *mockStore) CreateSession(context.Context, *model.Session) error            { return nil }
-func (m *mockStore) GetSession(context.Context, string) (*model.Session, error)     { return nil, nil }
-func (m *mockStore) DeleteSession(context.Context, string) error                    { return nil }
-func (m *mockStore) DeleteExpiredSessions(context.Context) (int64, error)           { return 0, nil }
-func (m *mockStore) DeleteSessionsByUserID(context.Context, string) (int64, error)  { return 0, nil }
+func (m *mockStore) CreateSession(context.Context, *model.Session) error           { return nil }
+func (m *mockStore) GetSession(context.Context, string) (*model.Session, error)    { return nil, nil }
+func (m *mockStore) DeleteSession(context.Context, string) error                   { return nil }
+func (m *mockStore) DeleteExpiredSessions(context.Context) (int64, error)          { return 0, nil }
+func (m *mockStore) DeleteSessionsByUserID(context.Context, string) (int64, error) { return 0, nil }
 
-func (m *mockStore) CreateWorker(context.Context, *model.Worker) error          { return nil }
-func (m *mockStore) GetWorker(context.Context, string) (*model.Worker, error)   { return nil, nil }
-func (m *mockStore) UpdateWorker(context.Context, *model.Worker) error          { return nil }
-func (m *mockStore) DeleteWorker(context.Context, string) error                 { return nil }
-func (m *mockStore) ListWorkers(context.Context) ([]*model.Worker, error)       { return nil, nil }
+func (m *mockStore) CreateWorker(context.Context, *model.Worker) error        { return nil }
+func (m *mockStore) GetWorker(context.Context, string) (*model.Worker, error) { return nil, nil }
+func (m *mockStore) UpdateWorker(context.Context, *model.Worker) error        { return nil }
+func (m *mockStore) DeleteWorker(context.Context, string) error               { return nil }
+func (m *mockStore) ListWorkers(context.Context) ([]*model.Worker, error)     { return nil, nil }
 func (m *mockStore) CheckoutTask(context.Context, string, string, model.ContainerRuntime) (*model.Task, error) {
 	return nil, nil
 }
@@ -114,13 +114,19 @@ func (m *mockStore) MarkStaleWorkersOffline(_ context.Context, _ time.Duration) 
 	return nil, nil
 }
 func (m *mockStore) RequeueWorkerTasks(context.Context, string) (int, error) { return 0, nil }
+func (m *mockStore) ReconcileWorkerTasks(context.Context, string, []string, time.Duration) ([]string, error) {
+	return nil, nil
+}
+func (m *mockStore) CancelledTasksForWorker(context.Context, []string) ([]string, error) {
+	return nil, nil
+}
 
 func (m *mockStore) GetUser(context.Context, string) (*model.User, error) { return nil, nil }
 func (m *mockStore) GetOrCreateUser(context.Context, string, model.AuthProvider) (*model.User, error) {
 	return nil, nil
 }
-func (m *mockStore) UpdateUser(context.Context, *model.User) error            { return nil }
-func (m *mockStore) ListUsers(context.Context) ([]*model.User, error)         { return nil, nil }
+func (m *mockStore) UpdateUser(context.Context, *model.User) error    { return nil }
+func (m *mockStore) ListUsers(context.Context) ([]*model.User, error) { return nil, nil }
 func (m *mockStore) LinkProvider(context.Context, string, model.AuthProvider, string) error {
 	return nil
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2113,6 +2113,111 @@ func (s *SQLiteStore) RequeueWorkerTasks(ctx context.Context, workerID string) (
 	return int(n), nil
 }
 
+// ReconcileWorkerTasks requeues tasks the database attributes to workerID
+// (state=RUNNING, executor_type=worker) that the worker no longer reports as
+// running. running is the set of task IDs the worker claims to be executing,
+// reported via heartbeat. Tasks whose started_at is younger than minAge are left
+// alone to avoid racing the checkout→first-heartbeat window (a freshly checked-out
+// task the worker has not yet had a chance to report). Returns the IDs requeued.
+//
+// This complements MarkStaleWorkersOffline+RequeueWorkerTasks (which only handles
+// dead workers): it catches the alive-but-forgetful case where a worker keeps
+// heartbeating after a server restart but has dropped its in-flight task.
+func (s *SQLiteStore) ReconcileWorkerTasks(ctx context.Context, workerID string, running []string, minAge time.Duration) ([]string, error) {
+	s.logger.Debug("sql", "op", "reconcile_worker_tasks", "worker_id", workerID, "running", len(running))
+
+	runningSet := make(map[string]struct{}, len(running))
+	for _, id := range running {
+		runningSet[id] = struct{}{}
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, started_at FROM tasks
+		 WHERE state = 'RUNNING' AND executor_type = 'worker' AND external_id = ?`, workerID)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile: query running tasks: %w", err)
+	}
+
+	cutoff := time.Now().UTC().Add(-minAge)
+	var orphans []string
+	for rows.Next() {
+		var id string
+		var startedAt *string
+		if err := rows.Scan(&id, &startedAt); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("reconcile: scan: %w", err)
+		}
+		// Worker still claims this task — legitimately in-flight.
+		if _, ok := runningSet[id]; ok {
+			continue
+		}
+		// Within the grace window — too fresh to judge as orphaned.
+		if startedAt != nil {
+			if t, terr := parseTimeOrZero(*startedAt); terr == nil && t.After(cutoff) {
+				continue
+			}
+		}
+		orphans = append(orphans, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reconcile: rows: %w", err)
+	}
+
+	for _, id := range orphans {
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE tasks SET state = 'QUEUED', external_id = '', started_at = NULL
+			 WHERE id = ? AND state = 'RUNNING' AND executor_type = 'worker' AND external_id = ?`,
+			id, workerID); err != nil {
+			return nil, fmt.Errorf("reconcile: requeue %s: %w", id, err)
+		}
+		// Clear current_task only if it pointed at this orphaned task.
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE workers SET current_task = '' WHERE id = ? AND current_task = ?`,
+			workerID, id); err != nil {
+			return nil, fmt.Errorf("reconcile: clear current_task %s: %w", id, err)
+		}
+	}
+
+	return orphans, nil
+}
+
+// CancelledTasksForWorker returns the subset of the given task IDs whose owning
+// submission is CANCELLED — the tasks a worker is running that it should kill.
+// The submission state is the durable cancellation signal: the scheduler marks a
+// cancelled submission's tasks terminal (SKIPPED), but that does not stop the
+// worker's process, which is what this drives. Returns nil for an empty input.
+func (s *SQLiteStore) CancelledTasksForWorker(ctx context.Context, taskIDs []string) ([]string, error) {
+	if len(taskIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(taskIDs))
+	args := make([]any, len(taskIDs))
+	for i, id := range taskIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := `SELECT t.id FROM tasks t
+		 JOIN submissions s ON t.submission_id = s.id
+		 WHERE t.id IN (` + strings.Join(placeholders, ",") + `)
+		   AND s.state = 'CANCELLED'`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("cancelled tasks: query: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("cancelled tasks: scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // --- User operations ---
 
 func (s *SQLiteStore) GetUser(ctx context.Context, username string) (*model.User, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -66,6 +66,8 @@ type Store interface {
 	CheckoutTask(ctx context.Context, workerID string, workerGroup string, runtime model.ContainerRuntime) (*model.Task, error)
 	MarkStaleWorkersOffline(ctx context.Context, timeout time.Duration) ([]*model.Worker, error)
 	RequeueWorkerTasks(ctx context.Context, workerID string) (int, error)
+	ReconcileWorkerTasks(ctx context.Context, workerID string, running []string, minAge time.Duration) ([]string, error)
+	CancelledTasksForWorker(ctx context.Context, taskIDs []string) ([]string, error)
 
 	// User operations
 	GetUser(ctx context.Context, username string) (*model.User, error)

--- a/internal/store/worker_reconcile_test.go
+++ b/internal/store/worker_reconcile_test.go
@@ -1,0 +1,161 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/me/gowe/pkg/model"
+)
+
+// runningTask creates and persists a RUNNING worker task attributed to workerID,
+// started startedAgo in the past. Returns the task ID.
+func runningTask(t *testing.T, st *SQLiteStore, sub *model.Submission, id, workerID string, startedAgo time.Duration) string {
+	t.Helper()
+	ctx := context.Background()
+	task := sampleTask(sub.ID)
+	task.ID = id
+	task.State = model.TaskStateRunning
+	task.ExecutorType = model.ExecutorTypeWorker
+	task.ExternalID = workerID
+	started := time.Now().UTC().Add(-startedAgo)
+	task.StartedAt = &started
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task %s: %v", id, err)
+	}
+	return task.ID
+}
+
+func reconcileFixture(t *testing.T) (*SQLiteStore, *model.Submission) {
+	t.Helper()
+	ctx := context.Background()
+	st := testStore(t)
+	wf := sampleWorkflow()
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	sub := sampleSubmission(wf.ID)
+	if err := st.CreateSubmission(ctx, sub); err != nil {
+		t.Fatalf("create submission: %v", err)
+	}
+	return st, sub
+}
+
+// A RUNNING task the worker no longer reports, older than the grace window, is a
+// zombie and must be requeued — this is the server-restart orphan case (#118).
+func TestReconcileWorkerTasks_RequeuesOrphan(t *testing.T) {
+	ctx := context.Background()
+	st, sub := reconcileFixture(t)
+	id := runningTask(t, st, sub, "task_zombie", "wrk_alive", 10*time.Minute)
+
+	// Worker reports an empty running set (it forgot the task across a restart).
+	requeued, err := st.ReconcileWorkerTasks(ctx, "wrk_alive", nil, time.Minute)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(requeued) != 1 || requeued[0] != id {
+		t.Fatalf("requeued = %v, want [%s]", requeued, id)
+	}
+
+	got, _ := st.GetTask(ctx, id)
+	if got.State != model.TaskStateQueued {
+		t.Errorf("state = %s, want QUEUED", got.State)
+	}
+	if got.ExternalID != "" {
+		t.Errorf("external_id = %q, want empty", got.ExternalID)
+	}
+	if got.StartedAt != nil {
+		t.Errorf("started_at = %v, want nil", got.StartedAt)
+	}
+}
+
+// A RUNNING task the worker still reports as running is legitimately in-flight and
+// must be left alone.
+func TestReconcileWorkerTasks_LeavesActiveTask(t *testing.T) {
+	ctx := context.Background()
+	st, sub := reconcileFixture(t)
+	id := runningTask(t, st, sub, "task_active", "wrk_alive", 10*time.Minute)
+
+	requeued, err := st.ReconcileWorkerTasks(ctx, "wrk_alive", []string{id}, time.Minute)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(requeued) != 0 {
+		t.Fatalf("requeued = %v, want none", requeued)
+	}
+	got, _ := st.GetTask(ctx, id)
+	if got.State != model.TaskStateRunning {
+		t.Errorf("state = %s, want RUNNING (left alone)", got.State)
+	}
+}
+
+// A freshly-checked-out RUNNING task that the worker has not yet reported (within
+// the grace window) must not be reaped — avoids the checkout→first-heartbeat race.
+func TestReconcileWorkerTasks_GraceWindow(t *testing.T) {
+	ctx := context.Background()
+	st, sub := reconcileFixture(t)
+	id := runningTask(t, st, sub, "task_fresh", "wrk_alive", 2*time.Second)
+
+	requeued, err := st.ReconcileWorkerTasks(ctx, "wrk_alive", nil, time.Minute)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(requeued) != 0 {
+		t.Fatalf("requeued = %v, want none (within grace window)", requeued)
+	}
+	got, _ := st.GetTask(ctx, id)
+	if got.State != model.TaskStateRunning {
+		t.Errorf("state = %s, want RUNNING (grace window)", got.State)
+	}
+}
+
+// Reconciliation is scoped to the heartbeating worker: a different worker's
+// RUNNING tasks must not be touched, even if absent from this worker's report.
+func TestReconcileWorkerTasks_IgnoresOtherWorkers(t *testing.T) {
+	ctx := context.Background()
+	st, sub := reconcileFixture(t)
+	other := runningTask(t, st, sub, "task_other", "wrk_other", 10*time.Minute)
+
+	requeued, err := st.ReconcileWorkerTasks(ctx, "wrk_alive", nil, time.Minute)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(requeued) != 0 {
+		t.Fatalf("requeued = %v, want none (other worker's task)", requeued)
+	}
+	got, _ := st.GetTask(ctx, other)
+	if got.State != model.TaskStateRunning {
+		t.Errorf("other worker task state = %s, want RUNNING", got.State)
+	}
+}
+
+// CancelledTasksForWorker returns those candidate tasks whose owning submission is
+// CANCELLED — the set the worker should kill (#113).
+func TestCancelledTasksForWorker(t *testing.T) {
+	ctx := context.Background()
+	st, sub := reconcileFixture(t)
+	cancelledTask := runningTask(t, st, sub, "task_cancelled", "wrk_alive", time.Minute)
+
+	// A second submission that stays running, with its own task.
+	liveSub := sampleSubmission(sub.WorkflowID)
+	liveSub.ID = "sub_live"
+	liveSub.State = model.SubmissionStateRunning
+	if err := st.CreateSubmission(ctx, liveSub); err != nil {
+		t.Fatalf("create live submission: %v", err)
+	}
+	liveTask := runningTask(t, st, liveSub, "task_live", "wrk_alive", time.Minute)
+
+	// Cancel the first submission.
+	sub.State = model.SubmissionStateCancelled
+	if err := st.UpdateSubmission(ctx, sub); err != nil {
+		t.Fatalf("cancel submission: %v", err)
+	}
+
+	got, err := st.CancelledTasksForWorker(ctx, []string{cancelledTask, liveTask})
+	if err != nil {
+		t.Fatalf("cancelled tasks: %v", err)
+	}
+	if len(got) != 1 || got[0] != cancelledTask {
+		t.Fatalf("cancelled = %v, want [%s]", got, cancelledTask)
+	}
+}

--- a/internal/worker/active_tasks.go
+++ b/internal/worker/active_tasks.go
@@ -1,0 +1,82 @@
+package worker
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// activeTaskSet tracks the tasks a worker is currently executing along with the
+// cancel function for each task's execution context. It is the durable link
+// between a task ID and the running process, used to (a) report running tasks on
+// each heartbeat and (b) cancel a specific task when the server signals it.
+type activeTaskSet struct {
+	mu        sync.Mutex
+	m         map[string]context.CancelFunc
+	cancelled map[string]struct{} // tasks explicitly cancelled via cancel()
+}
+
+func newActiveTaskSet() *activeTaskSet {
+	return &activeTaskSet{
+		m:         make(map[string]context.CancelFunc),
+		cancelled: make(map[string]struct{}),
+	}
+}
+
+// add registers a running task and its cancel function.
+func (a *activeTaskSet) add(taskID string, cancel context.CancelFunc) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.m[taskID] = cancel
+	delete(a.cancelled, taskID)
+}
+
+// remove deregisters a task (called when execution finishes).
+func (a *activeTaskSet) remove(taskID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.m, taskID)
+	delete(a.cancelled, taskID)
+}
+
+// ids returns the IDs of all currently-running tasks, sorted for stable output.
+func (a *activeTaskSet) ids() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(a.m))
+	for id := range a.m {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// cancel invokes the cancel function for the given task if it is registered and
+// records that the cancellation was explicit (vs. a worker-shutdown context
+// cancellation). Returns true if the task was found and cancelled.
+func (a *activeTaskSet) cancel(taskID string) bool {
+	a.mu.Lock()
+	cancel, ok := a.m[taskID]
+	if ok {
+		a.cancelled[taskID] = struct{}{}
+	}
+	a.mu.Unlock()
+	if !ok {
+		return false
+	}
+	cancel()
+	return true
+}
+
+// wasCancelled reports whether the task was explicitly cancelled via cancel().
+// This distinguishes a server-driven cancellation (report SKIPPED) from a
+// worker-shutdown context cancellation (leave the task for the server to requeue).
+func (a *activeTaskSet) wasCancelled(taskID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, ok := a.cancelled[taskID]
+	return ok
+}

--- a/internal/worker/active_tasks_test.go
+++ b/internal/worker/active_tasks_test.go
@@ -1,0 +1,68 @@
+package worker
+
+import (
+	"context"
+	"testing"
+)
+
+func TestActiveTaskSet_AddIDsRemove(t *testing.T) {
+	a := newActiveTaskSet()
+	if ids := a.ids(); ids != nil {
+		t.Fatalf("empty set ids = %v, want nil", ids)
+	}
+
+	a.add("task_b", func() {})
+	a.add("task_a", func() {})
+	ids := a.ids()
+	if len(ids) != 2 || ids[0] != "task_a" || ids[1] != "task_b" {
+		t.Fatalf("ids = %v, want sorted [task_a task_b]", ids)
+	}
+
+	a.remove("task_a")
+	if ids := a.ids(); len(ids) != 1 || ids[0] != "task_b" {
+		t.Fatalf("after remove ids = %v, want [task_b]", ids)
+	}
+}
+
+func TestActiveTaskSet_CancelInvokesContext(t *testing.T) {
+	a := newActiveTaskSet()
+	ctx, cancel := context.WithCancel(context.Background())
+	a.add("task_x", cancel)
+
+	if ok := a.cancel("task_missing"); ok {
+		t.Error("cancel of unknown task returned true")
+	}
+	if ctx.Err() != nil {
+		t.Error("context cancelled unexpectedly")
+	}
+
+	if ok := a.cancel("task_x"); !ok {
+		t.Fatal("cancel of known task returned false")
+	}
+	if ctx.Err() != context.Canceled {
+		t.Errorf("context err = %v, want context.Canceled", ctx.Err())
+	}
+	if !a.wasCancelled("task_x") {
+		t.Error("wasCancelled(task_x) = false, want true after explicit cancel")
+	}
+}
+
+func TestActiveTaskSet_WasCancelledDistinguishesShutdown(t *testing.T) {
+	a := newActiveTaskSet()
+	a.add("task_y", func() {})
+
+	// A task that finishes normally (never explicitly cancelled) reports false —
+	// this is how a worker-shutdown context cancellation is distinguished from a
+	// server-driven cancel.
+	if a.wasCancelled("task_y") {
+		t.Error("wasCancelled(task_y) = true, want false (not explicitly cancelled)")
+	}
+
+	// re-adding a task clears any stale cancelled marker.
+	a.cancel("task_y")
+	a.remove("task_y")
+	a.add("task_y", func() {})
+	if a.wasCancelled("task_y") {
+		t.Error("wasCancelled after re-add = true, want false (marker cleared)")
+	}
+}

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -97,14 +97,24 @@ func (c *Client) Register(ctx context.Context, name, hostname, group, runtime st
 	return &worker, nil
 }
 
-// Heartbeat sends a heartbeat to update last_seen.
-func (c *Client) Heartbeat(ctx context.Context) error {
-	_, err := c.doRequest(ctx, http.MethodPut,
-		fmt.Sprintf("/api/v1/workers/%s/heartbeat", c.workerID), nil)
+// Heartbeat sends a heartbeat to update last_seen, reporting the worker's
+// currently-running task IDs. The server uses this to reconcile orphaned tasks
+// and returns any tasks the worker should cancel (their submission was cancelled).
+func (c *Client) Heartbeat(ctx context.Context, running []string) (*model.HeartbeatResponse, error) {
+	body, err := json.Marshal(model.HeartbeatRequest{RunningTasks: running})
 	if err != nil {
-		return fmt.Errorf("heartbeat: %w", err)
+		return nil, fmt.Errorf("heartbeat: marshal: %w", err)
 	}
-	return nil
+	resp, err := c.doRequest(ctx, http.MethodPut,
+		fmt.Sprintf("/api/v1/workers/%s/heartbeat", c.workerID), body)
+	if err != nil {
+		return nil, fmt.Errorf("heartbeat: %w", err)
+	}
+	var hb model.HeartbeatResponse
+	if err := decodeResponseData(resp, &hb); err != nil {
+		return nil, fmt.Errorf("heartbeat: %w", err)
+	}
+	return &hb, nil
 }
 
 // Checkout requests a task from the server. Returns nil if no work available (204).

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -33,18 +33,19 @@ type Worker struct {
 	stageOut          string
 	stagerCfg         StagerConfig
 	poll              time.Duration
-	containerRuntime  string               // "docker", "apptainer", or "none"
-	gpu               GPUWorkerConfig     // GPU configuration
-	resources         ResourceWorkerConfig // Resource limits
-	imageDir          string              // Base directory for resolving .sif image paths
-	dockerHostPathMap map[string]string // Docker-in-Docker path mapping
-	dockerVolume      string            // Named Docker volume shared with tool containers
-	inputPathMap      map[string]string // Input path mapping for host->container translation
-	extraBinds        []toolexec.ExtraBind // Extra bind mounts for containers
-	datasets          map[string]string   // Merged dataset map: ID → host path
-	secrets           map[string]string   // Secret env vars injected into containers
-	envVars           map[string]string   // Non-secret env vars injected into containers
+	containerRuntime  string                   // "docker", "apptainer", or "none"
+	gpu               GPUWorkerConfig          // GPU configuration
+	resources         ResourceWorkerConfig     // Resource limits
+	imageDir          string                   // Base directory for resolving .sif image paths
+	dockerHostPathMap map[string]string        // Docker-in-Docker path mapping
+	dockerVolume      string                   // Named Docker volume shared with tool containers
+	inputPathMap      map[string]string        // Input path mapping for host->container translation
+	extraBinds        []toolexec.ExtraBind     // Extra bind mounts for containers
+	datasets          map[string]string        // Merged dataset map: ID → host path
+	secrets           map[string]string        // Secret env vars injected into containers
+	envVars           map[string]string        // Non-secret env vars injected into containers
 	wsStager          *staging.WorkspaceStager // Workspace stager for ws:// URIs (nil if disabled)
+	active            *activeTaskSet           // In-flight tasks → per-task cancel funcs
 	logger            *slog.Logger
 }
 
@@ -361,6 +362,7 @@ func New(cfg Config, logger *slog.Logger) (*Worker, error) {
 		datasets:          datasets,
 		secrets:           cfg.Secrets,
 		envVars:           cfg.EnvVars,
+		active:            newActiveTaskSet(),
 		logger:            logger.With("component", "worker"),
 	}, nil
 }
@@ -409,8 +411,18 @@ func (w *Worker) heartbeatLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := w.client.Heartbeat(ctx); err != nil {
+			resp, err := w.client.Heartbeat(ctx, w.active.ids())
+			if err != nil {
 				w.logger.Warn("heartbeat failed", "error", err)
+				continue
+			}
+			// Cancel any tasks the server reports as cancelled. Cancelling the
+			// task's execution context kills the underlying process and frees
+			// resources (e.g. GPU) without waiting for the tool to finish.
+			for _, taskID := range resp.CancelTasks {
+				if w.active.cancel(taskID) {
+					w.logger.Info("cancelling task on server request", "task_id", taskID)
+				}
 			}
 		}
 	}
@@ -471,13 +483,63 @@ func (w *Worker) executeTask(ctx context.Context, task *model.Task) error {
 		return w.reportFailure(ctx, task, fmt.Errorf("create task dir: %w", err))
 	}
 
+	// Per-task execution context so the heartbeat loop can cancel this specific
+	// task — killing its process and freeing resources (e.g. GPU) — without
+	// affecting the worker or other tasks.
+	runCtx, cancel := context.WithCancel(ctx)
+	w.active.add(task.ID, cancel)
+	defer func() {
+		w.active.remove(task.ID)
+		cancel()
+	}()
+
 	// Check if task has Tool+Job (new format) or legacy _base_command.
 	if task.HasTool() {
-		return w.executeWithCWLTool(ctx, task, taskDir)
+		return w.executeWithCWLTool(runCtx, task, taskDir)
 	}
 
 	// Legacy path: use _base_command from task.Inputs.
-	return w.executeLegacy(ctx, task, taskDir)
+	return w.executeLegacy(runCtx, task, taskDir)
+}
+
+// reportComplete reports a final task result, detaching from ctx cancellation so a
+// cancelled or killed task can still be reported (bounded by a short timeout).
+func (w *Worker) reportComplete(ctx context.Context, taskID string, result TaskResult) error {
+	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	return w.client.ReportComplete(rctx, taskID, result)
+}
+
+// reportCancelled reports a task as SKIPPED (the scheduler's terminal state for a
+// cancelled task), used when the server has cancelled the task mid-execution.
+func (w *Worker) reportCancelled(ctx context.Context, task *model.Task) error {
+	exitCode := -1
+	return w.reportComplete(ctx, task.ID, TaskResult{
+		State:    model.TaskStateSkipped,
+		ExitCode: &exitCode,
+		Stderr:   "task cancelled by server",
+	})
+}
+
+// handleExecCancellation reports the right terminal outcome when tool execution
+// returns an error and the run context was cancelled. It returns (handled, error):
+// handled=false means the cancellation did not apply and the caller should fall
+// back to normal failure reporting.
+func (w *Worker) handleExecCancellation(runCtx context.Context, task *model.Task) (bool, error) {
+	switch {
+	case w.active.wasCancelled(task.ID):
+		// Explicit server-driven cancellation → report SKIPPED (terminal).
+		w.logger.Info("task cancelled by server, reporting SKIPPED", "task_id", task.ID)
+		return true, w.reportCancelled(runCtx, task)
+	case runCtx.Err() != nil:
+		// Context cancelled but not an explicit task cancel → the worker is
+		// shutting down. Leave the task non-terminal so the server reaper requeues
+		// it rather than marking it FAILED.
+		w.logger.Info("worker shutting down mid-task, leaving for requeue", "task_id", task.ID)
+		return true, runCtx.Err()
+	default:
+		return false, nil
+	}
 }
 
 // executeWithCWLTool executes a task using the cwltool package with full CWL support.
@@ -559,8 +621,14 @@ func (w *Worker) executeWithCWLTool(ctx context.Context, task *model.Task, taskD
 
 	// Handle execution errors.
 	if err != nil {
+		// If the run context was cancelled, report the cancellation outcome
+		// (SKIPPED for an explicit server cancel; leave for requeue on shutdown)
+		// rather than a spurious FAILED.
+		if handled, cerr := w.handleExecCancellation(ctx, task); handled {
+			return cerr
+		}
 		if result != nil {
-			return w.client.ReportComplete(ctx, task.ID, TaskResult{
+			return w.reportComplete(ctx, task.ID, TaskResult{
 				State:    model.TaskStateFailed,
 				ExitCode: &result.ExitCode,
 				Stdout:   result.Stdout,
@@ -585,7 +653,7 @@ func (w *Worker) executeWithCWLTool(ctx context.Context, task *model.Task, taskD
 		stagedOutputs[outputID] = w.stageOutputValue(ctx, output, task, outStager, "")
 	}
 
-	return w.client.ReportComplete(ctx, task.ID, TaskResult{
+	return w.reportComplete(ctx, task.ID, TaskResult{
 		State:    model.TaskStateSuccess,
 		ExitCode: &result.ExitCode,
 		Stdout:   result.Stdout,
@@ -640,6 +708,10 @@ func (w *Worker) executeLegacy(ctx context.Context, task *model.Task, taskDir st
 
 	result, runErr := w.runtime.Run(ctx, spec)
 	if runErr != nil {
+		// Cancellation takes precedence over a generic runtime error.
+		if handled, cerr := w.handleExecCancellation(ctx, task); handled {
+			return cerr
+		}
 		// Runtime infrastructure error (e.g., binary not found).
 		return w.reportFailure(ctx, task, runErr)
 	}
@@ -677,7 +749,7 @@ func (w *Worker) executeLegacy(ctx context.Context, task *model.Task, taskDir st
 		state = model.TaskStateFailed
 	}
 
-	return w.client.ReportComplete(ctx, task.ID, TaskResult{
+	return w.reportComplete(ctx, task.ID, TaskResult{
 		State:    state,
 		ExitCode: &result.ExitCode,
 		Stdout:   result.Stdout,
@@ -770,7 +842,7 @@ func (w *Worker) stageOutputValue(ctx context.Context, v any, task *model.Task, 
 // reportFailure sends a FAILED completion with the given error as stderr.
 func (w *Worker) reportFailure(ctx context.Context, task *model.Task, execErr error) error {
 	exitCode := -1
-	reportErr := w.client.ReportComplete(ctx, task.ID, TaskResult{
+	reportErr := w.reportComplete(ctx, task.ID, TaskResult{
 		State:    model.TaskStateFailed,
 		ExitCode: &exitCode,
 		Stderr:   execErr.Error(),

--- a/pkg/model/worker.go
+++ b/pkg/model/worker.go
@@ -24,6 +24,23 @@ type Worker struct {
 	RegisteredAt time.Time         `json:"registered_at"`
 }
 
+// HeartbeatRequest is the body a worker sends on each heartbeat. RunningTasks is
+// the set of task IDs the worker is currently executing; the server uses it to
+// reconcile orphaned tasks and to decide which tasks to cancel. An empty body
+// (no running tasks) is valid and backward-compatible.
+type HeartbeatRequest struct {
+	RunningTasks []string `json:"running_tasks,omitempty"`
+}
+
+// HeartbeatResponse is the server's reply to a heartbeat. CancelTasks lists task
+// IDs the worker is running whose submission has been cancelled — the worker
+// should kill those and report them CANCELLED.
+type HeartbeatResponse struct {
+	WorkerID    string      `json:"worker_id"`
+	State       WorkerState `json:"state"`
+	CancelTasks []string    `json:"cancel_tasks,omitempty"`
+}
+
 // WorkerState represents the lifecycle state of a Worker.
 type WorkerState string
 


### PR DESCRIPTION
## Summary

Fixes **#118** (zombie tasks after server restart) and **#113** (worker keeps running a cancelled task). Both stem from the same root cause: the worker↔server task-state binding was **one-directional**. The heartbeat was fire-and-forget, so the server's DB and the worker's in-process state could drift apart with nothing to reconcile them.

The fix makes the heartbeat **bidirectional and reconciling**:
- Worker reports its actual in-flight task IDs on each heartbeat (`running_tasks`).
- Server returns the subset whose submission was cancelled (`cancel_tasks`).

## #118 — zombie reconciliation
- `store.ReconcileWorkerTasks` requeues tasks the DB attributes to a worker (`RUNNING`) that the worker no longer reports, **past a 30s grace window** so a freshly-checked-out task isn't reaped before its first heartbeat.
- This catches the *alive-but-forgetful* worker after a restart — the exact production scenario (tasks sat `RUNNING` for 138 min across two restarts) that the existing stale-worker reaper (heartbeat-timeout only) missed.
- **No blind startup sweep**: requeuing all `RUNNING` worker tasks at boot would yank tasks from workers that genuinely survived the restart. The grace-windowed heartbeat reconcile is the safe mechanism; the existing reaper still covers workers that never reconnect.

## #113 — worker cancel
- `store.CancelledTasksForWorker` keys on the durable signal (submission `CANCELLED`).
- `activeTaskSet` gives each task its own cancel context; the heartbeat loop kills the **specific** task's process (freeing the GPU) within one heartbeat (~5s) — no SSE/polling infrastructure.
- Result reporting is **detached** from the per-task context (`context.WithoutCancel` + timeout) so a killed task can still report its outcome.
- Explicit cancel → reports `SKIPPED` (the scheduler's terminal-cancel state); a worker-*shutdown* context cancellation is distinguished via `wasCancelled` and left for the reaper to requeue rather than mis-marked `FAILED`.

## Tests (written first, all passing; full `go test ./...` green)
- **Store**: orphan requeue, leaves-active-task, grace-window, ignores-other-workers, cancelled-tasks lookup.
- **Handler**: heartbeat reconciles orphan, keeps reported task, returns `cancel_tasks` on cancelled submission, empty-body backward-compat.
- **Worker**: `activeTaskSet` add/ids/remove, cancel invokes context, shutdown-vs-explicit-cancel distinction.

## Follow-ups (deliberately out of scope)
- **Idempotency gate** (`gowe:Execution.idempotent`, #118): current behavior requeues unconditionally, safe for existing poll/check-idempotent worker tools. Worth adding if non-idempotent worker tools appear.
- **Docker container kill**: `CommandContext` cleanly kills local and Apptainer processes (the container *is* the child). For `docker run`, a deterministic `--name` + `docker kill` would close the gap. Not needed here (deployment is Apptainer-based).

Closes #118
Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)