### PR TITLE
fix(resolvers): preserve ws:// and shock:// URIs in File/Directory locations

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -438,22 +438,29 @@ func ResolveFilePaths(v any, baseDir string) any {
 			var absLocation string
 			if loc, ok := result["location"].(string); ok {
 				// Decode URL-encoded characters in the location.
-				loc = cwl.DecodeLocation(loc)
+				decoded := cwl.DecodeLocation(loc)
+				scheme, _ := cwl.ParseLocationScheme(decoded)
 
-				if strings.HasPrefix(loc, "file://") {
-					// Strip file:// prefix and resolve.
-					localPath := strings.TrimPrefix(loc, "file://")
+				switch {
+				case scheme == cwl.SchemeFile || strings.HasPrefix(decoded, "file://"):
+					// Strip file:// prefix and resolve to a local path.
+					localPath := strings.TrimPrefix(decoded, "file://")
 					if !filepath.IsAbs(localPath) {
 						localPath = filepath.Join(baseDir, localPath)
 					}
 					absLocation = localPath
 					result["location"] = "file://" + localPath
-				} else if !strings.HasPrefix(loc, "http://") && !strings.HasPrefix(loc, "https://") {
-					// Relative local path.
-					if !filepath.IsAbs(loc) {
-						absLocation = filepath.Join(baseDir, loc)
+				case scheme != "":
+					// Remote/non-local URI (http, https, ws, shock, …): preserve the
+					// location verbatim and derive no local path. ws:// in particular
+					// must reach the BV-BRC executor intact so it can be flattened to a
+					// workspace path (issue #117).
+				default:
+					// Relative or absolute local path.
+					if !filepath.IsAbs(decoded) {
+						absLocation = filepath.Join(baseDir, decoded)
 					} else {
-						absLocation = loc
+						absLocation = decoded
 					}
 					result["location"] = absLocation
 				}

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -14,6 +14,62 @@ func testdataPath(rel string) string {
 	return filepath.Join("..", "..", "testdata", rel)
 }
 
+// ResolveFilePaths must NOT mangle remote URI locations (ws://, shock://,
+// http(s)://): they are not local paths and must survive bundling intact so the
+// BV-BRC executor can flatten them to a workspace path, and so worker/local
+// execution can resolve them. Only file:// and scheme-less locations are local.
+func TestResolveFilePaths_PreservesRemoteURIs(t *testing.T) {
+	cases := []struct {
+		name     string
+		class    string
+		location string
+	}{
+		{"workspace file", "File", "ws:///user@bvbrc/home/data/contigs.fasta"},
+		{"workspace dir", "Directory", "ws:///user@bvbrc/home/output"},
+		{"shock file", "File", "shock://p3.theseed.org/node/abc123"},
+		{"https file", "File", "https://example.com/data/x.fasta"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := map[string]any{"class": tc.class, "location": tc.location}
+			out, ok := ResolveFilePaths(in, "/jobs/basedir").(map[string]any)
+			if !ok {
+				t.Fatalf("ResolveFilePaths returned %T, want map", out)
+			}
+			if got := out["location"]; got != tc.location {
+				t.Errorf("location = %q, want %q (must be preserved, not joined with baseDir)", got, tc.location)
+			}
+			// A remote URI must not acquire a local baseDir-joined path.
+			if p, ok := out["path"].(string); ok && strings.Contains(p, "/jobs/basedir") {
+				t.Errorf("path = %q leaked baseDir for a remote URI", p)
+			}
+		})
+	}
+}
+
+// file:// and relative locations remain local-path resolution (regression guard
+// that the remote-URI fix did not change local behavior).
+func TestResolveFilePaths_LocalStillResolved(t *testing.T) {
+	t.Run("file:// localized", func(t *testing.T) {
+		in := map[string]any{"class": "File", "location": "file:///tmp/staged/x.fasta"}
+		out := ResolveFilePaths(in, "/jobs/basedir").(map[string]any)
+		if got := out["location"]; got != "file:///tmp/staged/x.fasta" {
+			t.Errorf("location = %q, want file:///tmp/staged/x.fasta", got)
+		}
+		if got := out["path"]; got != "/tmp/staged/x.fasta" {
+			t.Errorf("path = %q, want /tmp/staged/x.fasta", got)
+		}
+	})
+	t.Run("relative joined with baseDir", func(t *testing.T) {
+		in := map[string]any{"class": "File", "location": "sub/x.fasta"}
+		out := ResolveFilePaths(in, "/jobs/basedir").(map[string]any)
+		if got := out["location"]; got != "/jobs/basedir/sub/x.fasta" {
+			t.Errorf("location = %q, want /jobs/basedir/sub/x.fasta", got)
+		}
+	})
+}
+
 func TestBundle_SeparateFiles(t *testing.T) {
 	result, err := Bundle(testdataPath("separate/pipeline.cwl"))
 	if err != nil {

--- a/internal/cwlrunner/resolve_ws_test.go
+++ b/internal/cwlrunner/resolve_ws_test.go
@@ -1,0 +1,36 @@
+package cwlrunner
+
+import "testing"
+
+// resolveFileObject must preserve remote URI locations (ws://, shock://,
+// http(s)://) rather than joining them with baseDir as if relative (issue #117).
+func TestResolveFileObject_PreservesRemoteURIs(t *testing.T) {
+	cases := []struct {
+		name, class, location string
+	}{
+		{"workspace file", "File", "ws:///user@bvbrc/home/data/contigs.fasta"},
+		{"workspace dir", "Directory", "ws:///user@bvbrc/home/output"},
+		{"shock file", "File", "shock://p3.theseed.org/node/abc123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := resolveFileObject(map[string]any{"class": tc.class, "location": tc.location}, "/jobs/basedir")
+			if got := out["location"]; got != tc.location {
+				t.Errorf("location = %q, want %q (preserved, not joined)", got, tc.location)
+			}
+			if p, ok := out["path"].(string); ok && p != "" {
+				t.Errorf("path = %q set for a remote URI; want no local path", p)
+			}
+		})
+	}
+}
+
+func TestResolveFileObject_LocalStillResolved(t *testing.T) {
+	out := resolveFileObject(map[string]any{"class": "File", "location": "file:///tmp/x.fasta"}, "/jobs/basedir")
+	if got := out["location"]; got != "file:///tmp/x.fasta" {
+		t.Errorf("location = %q, want file:///tmp/x.fasta", got)
+	}
+	if got := out["path"]; got != "/tmp/x.fasta" {
+		t.Errorf("path = %q, want /tmp/x.fasta", got)
+	}
+}

--- a/internal/cwlrunner/runner.go
+++ b/internal/cwlrunner/runner.go
@@ -1669,9 +1669,11 @@ func splitBasenameExt(basename string) (string, string) {
 	return basename, ""
 }
 
-// isURI checks if a string is a URI.
+// isURI reports whether s has a recognized URI scheme (file, http, https, ws,
+// shock, …). Delegates to cwl.IsURI so all resolvers agree on which locations
+// must be preserved rather than joined with a base directory (issue #117).
 func isURI(s string) bool {
-	return len(s) > 5 && (s[:5] == "file:" || s[:5] == "http:" || s[:6] == "https:")
+	return cwl.IsURI(s)
 }
 
 // resolveStepInputs resolves inputs for a workflow step.

--- a/internal/cwltool/helpers.go
+++ b/internal/cwltool/helpers.go
@@ -761,8 +761,11 @@ func splitBasenameExt(basename string) (string, string) {
 	return basename, ""
 }
 
+// isURI reports whether s has a recognized URI scheme (file, http, https, ws,
+// shock, …). Delegates to cwl.IsURI so all resolvers agree on which locations
+// must be preserved rather than joined with a base directory (issue #117).
 func isURI(s string) bool {
-	return len(s) > 5 && (s[:5] == "file:" || s[:5] == "http:" || s[:6] == "https:")
+	return cwl.IsURI(s)
 }
 
 // stageOutOfVolumeInputs copies input files that are outside the named volume

--- a/internal/cwltool/helpers_ws_test.go
+++ b/internal/cwltool/helpers_ws_test.go
@@ -1,0 +1,37 @@
+package cwltool
+
+import "testing"
+
+// ResolveFileObject must preserve remote URI locations (ws://, shock://,
+// http(s)://) rather than treating them as relative paths and joining them with
+// baseDir (issue #117). Only file:// and scheme-less locations are local.
+func TestResolveFileObject_PreservesRemoteURIs(t *testing.T) {
+	cases := []struct {
+		name, class, location string
+	}{
+		{"workspace file", "File", "ws:///user@bvbrc/home/data/contigs.fasta"},
+		{"workspace dir", "Directory", "ws:///user@bvbrc/home/output"},
+		{"shock file", "File", "shock://p3.theseed.org/node/abc123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := ResolveFileObject(map[string]any{"class": tc.class, "location": tc.location}, "/jobs/basedir")
+			if got := out["location"]; got != tc.location {
+				t.Errorf("location = %q, want %q (preserved, not joined)", got, tc.location)
+			}
+			if p, ok := out["path"].(string); ok && p != "" {
+				t.Errorf("path = %q set for a remote URI; want no local path", p)
+			}
+		})
+	}
+}
+
+func TestResolveFileObject_LocalStillResolved(t *testing.T) {
+	out := ResolveFileObject(map[string]any{"class": "File", "location": "file:///tmp/x.fasta"}, "/jobs/basedir")
+	if got := out["location"]; got != "file:///tmp/x.fasta" {
+		t.Errorf("location = %q, want file:///tmp/x.fasta", got)
+	}
+	if got := out["path"]; got != "/tmp/x.fasta" {
+		t.Errorf("path = %q, want /tmp/x.fasta", got)
+	}
+}

--- a/internal/executor/bvbrc_ws_roundtrip_test.go
+++ b/internal/executor/bvbrc_ws_roundtrip_test.go
@@ -1,0 +1,70 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/me/gowe/internal/bundle"
+	"github.com/me/gowe/pkg/model"
+)
+
+// TestBVBRCExecutor_WorkspaceURIRoundTrip proves the end-to-end invariant behind
+// issue #117: a ws:// (or shock://) File/Directory input survives the bundling
+// stage (bundle.ResolveFilePaths) un-mangled AND is flattened to a bare
+// workspace-path string when submitted to the BV-BRC API — never sent as a CWL
+// File/Directory object. This guards against a regression in any of the three
+// resolvers re-introducing the filepath.Join mangling.
+func TestBVBRCExecutor_WorkspaceURIRoundTrip(t *testing.T) {
+	// 1. Inputs as they arrive from a job (CWL File/Directory objects with ws://).
+	rawInputs := map[string]any{
+		"output_path": map[string]any{
+			"class":    "Directory",
+			"location": "ws:///user@bvbrc/home/output",
+		},
+		"contigs": map[string]any{
+			"class":    "File",
+			"location": "ws:///user@bvbrc/home/data/contigs.fasta",
+		},
+		"shock_ref": map[string]any{
+			"class":    "File",
+			"location": "shock://p3.theseed.org/node/abc123",
+		},
+	}
+
+	// 2. Bundling stage: ResolveFilePaths must NOT mangle the ws:// locations.
+	resolvedInputs := make(map[string]any, len(rawInputs))
+	for k, v := range rawInputs {
+		resolvedInputs[k] = bundle.ResolveFilePaths(v, "/jobs/basedir")
+	}
+
+	// 3. Submit through the BV-BRC executor; it flattens File/Directory → string.
+	mock := &mockRPCCaller{result: json.RawMessage(`[{"id":"j1","status":"queued"}]`)}
+	e := newTestBVBRCExecutor(mock)
+	task := &model.Task{ID: "task_1", BVBRCAppID: "GenomeAssembly2", Inputs: resolvedInputs}
+
+	if _, err := e.Submit(context.Background(), task); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	// 4. The BV-BRC API must receive flat workspace-path strings, not CWL objects.
+	params, ok := mock.calls[0].Params[1].(map[string]any)
+	if !ok {
+		t.Fatalf("params not a map: %T", mock.calls[0].Params[1])
+	}
+	want := map[string]string{
+		"output_path": "/user@bvbrc/home/output",
+		"contigs":     "/user@bvbrc/home/data/contigs.fasta",
+		"shock_ref":   "shock://p3.theseed.org/node/abc123",
+	}
+	for k, exp := range want {
+		got, isStr := params[k].(string)
+		if !isStr {
+			t.Errorf("param %q = %T (%v), want flat string %q — a CWL object reached the API", k, params[k], params[k], exp)
+			continue
+		}
+		if got != exp {
+			t.Errorf("param %q = %q, want %q", k, got, exp)
+		}
+	}
+}

--- a/pkg/cwl/location.go
+++ b/pkg/cwl/location.go
@@ -27,6 +27,17 @@ func ParseLocationScheme(location string) (scheme, path string) {
 	return "", location
 }
 
+// IsURI reports whether s is a URI with a recognized scheme prefix (file, http,
+// https, ws, shock, s3, …) — i.e. it has a "scheme://" prefix. Bare, relative,
+// and absolute local paths return false; those must be resolved against a base
+// directory. Centralizing this here keeps every resolver (bundler, cwltool,
+// cwlrunner) in agreement about which locations are URIs that must be preserved
+// rather than joined with a base directory.
+func IsURI(s string) bool {
+	scheme, _ := ParseLocationScheme(s)
+	return scheme != ""
+}
+
 // BuildLocation constructs a scheme://path URI.
 func BuildLocation(scheme, path string) string {
 	switch scheme {

--- a/pkg/cwl/location_test.go
+++ b/pkg/cwl/location_test.go
@@ -89,6 +89,39 @@ func TestInferScheme(t *testing.T) {
 	}
 }
 
+func TestIsURI(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		// Recognized URI schemes — all true.
+		{"file:///data/output", true},
+		{"http://example.com/x", true},
+		{"https://example.com/x", true},
+		{"ws:///user@bvbrc/home/contigs.fasta", true},
+		{"shock://p3.theseed.org/node/abc", true},
+		{"s3://bucket/key", true},
+		// Bare/relative/absolute local paths — all false (must be joined with baseDir).
+		{"/user@bvbrc/home/output", false},
+		{"/tmp/local/path", false},
+		{"relative/path", false},
+		{"contigs.fasta", false},
+		{"", false},
+		// Windows-style path is not a URI.
+		{`C:\data\x`, false},
+		// A leading "://" with no scheme is not a URI.
+		{"://nope", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := IsURI(tt.input); got != tt.want {
+				t.Errorf("IsURI(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseLocationScheme_RoundTrip(t *testing.T) {
 	// Ensure BuildLocation → ParseLocationScheme round-trips correctly.
 	cases := []struct {


### PR DESCRIPTION
## Summary

Fixes **#117**. CWL File/Directory location resolution treated any location without a `file:`/`http(s):` scheme as a relative local path and joined it with the base directory. A `ws:///user@bvbrc/...` location was mangled into `/basedir/ws:/user@bvbrc/...` by **three independent resolvers**:

| Resolver | Path it affects |
|----------|-----------------|
| `cwltool/helpers.go:isURI` | worker/local CWL execution (`task.Job`) |
| `cwlrunner/runner.go:isURI` | standalone `cwl-runner` |
| `bundle.ResolveFilePaths` | bundling → BV-BRC `task.Inputs` |

The **bundle path is the most damaging**: it corrupts the `ws://` location *before* `task.Inputs` reaches the BV-BRC executor, so the executor's (correct) flattener `resolveBVBRCInput → resolveLocation` receives garbage and ships a bogus path to `AppService.start_app`. This is why workspace inputs had to be declared as `string` instead of `File`/`Directory`.

## Fix — one source of truth

- Add `cwl.IsURI(s)`: true when `ParseLocationScheme` yields a scheme (`file`/`http`/`https`/`ws`/`shock`/`s3`/…); bare/relative/absolute paths → false.
- `cwltool.isURI` and `cwlrunner.isURI` delegate to `cwl.IsURI`.
- `bundle.ResolveFilePaths` switches on `cwl.ParseLocationScheme`: `file://` is localized, any **other non-file scheme is preserved verbatim** with no derived local path, and only scheme-less values are joined with `baseDir`.

The BV-BRC executor still flattens File/Directory CWL objects to workspace-path strings — **CWL objects never reach the API**.

## Tests (written first)

- `pkg/cwl`: `TestIsURI` (all schemes + relative/absolute/bare/`C:\`/`://nope`).
- `bundle`: `ws://`/`shock://`/`https://` File/Directory survive un-mangled; `file://` and relative still resolve locally.
- `cwltool` + `cwlrunner`: `ResolveFileObject`/`resolveFileObject` preserve remote URIs.
- `executor`: **round-trip lock-in** — `ws://` input → `bundle.ResolveFilePaths` → executor flatten → asserts plain `/user@bvbrc/...` string reaches the API (and a CWL object never does).

Full `go test ./...` green; `go vet` + `gofmt` clean.

## Note

This bug had to be fixed in **three** copy-pasted resolvers; `cwltool.ResolveFileObject` and `cwlrunner.resolveFileObject` are byte-for-byte identical. A follow-up issue tracks unifying them so the next such fix lands in one place.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)