### PR TITLE
fix(validator): accept valid CWL ${...} JavaScript expression bodies

### DIFF
--- a/internal/parser/validator.go
+++ b/internal/parser/validator.go
@@ -4,11 +4,16 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/me/gowe/pkg/cwl"
 	"github.com/me/gowe/pkg/model"
 )
+
+// reReturnStmt matches a JavaScript `return` keyword on a word boundary, used to
+// recognize a CWL ${ ... } JavaScript expression body.
+var reReturnStmt = regexp.MustCompile(`\breturn\b`)
 
 // Validator performs semantic validation on a parsed CWL GraphDocument.
 type Validator struct {
@@ -373,10 +378,18 @@ func checkShellInterp(glob any, field, kind string) []model.FieldError {
 	return nil
 }
 
-// checkShellInterpString reports any ${...} substring as a FieldError.
-// CWL parameter references use $(...), never ${...}; the latter is shell
-// syntax that CWL treats as a literal string.
+// checkShellInterpString reports a ${...} substring as a FieldError when it is
+// shell-style interpolation. CWL parameter references use $(...), and ${...}
+// embedded in a larger literal is shell syntax that CWL treats as a literal
+// string. However, a value that is a single whole-string ${ ... } block
+// containing a return statement is a valid CWL JavaScript expression *body*
+// (legal in outputEval and expression globs with InlineJavascriptRequirement);
+// such values are accepted.
 func checkShellInterpString(s, field, kind string) []model.FieldError {
+	if isJSExpressionBody(s) {
+		return nil
+	}
+
 	idx := strings.Index(s, "${")
 	if idx < 0 {
 		return nil
@@ -397,6 +410,45 @@ func checkShellInterpString(s, field, kind string) []model.FieldError {
 				"Replace with a valid CWL expression like $(inputs.<input_id>).",
 			kind, fragment),
 	}}
+}
+
+// isJSExpressionBody reports whether s is a single whole-string ${ ... } block
+// containing a return statement — the CWL JavaScript expression-body form. Such
+// a value is a valid expression (in outputEval or an expression glob when
+// InlineJavascriptRequirement is in scope), not shell-style interpolation.
+//
+// It distinguishes:
+//   - valid:   "${ return parseFloat(self[0].contents); }"   (whole block + return)
+//   - invalid: "${params.output_path}/blast_out.json"        (embedded, no return)
+//   - invalid: "${self[0].contents.trim()}"                  (no return; use $(...))
+//
+// Brace matching handles nested braces in the JS body (loops, conditionals).
+func isJSExpressionBody(s string) bool {
+	t := strings.TrimSpace(s)
+	if !strings.HasPrefix(t, "${") || !strings.HasSuffix(t, "}") {
+		return false
+	}
+	// The opening "${" must balance with the trailing "}" as one block — i.e. the
+	// brace opened at index 1 closes only at the final character. If it closes
+	// earlier, the string is "${...}<more>" (embedded), not a whole expression.
+	depth := 0
+	for i := 1; i < len(t); i++ {
+		switch t[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 && i != len(t)-1 {
+				return false
+			}
+		}
+	}
+	if depth != 0 {
+		return false // unbalanced
+	}
+	// A CWL ${...} body must return a value; require a return keyword to
+	// distinguish it from shell-style ${var} / ${var.attr} references.
+	return reReturnStmt.MatchString(t)
 }
 
 func (v *Validator) validateDAG(graph *cwl.GraphDocument) []model.FieldError {

--- a/internal/parser/validator_test.go
+++ b/internal/parser/validator_test.go
@@ -360,7 +360,7 @@ func TestValidate_OutputBinding_ShellInterp_RejectGlob(t *testing.T) {
 	g := validGraph()
 	g.Tools["tool1"].Outputs = map[string]cwl.ToolOutputParam{
 		"blast_json": {
-			
+
 			Type: "File",
 			OutputBinding: &cwl.OutputBinding{
 				Glob: "${params.output_path}/.${params.output_file}/blast_out.json",
@@ -384,7 +384,7 @@ func TestValidate_OutputBinding_ShellInterp_RejectGlobArray(t *testing.T) {
 	g := validGraph()
 	g.Tools["tool1"].Outputs = map[string]cwl.ToolOutputParam{
 		"results": {
-			
+
 			Type: "File[]",
 			OutputBinding: &cwl.OutputBinding{
 				Glob: []any{"good_*.txt", "${BAD}/bad_*.txt"},
@@ -405,7 +405,7 @@ func TestValidate_OutputBinding_ShellInterp_RejectOutputEval(t *testing.T) {
 	g := validGraph()
 	g.Tools["tool1"].Outputs = map[string]cwl.ToolOutputParam{
 		"computed": {
-			
+
 			Type: "File",
 			OutputBinding: &cwl.OutputBinding{
 				Glob:       "out.txt",
@@ -427,7 +427,7 @@ func TestValidate_OutputBinding_Valid_CWLExpression(t *testing.T) {
 	g := validGraph()
 	g.Tools["tool1"].Outputs = map[string]cwl.ToolOutputParam{
 		"tree_nwk": {
-			
+
 			Type: "File",
 			OutputBinding: &cwl.OutputBinding{
 				Glob:       "$(inputs.output_file)_tree.nwk",
@@ -435,14 +435,14 @@ func TestValidate_OutputBinding_Valid_CWLExpression(t *testing.T) {
 			},
 		},
 		"plain": {
-			
+
 			Type: "File",
 			OutputBinding: &cwl.OutputBinding{
 				Glob: "blast_out.json",
 			},
 		},
 		"all_results": {
-			
+
 			Type: "File[]",
 			OutputBinding: &cwl.OutputBinding{
 				Glob: []any{"$(inputs.output_file)*.txt", "report.html"},
@@ -451,6 +451,69 @@ func TestValidate_OutputBinding_Valid_CWLExpression(t *testing.T) {
 	}
 	if apiErr := v.Validate(g); apiErr != nil {
 		t.Errorf("valid CWL $(...) expressions should pass, got: %v", apiErr)
+	}
+}
+
+func TestValidate_OutputBinding_Valid_JSExpressionBody(t *testing.T) {
+	// A whole-string ${ ... } block containing a return statement is a valid CWL
+	// JavaScript expression body (legal in outputEval and expression globs with
+	// InlineJavascriptRequirement). It must NOT be flagged as shell-style. These
+	// mirror CWL v1.2 conformance tests (optional-numerical-output-0, wc4-tool,
+	// listing_shallow3) that regressed under the original blanket ${...} check.
+	cases := []struct {
+		name string
+		out  cwl.ToolOutputParam
+	}{
+		{
+			name: "single-line outputEval with return",
+			out: cwl.ToolOutputParam{
+				Type: "float",
+				OutputBinding: &cwl.OutputBinding{
+					Glob:       "a.txt",
+					OutputEval: "${\n    return parseFloat(self[0].contents);\n}",
+				},
+			},
+		},
+		{
+			name: "multi-line outputEval with nested braces and return",
+			out: cwl.ToolOutputParam{
+				Type: "int",
+				OutputBinding: &cwl.OutputBinding{
+					Glob:       "output.txt",
+					OutputEval: "${\n  var s = self[0].contents.split(/\\r?\\n/);\n  return parseInt(s[s.length-2]);\n}",
+				},
+			},
+		},
+		{
+			name: "loop body with inner braces and return",
+			out: cwl.ToolOutputParam{
+				Type: "File",
+				OutputBinding: &cwl.OutputBinding{
+					Glob:       ".",
+					OutputEval: "${\n  for (var i = 0; i < self[0].listing.length; i++) {\n    if (self[0].listing[i].basename == \"file2\") {\n      return self[0].listing[i];\n    }\n  }\n}",
+				},
+			},
+		},
+		{
+			name: "expression-body glob with return",
+			out: cwl.ToolOutputParam{
+				Type: "File",
+				OutputBinding: &cwl.OutputBinding{
+					Glob: "${ return inputs.name + \".txt\"; }",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := testValidator()
+			g := validGraph()
+			g.Tools["tool1"].Outputs = map[string]cwl.ToolOutputParam{"computed": tc.out}
+			if apiErr := v.Validate(g); apiErr != nil {
+				t.Errorf("valid ${...} JS expression body should pass, got: %v", apiErr.Details)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes **#120**. Commit `f216c5b` added `validateOutputBindings` to reject shell-style `${...}` interpolation in `outputBinding.glob`/`outputEval` (which silently produces garbage output paths — the blast-protein-search bug). But it flagged **any** `${...}`, including the legitimate CWL **JavaScript expression-body** form: a whole-string `${ ... }` block containing a `return`, legal in `outputEval` and expression globs when `InlineJavascriptRequirement` is in scope.

This **regressed 7 CWL v1.2 conformance tests** (28, 29, 31, 59, 117, 249, 256, all `VALIDATION_ERROR`) and would break any real workflow using a JS expression body. It was caught running the full conformance suite against `main` — the one regression in the commits untested since 2026-06-04.

## Fix

Add `isJSExpressionBody`: a value is accepted (not flagged) when it is a single, **brace-balanced, whole-string `${ ... }` block containing a `return` statement**. This cleanly distinguishes:

| Value | Verdict |
|-------|---------|
| `"${ return parseFloat(self[0].contents); }"` | ✅ valid (whole block + return) |
| `"${params.output_path}/blast_out.json"` | ❌ embedded, no return — shell-style |
| `"${self[0].contents.trim()}"` | ❌ no return — should use `$(...)` |

Brace matching handles nested braces (loops/conditionals) in the JS body. The original anti-pattern detection — the blast glob bug and the existing `RejectGlob`/`RejectGlobArray`/`RejectOutputEval` tests — is fully preserved.

## Verification

- **7 conformance tests pass again** (re-ran `-n 28,29,31,59,117,249,256` → all pass).
- New table-driven test `TestValidate_OutputBinding_Valid_JSExpressionBody` (4 cases mirroring the conformance bodies) passes; the 3 existing reject tests still reject.
- Full `go test ./...` green; `go vet` + `gofmt` clean.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)