### PR TITLE
fix(cli): preserve ws:// Directory location during input upload

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -842,6 +842,14 @@ func uploadFileInput(fileObj map[string]any, quiet bool) (map[string]any, error)
 
 // uploadDirectoryInput uploads all files in a Directory's listing.
 func uploadDirectoryInput(dirObj map[string]any, quiet bool) (map[string]any, error) {
+	// A Directory whose location is a remote URI (ws://, shock://, http(s)://) is
+	// already accessible to the executor/worker — it must not be uploaded and its
+	// location must be preserved (e.g. a BV-BRC ws:// output_path). Mirrors
+	// uploadFileInput, which leaves remote-URI File locations untouched (#117).
+	if loc, _ := dirObj["location"].(string); cwl.IsURI(loc) {
+		return dirObj, nil
+	}
+
 	result := make(map[string]any)
 	for k, v := range dirObj {
 		result[k] = v

--- a/internal/cli/upload_ws_test.go
+++ b/internal/cli/upload_ws_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"testing"
+)
+
+// A Directory input whose location is a remote URI (ws://, shock://, http(s)://)
+// is already accessible to the executor/worker and must be preserved verbatim —
+// not uploaded and not stripped of its location. Regression guard for the
+// "Directory loses location" half of #117 (uploadDirectoryInput previously did
+// an unconditional delete(result, "location")).
+func TestUploadDirectoryInput_PreservesRemoteURI(t *testing.T) {
+	cases := []struct {
+		name, location string
+	}{
+		{"workspace", "ws:///awilke@bvbrc/home/gowe-ws-test"},
+		{"shock", "shock://p3.theseed.org/node/abc123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := map[string]any{"class": "Directory", "location": tc.location}
+			out, err := uploadDirectoryInput(in, true)
+			if err != nil {
+				t.Fatalf("uploadDirectoryInput: %v", err)
+			}
+			if got := out["location"]; got != tc.location {
+				t.Errorf("location = %v, want %q (must be preserved, not dropped)", got, tc.location)
+			}
+		})
+	}
+}
+
+// A File input with a remote URI location is likewise preserved (already the
+// case; locks it in alongside the Directory fix).
+func TestUploadFileInput_PreservesRemoteURI(t *testing.T) {
+	in := map[string]any{"class": "File", "location": "ws:///awilke@bvbrc/home/data/contigs.fasta"}
+	out, err := uploadFileInput(in, true)
+	if err != nil {
+		t.Fatalf("uploadFileInput: %v", err)
+	}
+	if got := out["location"]; got != "ws:///awilke@bvbrc/home/data/contigs.fasta" {
+		t.Errorf("location = %v, want preserved ws:// URI", got)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #117, found while verifying the ws:// fix against a real submission. The merged #117 PR fixed the three location resolvers, so a **File** ws:// input reaches the submission payload un-mangled. But a **Directory** ws:// input (e.g. `output_path`) was still reduced to bare `{"class":"Directory"}` — its location dropped — by a fourth code path: `uploadDirectoryInput` (`internal/cli/run.go`).

That function ends with an unconditional `delete(result, "location")`. Correct for a *local* directory that was uploaded (its listing entries carry server-side locations), but wrong for a remote-URI directory (ws://, shock://, http(s)://) that is already accessible and must not be uploaded — so BV-BRC received no output location. (`uploadFileInput` already leaves remote-URI files untouched, which is why File worked.)

## Fix

Mirror `uploadFileInput`: early-return the Directory unchanged when its location is a remote URI (`cwl.IsURI`). Local directories still upload and strip as before.

## Evidence (live, deployed 7922a57)

Captured the deployed CLI's actual submission payload for a `GenomeAnnotation` job with ws:// inputs:
- `contigs` (File) → `ws:///awilke@bvbrc/home/data/contigs.fasta` ✅ preserved
- `output_path` (Directory) → `{"class":"Directory"}` ❌ location dropped ← fixed here

## Tests

`TestUploadDirectoryInput_PreservesRemoteURI` (ws:// + shock://) and `TestUploadFileInput_PreservesRemoteURI`, written first. Full `go test ./...` green; vet + gofmt clean.

This is a CLI-only change (no server/worker behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)