### PR TITLE
fix(cli): only skip upload for remote-URI directories, not file://

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -842,12 +842,15 @@ func uploadFileInput(fileObj map[string]any, quiet bool) (map[string]any, error)
 
 // uploadDirectoryInput uploads all files in a Directory's listing.
 func uploadDirectoryInput(dirObj map[string]any, quiet bool) (map[string]any, error) {
-	// A Directory whose location is a remote URI (ws://, shock://, http(s)://) is
+	// A Directory whose location is a REMOTE URI (ws://, shock://, http(s)://) is
 	// already accessible to the executor/worker — it must not be uploaded and its
-	// location must be preserved (e.g. a BV-BRC ws:// output_path). Mirrors
-	// uploadFileInput, which leaves remote-URI File locations untouched (#117).
-	if loc, _ := dirObj["location"].(string); cwl.IsURI(loc) {
-		return dirObj, nil
+	// location must be preserved (e.g. a BV-BRC ws:// output_path). file:// and
+	// scheme-less locations are LOCAL and must still be uploaded, so exclude them:
+	// cwl.IsURI is true for file:// too, which is why we check the scheme directly.
+	if loc, _ := dirObj["location"].(string); loc != "" {
+		if scheme, _ := cwl.ParseLocationScheme(loc); scheme != "" && scheme != cwl.SchemeFile {
+			return dirObj, nil
+		}
 	}
 
 	result := make(map[string]any)

--- a/internal/cli/upload_ws_test.go
+++ b/internal/cli/upload_ws_test.go
@@ -30,6 +30,22 @@ func TestUploadDirectoryInput_PreservesRemoteURI(t *testing.T) {
 	}
 }
 
+// A file:// Directory is LOCAL and must NOT take the remote-URI early-return —
+// it must still go through the upload path. Regression guard: cwl.IsURI returns
+// true for file://, so the guard must check the scheme, not just IsURI. Using a
+// nonexistent path means no upload is attempted (no server client needed); the
+// observable is that the local-path branch ran and stripped the location.
+func TestUploadDirectoryInput_FileURLNotPreserved(t *testing.T) {
+	in := map[string]any{"class": "Directory", "location": "file:///nonexistent-dir-xyz-12345"}
+	out, err := uploadDirectoryInput(in, true)
+	if err != nil {
+		t.Fatalf("uploadDirectoryInput: %v", err)
+	}
+	if _, ok := out["location"]; ok {
+		t.Errorf("file:// directory kept its location %v — it took the remote-URI early-return instead of the local upload path", out["location"])
+	}
+}
+
 // A File input with a remote URI location is likewise preserved (already the
 // case; locks it in alongside the Directory fix).
 func TestUploadFileInput_PreservesRemoteURI(t *testing.T) {


### PR DESCRIPTION
## Summary

Regression fix for **#124**. That PR's guard used `cwl.IsURI(loc)` to early-return Directory inputs with a remote-URI location. But **`cwl.IsURI` is true for `file://` too** (it's a URI scheme), so local `file://` directories also took the early-return and were **never uploaded to the worker**.

This broke every local Directory test in **server-worker** conformance — 11 failures (`dir*.cwl`, `listing_deep*`, `iwd-*`, `recursive-input-directory`, `capture-files-and-dirs`). server-local passed because it can still reach the local `file://` path without staging; only the separate worker needs the upload.

## Fix

Check the scheme directly: skip upload only for a non-empty, **non-file** scheme (`ws`, `shock`, `http`, `https`). `file://` and scheme-less locations stay local and upload as before.

## Tests

- `TestUploadDirectoryInput_FileURLNotPreserved` — the regression guard that was missing (the earlier local-upload test was dropped because it needed a server client; this one uses a nonexistent path to stay client-free).
- Existing remote-URI preservation tests still pass.

## Conformance (re-run with the fix)

| Mode | Result |
|------|--------|
| cwl-runner | all pass |
| server-local | 376 / 0 / 2 |
| server-worker | **376 / 0 / 2** (was 365/11/2) |

Full `go test ./...` green; vet + gofmt clean. CLI-only change.

Related: #117, #124, #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)