### PR TITLE
fix(bvbrc): flatten File/Directory nested inside group/record params

### DIFF
--- a/internal/executor/bvbrc.go
+++ b/internal/executor/bvbrc.go
@@ -519,7 +519,15 @@ func resolveBVBRCInput(v any) any {
 		if class == "File" || class == "Directory" {
 			return resolveLocation(val)
 		}
-		return val
+		// Recurse into nested maps. [bvbrc:group] / record parameters (e.g.
+		// paired_end_libs) carry File/Directory objects in their fields; those
+		// must be flattened to workspace path strings too, or BV-BRC receives a
+		// raw CWL object ("File HASH(0x...) does not exist").
+		out := make(map[string]any, len(val))
+		for k, item := range val {
+			out[k] = resolveBVBRCInput(item)
+		}
+		return out
 	case []any:
 		resolved := make([]any, len(val))
 		for i, item := range val {

--- a/internal/executor/bvbrc_test.go
+++ b/internal/executor/bvbrc_test.go
@@ -285,6 +285,64 @@ func TestBVBRCExecutor_SubmitFileAndDirectoryResolved(t *testing.T) {
 	}
 }
 
+// File/Directory objects nested inside a [bvbrc:group] / record parameter (e.g.
+// paired_end_libs[].read1) must also be flattened to workspace path strings.
+// Reproduces the real GenomeAssembly2 failure where read1/read2 reached BV-BRC as
+// CWL objects ("File HASH(0x...) does not exist").
+func TestBVBRCExecutor_SubmitFlattensNestedGroupFiles(t *testing.T) {
+	mock := &mockRPCCaller{result: json.RawMessage(`[{"id":"j1","status":"queued"}]`)}
+	e := newTestBVBRCExecutor(mock)
+
+	task := &model.Task{
+		ID:         "task_1",
+		BVBRCAppID: "GenomeAssembly2",
+		Inputs: map[string]any{
+			"paired_end_libs": []any{
+				map[string]any{
+					"read1":    map[string]any{"class": "File", "location": "ws:///user@bvbrc/home/sample1_R1.fastq.gz"},
+					"read2":    map[string]any{"class": "File", "location": "ws:///user@bvbrc/home/sample1_R2.fastq.gz"},
+					"platform": "illumina",
+				},
+			},
+			"output_path": map[string]any{"class": "Directory", "location": "ws:///user@bvbrc/home/"},
+			"output_file": "asm",
+		},
+	}
+
+	if _, err := e.Submit(context.Background(), task); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	params := mock.calls[0].Params[1].(map[string]any)
+	libs, ok := params["paired_end_libs"].([]any)
+	if !ok || len(libs) != 1 {
+		t.Fatalf("paired_end_libs = %#v, want 1-element array", params["paired_end_libs"])
+	}
+	lib := libs[0].(map[string]any)
+
+	for _, field := range []struct{ key, want string }{
+		{"read1", "/user@bvbrc/home/sample1_R1.fastq.gz"},
+		{"read2", "/user@bvbrc/home/sample1_R2.fastq.gz"},
+	} {
+		got, isStr := lib[field.key].(string)
+		if !isStr {
+			t.Errorf("%s = %T (%v), want flat workspace string — a CWL object reached the API", field.key, lib[field.key], lib[field.key])
+			continue
+		}
+		if got != field.want {
+			t.Errorf("%s = %q, want %q", field.key, got, field.want)
+		}
+	}
+	// Non-File fields in the group are preserved as-is.
+	if lib["platform"] != "illumina" {
+		t.Errorf("platform = %v, want illumina", lib["platform"])
+	}
+	// Top-level Directory still flattens.
+	if got := params["output_path"]; got != "/user@bvbrc/home/" {
+		t.Errorf("output_path = %v, want /user@bvbrc/home/", got)
+	}
+}
+
 func TestBVBRCExecutor_StatusQueued(t *testing.T) {
 	mock := &mockRPCCaller{
 		result: json.RawMessage(`[{"job-1":{"status":"queued"}}]`),


### PR DESCRIPTION
## Summary

Found by a **real** GenomeAssembly2 submission while verifying #117/#124. `resolveBVBRCInput` flattened only **top-level** File/Directory objects to workspace path strings; for any other map it returned the value unchanged **without recursing**. So File/Directory objects nested inside a `[bvbrc:group]` / record parameter (e.g. `paired_end_libs[].read1`) were sent to BV-BRC as raw CWL objects, and `start_app` preflight rejected them:

```
Reads as defined in parameters failed to validate.
  File HASH(0x...) does not exist
```

(`HASH(0x...)` is the Perl-side stringification of a CWL File hashref.)

This is the same "flatten to a URI string, never a CWL object" invariant that already held for top-level params — it just wasn't holding for nested ones. The unit tests only exercised top-level File/Directory, so they passed; the real submission is what caught it.

## Fix

Recurse into nested maps so File/Directory fields inside group/record params are flattened too. Non-File fields are preserved; top-level File/Directory and plain params are unchanged.

## Tests

`TestBVBRCExecutor_SubmitFlattensNestedGroupFiles` — a `paired_end_libs`-style group with nested ws:// File `read1`/`read2` now flattens to workspace path strings (reproduces today's failure). Existing executor tests still pass. Full `go test ./...` green; vet + gofmt clean.

## Note

This is a **server-side** change (the BV-BRC executor runs in the server), so it requires a server redeploy to take effect in production — unlike the CLI-only #124.

Related: #117, #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)