### PR TITLE
docs: architecture specification, ADR log, dossier, and deep dives

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,16 @@ The default `docker-compose.yml` uses fast poll intervals (`500ms`) for testing.
 
 ## Architecture
 
+**Deep-dive documentation:**
+
+- 📊 **[Architecture dossier](docs/architecture-dossier.html)** — a visual, per-layer overview
+  (topology, execution path, state machines, scheduler, executors, credentials, hints, storage).
+  Self-contained HTML — open it directly in a browser.
+- 📕 **[Specification](SPECIFICATION.md)** — the normative reference for how GoWe interprets and
+  executes workflows.
+- 📐 **[Architecture Decision Records](docs/adr/)** — the *why* behind the design.
+- 🔌 **[BV-BRC & Workspace deep dive](docs/BVBRC-Workspace-Deep-Dive.md)** · **[CWL hints reference](docs/cwl-hints.md)**
+
 ### Data Flow
 
 ```

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -61,6 +61,9 @@ informal synonym for **Workflow**. Code and docs MUST use the normative term.
 
 ## 4. Workflow definition
 
+Rationale for adopting CWL as the sole definition format:
+[ADR-0001](docs/adr/0001-adopt-cwl-v1.2-as-workflow-definition-format.md).
+
 ### 4.1 Format
 
 A workflow or tool definition MUST be a CWL v1.2 YAML or JSON document. GoWe supports:
@@ -437,7 +440,8 @@ The full route table is defined in `internal/server/`.
 
 GoWe separates credentials into four planes and holds them together with one invariant:
 **execution secrets MUST NOT travel back to the server** (§13.2). Identity is delegated to
-external providers — GoWe stores no user passwords.
+external providers — GoWe stores no user passwords. Rationale for the auth model:
+[ADR-0009](docs/adr/0009-delegated-identity-and-optional-worker-keys.md).
 
 ### 13.1 Credential planes
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -191,7 +191,7 @@ Submission                       one run of a workflow
 | DISPATCHED | Tasks created and submitted to executors. |
 | RUNNING | At least one Task running. |
 | COMPLETED / FAILED | All Tasks terminal, success/failure aggregated. |
-| SKIPPED | `when` evaluated false. |
+| SKIPPED | `when` evaluated false, **or** the StepInstance was non-terminal when its Submission was cancelled. |
 
 ### 6.3 Task states
 
@@ -206,7 +206,7 @@ with `FAILED → RETRYING → QUEUED` while retries remain.
 | RUNNING | Executing. |
 | SUCCESS / FAILED | Terminal outcome. |
 | RETRYING | Failed but eligible for retry; re-enters QUEUED. |
-| SKIPPED | Conditional skip. |
+| SKIPPED | Conditional skip (`when` false), **or** cancellation of a non-terminal Task when its Submission is cancelled. |
 
 > Worker-bound tasks MAY transition directly `PENDING → QUEUED`, bypassing `SCHEDULED`, so
 > they are immediately available for checkout.
@@ -276,12 +276,14 @@ Every backend MUST implement `Submit`, `Status`, `Cancel`, and `Logs`
 
 The scheduler MUST select a Task's backend in this order:
 
-1. Server `--default-executor`, if set — overrides all hints.
-2. `gowe:Execution.executor` (`worker` | `bvbrc` | `local`).
-3. `gowe:Execution.bvbrc_app_id` present ⇒ `bvbrc`.
-4. `DockerRequirement` or `gowe:Execution.docker_image` present ⇒ `worker` when workers are
+1. Server `--force-executor`, if set — forces every Task to this backend, ignoring all hints
+   and `--default-executor`. Intended for testing only.
+2. Server `--default-executor`, if set — overrides all hints.
+3. `gowe:Execution.executor` (`worker` | `bvbrc` | `local`).
+4. `gowe:Execution.bvbrc_app_id` present ⇒ `bvbrc`.
+5. `DockerRequirement` or `gowe:Execution.docker_image` present ⇒ `worker` when workers are
    online, else `local`.
-5. Default ⇒ `local`.
+6. Default ⇒ `local`.
 
 ### 8.3 Container image resolution
 
@@ -495,7 +497,11 @@ external providers — GoWe stores no user passwords. Rationale for the auth mod
 - The `X-Worker-Key` MUST NOT be logged in the clear; only a hash of it MAY be logged.
 - A BV-BRC token MAY be injected into a task's container as `BVBRC_TOKEN` when, and only when,
   `gowe:Execution.inject_bvbrc_token` is set (or a workspace stager requires it); the injected
-  token is the submitter's own, so the job runs under the user's identity.
+  token is the submitter's own, so the job runs under the user's identity. This opt-in gate is
+  a deliberate least-privilege boundary: a token MUST NOT be exposed to a tool that did not
+  request it. (A proposed change, PR #132 / issue #133, injects the token into every worker
+  task unconditionally and adds a `KB_AUTH_TOKEN` alias; if adopted, this clause and §13.1
+  MUST be revised, and the least-privilege trade-off recorded in an ADR.)
 - Response bodies MUST NOT expose stored tokens: submission token fields are serialized with
   `json:"-"`.
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,0 +1,539 @@
+# GoWe Specification
+
+> **Status**: Living specification · **Version**: draft-3 (2026-07-06)
+> **Applies to**: GoWe server, worker, CLI, and `cwl-runner`
+> **Companion documents**: [`docs/adr/`](docs/adr/) (why), [`docs/cwl-hints.md`](docs/cwl-hints.md)
+> (hint reference), [`docs/GoWe-Vocabulary.md`](docs/GoWe-Vocabulary.md) (concepts),
+> [`CONFORMANCE.md`](CONFORMANCE.md) (CWL conformance)
+
+This document is the normative reference for how GoWe interprets workflows and executes
+them. It consolidates the vocabulary, the CWL hint extensions, the execution model, and the
+worker/API contracts into one place. Where this specification and prose docs disagree, this
+document governs; where this document and the running code disagree, that is a bug in one of
+them — file it.
+
+---
+
+## 1. Conformance language
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are used as
+defined in RFC 2119. They apply to GoWe implementations (server, worker, runner), not to
+workflow authors, except where a statement is explicitly about a valid workflow document.
+
+---
+
+## 2. Scope
+
+GoWe is a workflow engine that:
+
+- accepts workflows and tools written in **CWL v1.2** (§4);
+- runs them through a **three-level execution model** (§6) driven by a **tick-based
+  scheduler** (§7);
+- dispatches concrete work to **five interchangeable executor backends** (§8);
+- distributes work to remote machines through a **pull-based worker protocol** (§9);
+- persists all state in an embedded **SQLite** store (§11) and exposes an **HTTP API** (§12).
+
+Out of scope for this document: the internal CWL expression engine, the BV-BRC JSON-RPC wire
+format (see [`docs/BVBRC-API.md`](docs/BVBRC-API.md)), and the web UI.
+
+---
+
+## 3. Terminology (normative)
+
+These terms are normative. Code, docs, and API responses MUST use them consistently.
+
+| Term | Definition |
+|------|------------|
+| **Workflow** | A declarative DAG of Steps with typed Inputs and Outputs. CWL `class: Workflow`. Describes *what* to compute, never *how* or *where*. |
+| **Tool** | A reusable single operation. CWL `class: CommandLineTool` or `ExpressionTool`. The unit of reuse. |
+| **Step** | One node in a Workflow's DAG; binds a Tool (or sub-Workflow) to input sources. Not executable alone. |
+| **Submission** (a.k.a. **Run**) | One execution of a Workflow with concrete input values. Top-level tracking entity. |
+| **StepInstance** | One runtime instance of a Step within a Submission. A scatter Step yields **N** StepInstances. |
+| **Task** | A concrete, schedulable unit of work bound to resolved inputs and assigned to an Executor. |
+| **Executor** | A pluggable backend that knows *how* to run a Task in one environment. |
+| **Scheduler** | The engine loop that advances the model, resolves dependencies, dispatches, retries, and finalizes. |
+| **Worker** | A remote process that pulls Tasks from the server and executes them. |
+
+Disambiguation: "job" (BV-BRC) ≈ **Task**; "job" (AWE) ≈ **Submission**; "pipeline" is an
+informal synonym for **Workflow**. Code and docs MUST use the normative term.
+
+---
+
+## 4. Workflow definition
+
+### 4.1 Format
+
+A workflow or tool definition MUST be a CWL v1.2 YAML or JSON document. GoWe supports:
+
+- `class: Workflow`, `class: CommandLineTool`, `class: ExpressionTool`;
+- `$graph` bundles (resolved by the bundler);
+- typed inputs/outputs (`File`, `Directory`, `string`, `int`, `long`, `float`, `double`,
+  `boolean`, records, arrays, enums, and `null`/optional unions);
+- `scatter` with `scatterMethod` ∈ {`dotproduct`, `flat_crossproduct`, `nested_crossproduct`};
+- conditional steps via `when` (v1.2);
+- standard requirements/hints including `DockerRequirement`, `ResourceRequirement`,
+  `InlineJavascriptRequirement`, `InitialWorkDirRequirement`, `EnvVarRequirement`,
+  `SecondaryFiles`, and `loadContents`.
+
+### 4.2 Portability requirement
+
+A conforming workflow MUST remain valid CWL that other engines can parse. All GoWe-specific
+metadata MUST be expressed as namespaced hints (§5) so that engines which do not understand
+them ignore them rather than failing.
+
+### 4.3 Conformance
+
+GoWe tracks the upstream CWL v1.2 conformance suite (378 tests). Supported execution modes
+and their current pass rates are recorded in [`docs/Execution-Modes.md`](docs/Execution-Modes.md)
+and [`CONFORMANCE.md`](CONFORMANCE.md). Known deviations (e.g. Apptainer network isolation,
+test 227) MUST be documented there.
+
+---
+
+## 5. GoWe hint extensions (normative)
+
+All extensions live under the namespace:
+
+```yaml
+$namespaces:
+  gowe: https://github.com/wilke/GoWe#
+```
+
+Extensions MUST be placed in `hints` unless noted. Rationale: [ADR-0002](docs/adr/0002-extend-cwl-via-namespaced-hints.md).
+
+### 5.1 `gowe:Execution`
+
+Controls placement of a Tool/Step. Recognized **only in `hints`**. A legacy `goweHint`
+alias is accepted for backward compatibility; new documents SHOULD use `gowe:Execution`.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `executor` | string | Backend: `local`, `worker`, or `bvbrc`. `container` is not a routing value. |
+| `worker_group` | string | Target worker group (e.g. `esmfold`, `gpu`). |
+| `bvbrc_app_id` | string | BV-BRC application id; implies `executor: bvbrc`. |
+| `docker_image` | string | Container image override. Takes priority over `DockerRequirement.dockerPull`. Feeds both Docker and Apptainer (§8.3). |
+| `gpu` | boolean | Request GPU passthrough. |
+| `inject_bvbrc_token` | boolean | Inject the caller's BV-BRC token into the task environment. |
+
+### 5.2 `gowe:ResourceData`
+
+Declares large reference datasets a Tool depends on. Accepted in `hints` or `requirements`.
+Rationale: [ADR-0008](docs/adr/0008-dataset-affinity-and-staging-modes.md).
+
+```yaml
+gowe:ResourceData:
+  datasets:
+    - id: alphafold        # MUST match a worker-advertised dataset id
+      path: /local_databases/alphafold
+      size: 2TB            # informational
+      mode: prestage       # prestage | cache (default: cache)
+      source: shock://...  # optional; reserved for on-demand caching
+```
+
+| `mode` | Scheduler behavior |
+|--------|--------------------|
+| `prestage` | Task MUST be dispatched only to a worker advertising this dataset id; it waits otherwise. |
+| `cache` | Task SHOULD prefer such a worker but MAY run elsewhere. |
+
+A dataset entry without an `id` MUST be ignored. An unknown/empty `mode` MUST default to
+`cache`.
+
+### 5.3 `DockerRequirement` (standard CWL, extended resolution)
+
+`DockerRequirement.dockerPull` is honored when present. GoWe resolves the image value by
+pattern:
+
+| Value | Resolution |
+|-------|------------|
+| ends with `.sif` (relative) | local Apptainer image, resolved against `--image-dir` |
+| absolute `.sif` path | used as-is |
+| anything else | pulled as `docker://<value>` |
+
+If both `gowe:Execution.docker_image` and `DockerRequirement.dockerPull` are set, the
+former wins.
+
+---
+
+## 6. Execution model (normative)
+
+Execution is a three-level hierarchy; each level has its own state machine and illegal
+transitions MUST be rejected (`pkg/model`). Rationale: [ADR-0003](docs/adr/0003-three-level-state-hierarchy.md).
+
+```
+Submission                       one run of a workflow
+  └── StepInstance               one per step; scatter ⇒ N
+        └── Task                 concrete work unit
+```
+
+### 6.1 Submission states
+
+`PENDING → RUNNING → COMPLETED | FAILED | CANCELLED`
+
+| State | Meaning |
+|-------|---------|
+| PENDING | Accepted; StepInstances/Tasks being created. |
+| RUNNING | At least one StepInstance is active. |
+| COMPLETED | All StepInstances terminal and none failed. |
+| FAILED | A StepInstance failed with no retries remaining. |
+| CANCELLED | Cancelled by the user. |
+
+### 6.2 StepInstance states
+
+`WAITING → READY → DISPATCHED → RUNNING → COMPLETED | FAILED | SKIPPED`
+
+| State | Meaning |
+|-------|---------|
+| WAITING | Upstream dependencies not yet satisfied. |
+| READY | All inputs available; eligible for dispatch. |
+| DISPATCHED | Tasks created and submitted to executors. |
+| RUNNING | At least one Task running. |
+| COMPLETED / FAILED | All Tasks terminal, success/failure aggregated. |
+| SKIPPED | `when` evaluated false. |
+
+### 6.3 Task states
+
+`PENDING → SCHEDULED → QUEUED → RUNNING → SUCCESS | FAILED | SKIPPED`,
+with `FAILED → RETRYING → QUEUED` while retries remain.
+
+| State | Meaning |
+|-------|---------|
+| PENDING | Created; awaiting input resolution. |
+| SCHEDULED | Inputs resolved; scheduler decided it runs. |
+| QUEUED | Handed to an executor / awaiting worker checkout. |
+| RUNNING | Executing. |
+| SUCCESS / FAILED | Terminal outcome. |
+| RETRYING | Failed but eligible for retry; re-enters QUEUED. |
+| SKIPPED | Conditional skip. |
+
+> Worker-bound tasks MAY transition directly `PENDING → QUEUED`, bypassing `SCHEDULED`, so
+> they are immediately available for checkout.
+
+### 6.4 State propagation
+
+State MUST propagate upward only: Task terminality drives StepInstance advancement (§7 phase
+4), and StepInstance terminality drives Submission finalization (§7 phase 5).
+
+---
+
+## 7. Scheduler semantics (normative)
+
+The scheduler runs a periodic **tick** (default ~2 s). Each tick MUST execute the following
+phases in order; a phase that errors MUST NOT silently skip later ticks. Reference:
+`internal/scheduler/loop.go`.
+
+| Phase | Action |
+|-------|--------|
+| 1 | Advance `WAITING → READY` StepInstances whose dependencies are all met. |
+| 1.5 | (Server mode) Pre-stage workspace inputs for PENDING submissions. |
+| 2 | Dispatch `READY` StepInstances: resolve inputs, create Tasks, submit to executors. |
+| 2.5 | Re-submit `RETRYING` tasks. |
+| 3 | Poll `QUEUED`/`RUNNING` tasks on async executors for status. |
+| 3.5 | Detect stuck `QUEUED` worker tasks (progress-based) and recover them. |
+| 4 | Advance `DISPATCHED`/`RUNNING` StepInstances when all their Tasks are terminal. |
+| 5 | Finalize submissions whose StepInstances are all terminal. |
+| 5.5 | (Server mode) Post-stage outputs to the workspace for completed submissions. |
+| 6 | Transition newly `FAILED` tasks to `RETRYING` while attempts remain. |
+
+### 7.1 Dependency resolution
+
+A StepInstance MUST NOT advance out of `WAITING` until every input source it references
+(workflow inputs or upstream step outputs) is available. Resolution operates at the
+StepInstance level.
+
+### 7.2 Scatter
+
+A scatter Step MUST expand into N StepInstances according to its `scatterMethod`. Each
+StepInstance owns its own Tasks and advances independently.
+
+### 7.3 Retry
+
+On Task `FAILED`, the scheduler MUST transition it to `RETRYING` and re-queue it if and only
+if retry attempts remain per the task's retry policy; otherwise the failure propagates to the
+StepInstance and Submission.
+
+---
+
+## 8. Executor model (normative)
+
+### 8.1 Interface
+
+Every backend MUST implement `Submit`, `Status`, `Cancel`, and `Logs`
+(`internal/executor/executor.go`) and register in the registry
+(`internal/executor/registry.go`). Rationale: [ADR-0005](docs/adr/0005-pluggable-executor-registry.md).
+
+| Backend | Kind | Runs a Task by… |
+|---------|------|-----------------|
+| `local` | sync | direct host process (`os/exec`). |
+| `docker` | sync | Docker container. |
+| `apptainer` | sync | Apptainer/Singularity container (`.sif`, `--nv`, binds). |
+| `worker` | async | queuing for a remote pull-worker (§9). |
+| `bvbrc` | async | BV-BRC JSON-RPC `start_app` + `query_tasks` polling ([ADR-0007](docs/adr/0007-generic-bvbrc-executor-over-operators.md)). |
+
+### 8.2 Selection order (first match wins)
+
+The scheduler MUST select a Task's backend in this order:
+
+1. Server `--default-executor`, if set — overrides all hints.
+2. `gowe:Execution.executor` (`worker` | `bvbrc` | `local`).
+3. `gowe:Execution.bvbrc_app_id` present ⇒ `bvbrc`.
+4. `DockerRequirement` or `gowe:Execution.docker_image` present ⇒ `worker` when workers are
+   online, else `local`.
+5. Default ⇒ `local`.
+
+### 8.3 Container image resolution
+
+Both `docker` and `apptainer` backends consume a single image string (from
+`gowe:Execution.docker_image` or `DockerRequirement.dockerPull`), resolved per §5.3. The
+field name `docker_image` is historical; it governs whichever container runtime executes the
+task.
+
+---
+
+## 9. Worker protocol (normative)
+
+Workers **pull**; the server MUST NOT push work. Rationale: [ADR-0004](docs/adr/0004-pull-based-worker-model.md).
+Workers authenticate with the `X-Worker-Key` header.
+
+### 9.1 Lifecycle
+
+1. **Register** — `POST /api/v1/workers` advertising capabilities: container runtime
+   (`docker`/`apptainer`/`none`), worker group, GPU, and available dataset ids.
+2. **Poll** — `GET /api/v1/workers/{id}/work` (default ~5 s). Returns the next matching Task,
+   or HTTP 204 if none.
+3. **Execute** — via `internal/toolexec`: stage inputs, launch the container/process, apply
+   mounts, GPU, and injected secrets.
+4. **Report** — `PUT /api/v1/workers/{id}/tasks/{tid}/status` for progress, then
+   `PUT …/tasks/{tid}/complete` with the result.
+5. **Heartbeat** — `PUT /api/v1/workers/{id}/heartbeat` periodically.
+6. **Deregister** — `DELETE /api/v1/workers/{id}`.
+
+### 9.2 Checkout matching
+
+The server MUST claim a Task atomically (`store.CheckoutTask`) such that at most one worker
+receives it. A Task is eligible for a worker only if:
+
+- the worker's container runtime satisfies the Task's requirement; **and**
+- the worker's group matches the Task's `worker_group` (step-level overrides the
+  submission-level `--group` fallback); **and**
+- dataset affinity is satisfied: every `prestage` dataset id is advertised by the worker;
+  `cache` dataset matches are preferred but not required.
+
+### 9.3 Liveness and recovery
+
+The scheduler MUST treat a worker as dead after missed heartbeats and MUST return its
+in-flight and stuck `QUEUED` tasks for re-dispatch (§7 phase 3.5). Secrets injected into a
+task MUST NOT be transmitted to the server.
+
+---
+
+## 10. Inputs & storage (normative)
+
+This section consolidates how a run's **inputs** are supplied and how **File/Directory data**
+is moved in and out across the supported storage backends. Rationale:
+[ADR-0008](docs/adr/0008-dataset-affinity-and-staging-modes.md). Operational detail lives in
+[`docs/Execution-Modes.md`](docs/Execution-Modes.md) and [`docs/tools/worker.md`](docs/tools/worker.md).
+
+### 10.1 Job inputs
+
+A **Submission** is a workflow plus a set of concrete input values (the *job*). Inputs are
+supplied at submit time, not configured as a backend:
+
+- **CLI** — `gowe submit <workflow> --inputs <file>`, where the file is a YAML/JSON job
+  document. Relative `File`/`Directory` paths MUST be resolved against the job file's own
+  directory before submission (`internal/cli/submit.go`, `bundle.ResolveFilePaths`).
+- **API** — `POST /api/v1/submissions` with the input values in the request body.
+
+Each `File`/`Directory` input carries a `location`; its URI scheme selects the storage
+backend in §10.2. A location with no scheme (or `file://`) is a local/shared-filesystem path.
+
+### 10.2 Storage backends
+
+Staging is a pluggable backend (`pkg/staging`) selected by the `location` URI scheme via the
+`Stager` interface (`pkg/staging/staging.go`, `ParseLocation`); `composite.go` dispatches by
+scheme. Each backend handles both stage-in (inputs) and stage-out (outputs).
+
+| Scheme | Backend file | Behavior | Status |
+|--------|--------------|----------|--------|
+| `local` / *(none)* | `file.go` | in place, no copy (`cwl-runner` default) | supported |
+| `file://` | `shared.go` | copy to a shared filesystem path (distributed workers) | supported |
+| `http(s)://` | *(http stager)* | HTTP PUT/POST upload, custom headers/auth/retry | defined |
+| `shock://` | `shock.go` | Shock data service (`shock://host/node/{id}`) | defined |
+| `ws://` | `workspace.go` | BV-BRC Workspace service (default for BV-BRC runs) | defined |
+| `s3://` | `s3.go` | S3-compatible object storage | planned |
+
+Backends marked *defined*/*planned* are implemented to varying degrees but not fully covered
+by the conformance suite; see the test matrix in [`docs/Execution-Modes.md`](docs/Execution-Modes.md).
+Staging supports **copy**, **symlink**, and **reference** modes.
+
+> **`ws://` (BV-BRC Workspace)** is *defined* — implemented end to end (submission, output
+> mapping, the stager, and server-side pre/post-staging) but not CI-verified, since it requires
+> a live BV-BRC service and a real user token. See
+> [`docs/BVBRC-Workspace-Deep-Dive.md`](docs/BVBRC-Workspace-Deep-Dive.md) for the full
+> submission/result round-trip and the specific gaps (wildcard-glob resolution, large-file
+> streaming, recursive directory download).
+
+### 10.3 Server-side staging and upload proxy
+
+When the server stages on behalf of a run (`cmd/server`):
+
+- `--workspace-staging server` with `--workspace-url <url>` — pre-stage `ws://` inputs and
+  post-stage outputs to a BV-BRC Workspace on the server (§7 phases 1.5 / 5.5). Empty =
+  passthrough to workers.
+- `--upload-backend shock|s3|local` selects the file-upload proxy backend, configured by:
+  - Shock — `--upload-shock-host`, `--upload-shock-http`, `--upload-shock-token`.
+  - S3 — `--upload-s3-endpoint`, `--upload-s3-region`, `--upload-s3-bucket`, `--upload-s3-prefix`,
+    `--upload-s3-access-key`, `--upload-s3-secret-key`, `--upload-s3-path-style`, `--upload-s3-disable-ssl`.
+  - Local — `--upload-local-dir`; `--upload-download-dirs` allow-lists download roots.
+
+### 10.4 Worker-side stage-in
+
+Workers resolve and stage a task's inputs before execution using their configured stagers
+(`internal/worker/stager_config.go`, `stagein.go`), then stage outputs back to the run's
+target scheme. `--extra-bind` injects arbitrary host paths into containers for plumbing and
+MUST NOT influence scheduling (only `gowe:ResourceData` does).
+
+### 10.5 Reference data (large read-only inputs)
+
+Large, pre-positioned datasets (databases, model weights) are **not** carried as `File`
+inputs. They are declared with the `gowe:ResourceData` hint (§5.2) and matched to workers by
+affinity (§9.2): `prestage` requires a worker advertising the dataset, `cache` prefers one.
+Workers advertise datasets via `--pre-stage-dir` or `--dataset id=path`.
+
+---
+
+## 11. Persistence (normative)
+
+State MUST be persisted to SQLite via `modernc.org/sqlite` (pure Go, no CGO), with
+`max_open_conns = 1` (single writer), WAL mode, and foreign keys enforced. Rationale:
+[ADR-0006](docs/adr/0006-sqlite-single-writer-persistence.md). Core tables: `workflows`
+(deduped by content hash), `submissions`, `step_instances`, `tasks`, `workers`, plus `users`,
+`sessions`, and label vocabulary. Schema migrations MUST be idempotent
+(`addColumnIfNotExists`; `internal/store/migrations.go`). Task checkout MUST be a single
+atomic statement backed by the `(state, executor_type)` index.
+
+---
+
+## 12. HTTP API (normative surface)
+
+All endpoints live under `/api/v1`. Responses use the envelope
+`{ status, request_id, timestamp, data }`. Auth: user endpoints via the API auth
+middleware; worker endpoints via `X-Worker-Key`; admin endpoints require the admin role.
+
+| Group | Representative endpoints |
+|-------|--------------------------|
+| Health | `GET /health` |
+| Workflows | `GET/POST /workflows`, `GET/PUT/DELETE /workflows/{id}`, `GET …/inputs`, `GET …/outputs`, `POST …/validate` |
+| Submissions | `GET/POST /submissions`, `GET /submissions/{id}`, `PUT …/cancel`, `PUT …/retry`, `GET …/tasks`, `GET …/tasks/{tid}/logs` |
+| Workers | `POST /workers`, `GET /workers`, `GET /workers/{id}/work`, `PUT /workers/{id}/heartbeat`, `PUT …/tasks/{tid}/status`, `PUT …/tasks/{tid}/complete`, `DELETE /workers/{id}` |
+| BV-BRC proxy | `GET /apps`, `GET /apps/{id}`, `GET /apps/{id}/cwl-tool`, `GET /workspace`, file up/download |
+| Streaming | `GET /sse/submissions/{id}` (server-sent events) |
+| Admin | `GET /admin/tasks/active`, `PUT /admin/tasks/{tid}/priority`, user/role and label management |
+
+The full route table is defined in `internal/server/`.
+
+---
+
+## 13. Security (normative)
+
+GoWe separates credentials into four planes and holds them together with one invariant:
+**execution secrets MUST NOT travel back to the server** (§13.2). Identity is delegated to
+external providers — GoWe stores no user passwords.
+
+### 13.1 Credential planes
+
+| Plane | Boundary | Carrier | Rule |
+|-------|----------|---------|------|
+| **User / API token** | client → server | `Authorization` (BV-BRC) or `X-MG-RAST-Token` (MG-RAST) header | Verified per request (§13.3). |
+| **Worker key** | worker → server | `X-Worker-Key` header | Authenticates and scopes a worker to groups (§13.3). |
+| **Worker secrets** | worker-local | `--secret`, `--secret-file` | Injected into the container env on the worker only; MUST NOT reach the server (§13.5). |
+| **Delegated BV-BRC token** | server → container | task `RuntimeHints` → `BVBRC_TOKEN` env | The submitter's own token, injected only when opted in (§13.5). |
+
+### 13.2 Trust boundary invariant
+
+- Credentials MUST NOT appear in workflow or tool definitions — they are inert data (§3).
+- Worker secrets and any token injected into a task's container environment MUST NOT be
+  transmitted to, logged by, or persisted by the server. The worker→server return path
+  carries task status and results only.
+- A worker MUST treat injected secrets as process-local: held in memory, written only into
+  the container environment at execution time, never echoed to the server or to logs.
+
+### 13.3 Authentication schemes
+
+| Scheme | Presented as | The server verifies | Applies to |
+|--------|--------------|---------------------|------------|
+| User token | `Authorization: Bearer <token>` or `X-MG-RAST-Token` | Provider-issued pipe-delimited token: non-empty username and unexpired `expiry` | User/API endpoints |
+| Anonymous | *(no token)* + server `--allow-anonymous` | Nothing; request runs as the anonymous user | User/API endpoints, if enabled |
+| Worker key | `X-Worker-Key` | Key present in the configured key set; yields allowed groups | Worker endpoints |
+
+- When a token is presented, the server MUST reject it if the username is empty or the token
+  is expired (`401`).
+- On first valid use of a provider token, the server MUST look up or create the corresponding
+  user account keyed by `(username, provider)`.
+- When no user keys/tokens apply and anonymous access is disabled, protected endpoints MUST
+  return `401`.
+- Worker-key enforcement is **optional**: if no keys are configured, worker endpoints are
+  open. Operators SHOULD configure keys in any multi-tenant or networked deployment.
+
+### 13.4 Authorization and roles
+
+- Roles are `user`, `admin`, and `anonymous` (`pkg/model`).
+- Admin membership is resolved from (highest priority first) the stored user role, the
+  `--admins` flag, the `GOWE_ADMINS` env var, and the config file. A user matching admin
+  config MUST be promoted on authentication.
+- `/api/v1/admin/*` endpoints MUST require the `admin` role (`403` otherwise).
+- Anonymous submissions MUST be restricted to the executors allowed by
+  `--anonymous-executors` (default `local,docker,worker`).
+
+### 13.5 Secrets and token handling
+
+- Worker secrets are loaded from `--secret`/`--secret-file` into worker memory. Secret
+  **names** MAY be logged; secret **values** MUST NOT be logged.
+- The `X-Worker-Key` MUST NOT be logged in the clear; only a hash of it MAY be logged.
+- A BV-BRC token MAY be injected into a task's container as `BVBRC_TOKEN` when, and only when,
+  `gowe:Execution.inject_bvbrc_token` is set (or a workspace stager requires it); the injected
+  token is the submitter's own, so the job runs under the user's identity.
+- Response bodies MUST NOT expose stored tokens: submission token fields are serialized with
+  `json:"-"`.
+
+### 13.6 Transport security
+
+- Worker→server transport MAY be TLS; workers support a custom CA (`--ca-cert`) and, for
+  testing only, `--insecure` to skip verification. `--insecure` MUST NOT be used in
+  production.
+- The server does not currently terminate TLS itself (see §13.7); production deployments
+  SHOULD run it behind a TLS-terminating proxy.
+
+### 13.7 Known limitations (informative)
+
+These are current-state gaps, not normative requirements. They are documented so operators
+can compensate and so the project can track hardening. Each SHOULD be addressed before a
+security-sensitive production deployment:
+
+- **Tokens at rest are plaintext.** The submitter's BV-BRC token is persisted unencrypted in
+  `submissions.user_token` (SQLite). Protect the database file accordingly.
+- **Worker keys are shared secrets.** Keys are stored plaintext in config/env with no
+  per-worker identity or rotation; a leaked key affects every worker sharing it.
+- **Server TLS is not enforced.** Cookie `Secure` is hardcoded off (a standing TODO) and the
+  server serves plain HTTP; front it with a TLS terminator.
+- **Anonymous mode widens exposure.** If `--allow-anonymous` is enabled, always scope it with
+  `--anonymous-executors`.
+
+---
+
+## 14. Entry points
+
+| Binary | Role |
+|--------|------|
+| `gowe` (`cmd/cli`) | User CLI: submit and inspect workflows via the API. |
+| `gowe-server` (`cmd/server`) | Control plane: HTTP API + scheduler + store. |
+| `gowe-worker` (`cmd/worker`) | Remote pull-worker daemon. |
+| `cwl-runner` (`cmd/cwl-runner`) | Standalone, serverless CWL runner (conformance/local). |
+
+---
+
+## 15. Versioning of this specification
+
+This specification is versioned independently of the software. A change that alters required
+behavior MUST bump the version line at the top and SHOULD be accompanied by a new or updated
+ADR. The specification describes the intended contract; divergence in code is a defect to
+reconcile against this document or a prompt to amend it.

--- a/docs/BVBRC-Workspace-Deep-Dive.md
+++ b/docs/BVBRC-Workspace-Deep-Dive.md
@@ -4,6 +4,10 @@
 > **Scope**: How a workflow step is submitted to BV-BRC, how results return, how the BV-BRC
 > Workspace (`ws://`) is used, and precisely why `ws://` is labelled **defined** rather than
 > **supported** in [`SPECIFICATION.md`](../SPECIFICATION.md) §10 and [`Execution-Modes.md`](Execution-Modes.md).
+>
+> **Note on code references**: `file.go:NNN` line numbers below are a snapshot taken against
+> `main` at authoring time and will drift as the code changes. Treat the enclosing
+> **function/symbol name** as the durable reference and the line number as a hint.
 
 ## TL;DR
 

--- a/docs/BVBRC-Workspace-Deep-Dive.md
+++ b/docs/BVBRC-Workspace-Deep-Dive.md
@@ -1,0 +1,167 @@
+# BV-BRC Submission & Workspace Deep Dive
+
+> **Status**: Reference · **Date**: 2026-07-06
+> **Scope**: How a workflow step is submitted to BV-BRC, how results return, how the BV-BRC
+> Workspace (`ws://`) is used, and precisely why `ws://` is labelled **defined** rather than
+> **supported** in [`SPECIFICATION.md`](../SPECIFICATION.md) §10 and [`Execution-Modes.md`](Execution-Modes.md).
+
+## TL;DR
+
+The BV-BRC + `ws://` path is **implemented end to end** — submission, status polling, output
+mapping, logs, cancel, the workspace stager, and server-side pre/post-staging are all present
+with no stubs or TODOs. It is labelled **defined** (not **supported**) because it is **not
+verified by the automated conformance suite** — it requires a live BV-BRC service and a real
+user token, which CI does not have — and because it carries a few functional edges that only
+surface against real infrastructure (§5).
+
+"Supported" in the storage taxonomy means *green in the conformance matrix on every commit*
+(`local`, `file://`). "Defined" means *implemented but not CI-verified*.
+
+---
+
+## 1. Submission path
+
+Routing selects the `bvbrc` executor when a step carries `gowe:Execution.executor: bvbrc` or a
+`bvbrc_app_id` (see `SPECIFICATION.md` §8.2 and [ADR-0007](adr/0007-generic-bvbrc-executor-over-operators.md)).
+`Submit()` in [`internal/executor/bvbrc.go`](../internal/executor/bvbrc.go) then:
+
+1. **Resolves the app id** — `task.BVBRCAppID`, falling back to the legacy `_bvbrc_app_id`
+   input (`bvbrc.go:96–104`).
+2. **Chooses the caller / identity** — `getTaskCaller` (`bvbrc.go:60–85`) builds a per-task RPC
+   caller from the submitter's own token (`RuntimeHints.StagerOverrides.HTTPCredential.Token`),
+   falling back to a default server caller. This is the delegated identity of
+   [ADR-0009](adr/0009-delegated-identity-and-optional-worker-keys.md): **the job runs as the
+   user**.
+3. **Flattens inputs to workspace paths** — `resolveBVBRCInput` (`bvbrc.go:513–540`) walks the
+   CWL inputs and converts every `File`/`Directory` object to a plain workspace path string,
+   recursing into record parameters (e.g. `paired_end_libs`). BV-BRC's Perl apps expect
+   `/user@bvbrc/home/...` strings, **not** CWL objects — passing a raw object yields
+   *"File HASH(0x...) does not exist"*.
+4. **Submits asynchronously** — `AppService.start_app([appID, params, workspacePath])`
+   (`bvbrc.go:143`) returns a **job UUID immediately** (`bvbrc.go:159–174`); the job runs on
+   BV-BRC while GoWe polls.
+
+> **Not called at submit time:** `query_app_description` / `enumerate_apps` exist in the client
+> ([`pkg/bvbrc/appservice.go`](../pkg/bvbrc/appservice.go)) but `Submit()` does not invoke them.
+> Parameters are trusted from the CWL tool, so a schema mismatch fails at BV-BRC rather than in a
+> pre-flight validation step. ADR-0007 describes dynamic schema fetching as the intended design;
+> the submit path does not yet exercise it.
+
+---
+
+## 2. Result return
+
+Async executors are polled each scheduler tick (`SPECIFICATION.md` §7 phase 3). `Status()`
+(`bvbrc.go:177–246`):
+
+1. Calls `AppService.query_tasks([externalID])` (`bvbrc.go:193`) → `status`, `output_files`
+   (`[[ws_path, uuid], …]`), and `parameters`.
+2. `mapBVBRCState` (`bvbrc.go:568–581`): `completed → SUCCESS`,
+   `failed`/`deleted`/`suspended` → `FAILED`, `in-progress → RUNNING`, `queued → QUEUED`.
+3. On success, `buildOutputs` (`bvbrc.go:250–289`) constructs a `result_folder` **`Directory`**
+   at `ws://{output_path}/.{output_file}` plus **`File`** objects with `ws://` locations,
+   matched to declared CWL output ids by glob. If `output_files` is empty,
+   `buildOutputsFromGlobs` (`bvbrc.go:292–327`) reconstructs outputs from the tool's glob
+   patterns.
+4. **Logs**: `query_task_details` → stdout/stderr URLs, fetched over HTTP with
+   `Authorization: OAuth <token>` (`bvbrc.go:448–511`). **Cancel**: `kill_task`
+   (`bvbrc.go:429–445`).
+
+A completed BV-BRC job thus becomes CWL outputs whose bytes live **in the workspace**,
+referenced by `ws://` URIs — not copied anywhere by default.
+
+---
+
+## 3. How the Workspace is used
+
+The BV-BRC Workspace plays two distinct roles, and the distinction is the heart of the label.
+
+### Role A — the Workspace *is* the storage (pure BV-BRC)
+
+For an all-BV-BRC workflow, apps read inputs from workspace paths and write outputs back to
+workspace paths. GoWe threads `ws://` path strings in (§1 step 3) and receives `ws://`
+references back (§2 step 3). **GoWe never moves the bytes**, and the `ws://` *stager* is not
+even invoked. This is the simplest path and the most likely to work unmodified.
+
+### Role B — the stager crosses the boundary (hybrid workflows)
+
+When BV-BRC data must meet a `local` / `worker` / container step, the stager in
+[`pkg/staging/workspace.go`](../pkg/staging/workspace.go) moves the bytes, driven by the
+server-side staging phases in [`internal/scheduler/workspace.go`](../internal/scheduler/workspace.go):
+
+- **Phase 1.5 pre-stage** — `prestageWorkspaceInputs` (`scheduler/workspace.go:31–102`)
+  downloads `ws://` inputs to local `file://` (via `WorkspaceGetDownloadURL` + HTTP GET with
+  OAuth) and rewrites the input locations so a container step can read them.
+- **Phase 5.5 post-stage** — `poststageWorkspaceOutputs` (`scheduler/workspace.go:106–198`)
+  uploads local `file://` outputs back to `ws://` (via `ensureDir` + `WorkspaceUpload`) and
+  writes a `_gowe_outputs.json` manifest.
+
+Enabled with `--workspace-staging server --workspace-url <url>` (`cmd/server/main.go:41–42`).
+
+The stager itself is complete — `StageIn` (`workspace.go:83`), `StageOut` (`workspace.go:125`),
+`UploadContent` (`workspace.go:248`), `ensureDir` (`workspace.go:304`), and token resolution
+(`workspace.go:345`) — with retries and no stubs.
+
+### Client surface
+
+[`pkg/bvbrc/workspace.go`](../pkg/bvbrc/workspace.go) implements `WorkspaceLs`, `Get`,
+`Create`, `CreateFolder`, `Upload`, `Delete`, `Copy`, `Move`, `SetPermissions`,
+`ListPermissions`, and `GetDownloadURL`. [`pkg/bvbrc/appservice.go`](../pkg/bvbrc/appservice.go)
+implements `enumerate_apps`, `query_app_description`, `start_app`, `query_tasks`,
+`query_task_details`, `kill_task`, `query_app_log`, and more.
+
+---
+
+## 4. Verification status
+
+| Check | State | Evidence |
+|-------|-------|----------|
+| Conformance suite covers `server-bvbrc` / `ws://` | **No** (❌) | [`Execution-Modes.md`](Execution-Modes.md) matrix, line 72 |
+| BV-BRC integration test exists | Yes, but gated | [`internal/executor/bvbrc_integration_test.go`](../internal/executor/bvbrc_integration_test.go) — `//go:build integration`, `skipIfNoBVBRC` skips without a live `BVBRC_TOKEN` |
+| Workspace stager tests hit a real service | **No** | `pkg/staging/workspace_test.go` is unit-only (URI parsing, token priority) |
+| Scheduler test exercises phase 1.5 / 5.5 | **No** | `internal/scheduler/integration_test.go` uses the local executor and never sets a workspace stager |
+
+**Why it cannot run green in CI:** the path needs a live BV-BRC App Service **and** Workspace,
+a valid non-expired user token, and a writable shared workspace — none of which exist in CI. So
+the matrix cell cannot be marked ✅ regardless of code quality.
+
+To exercise it manually:
+
+```bash
+export BVBRC_TOKEN="un=...|tokenid=...|expiry=...|..."
+go test -tags=integration -v ./internal/executor/ -run TestBVBRCIntegration
+```
+
+---
+
+## 5. Functional edges (what "defined" is honestly signalling)
+
+Beyond the verification gap, these edges only surface against real infrastructure:
+
+| Edge | Detail | Location |
+|------|--------|----------|
+| **Wildcard globs unresolved (fallback)** | When an app does not populate `output_files` **and** an output is a wildcard (`*.fasta`), the glob fallback deliberately skips it — resolving it would require a `WorkspaceLs` of the result folder, which the fallback does not do. The primary `output_files` path is unaffected. | `bvbrc.go:316` |
+| **Whole-file-in-memory staging** | `StageOut` does `os.ReadFile` and uploads the entire content as a string — memory-bound for multi-GB genomics files. | `workspace.go:156` |
+| **No recursive directory download** | `StageIn` is single-file; a `ws://` `Directory` output that a local step needs is not recursively listed and downloaded. | `workspace.go:83` |
+| **No submit-time schema validation** | `query_app_description` exists but is not called; bad params fail at BV-BRC, not pre-flight. | `bvbrc.go:95` |
+
+**The use case that is not proven:** a **hybrid** run that pulls `ws://` inputs down, executes
+locally / in a container, and pushes outputs back to the Workspace — verified automatically.
+The pure Role-A path (BV-BRC → BV-BRC) is most likely fine; the Role-B boundary-crossing path
+with large files, wildcard outputs, or directory outputs is exactly where the untested edges
+live.
+
+**Bottom line:** the code is all there. What is missing is automated proof and a handful of
+edge-case behaviours under real load. That is the difference between **defined** and
+**supported**.
+
+---
+
+## Related
+
+- [`SPECIFICATION.md`](../SPECIFICATION.md) §8 (executors), §10 (inputs & storage), §7 (scheduler phases)
+- [ADR-0007](adr/0007-generic-bvbrc-executor-over-operators.md) — generic BV-BRC executor
+- [ADR-0009](adr/0009-delegated-identity-and-optional-worker-keys.md) — delegated identity
+- [`Execution-Modes.md`](Execution-Modes.md) — the test matrix and status legend
+- [`BVBRC-App-Output-Convention.md`](BVBRC-App-Output-Convention.md) — the `.<output_file>` result-folder convention
+- [`BVBRC-API.md`](BVBRC-API.md) — the JSON-RPC surface

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,38 @@
+# NNNN. <Short decision title, imperative mood>
+
+- **Status**: Proposed | Accepted | Superseded by [ADR-XXXX](XXXX-....md) | Deprecated
+- **Date**: YYYY-MM-DD
+- **Deciders**: <who>
+- **Related**: <ADRs, issues, docs>
+
+## Context
+
+What is the problem, the forces at play, and the constraints? State the facts, not the
+decision. Include what makes this hard or contested — the reasons a reasonable engineer
+might choose differently. Link to the relevant code or documents.
+
+## Decision
+
+The choice, stated in one or two sentences using an active voice: "We will …".
+Then the specifics: what exactly is built, and the rules that follow from it (use MUST /
+SHOULD / MAY where they carry normative weight).
+
+## Consequences
+
+**Positive**
+- What gets easier or safer.
+
+**Negative**
+- What we give up or now have to carry.
+
+**Neutral**
+- Follow-on facts that are neither win nor loss.
+
+## Alternatives considered
+
+- **<Option>** — why it was not chosen.
+
+## References
+
+- Code: `path/to/file.go`
+- Docs: `docs/....md`

--- a/docs/adr/0001-adopt-cwl-v1.2-as-workflow-definition-format.md
+++ b/docs/adr/0001-adopt-cwl-v1.2-as-workflow-definition-format.md
@@ -1,0 +1,59 @@
+# 0001. Adopt CWL v1.2 as the workflow definition format
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-09
+- **Deciders**: GoWe core
+- **Related**: ADR-0002 (hint extensions), ADR-0007 (BV-BRC executor); [`GoWe-Vocabulary.md`](../GoWe-Vocabulary.md) Part 1
+
+## Context
+
+GoWe needs a format for users to describe multi-step scientific computations as a DAG,
+targeting BV-BRC apps, containers, and local tools. The realistic options were: invent a
+GoWe-native DSL, reuse an existing workflow language (CWL, WDL, Nextflow, Snakemake), or
+model workflows only through an API. The target audience is bioinformaticians, many of
+whom already write CWL, and a hard requirement is that workflow definitions be *data* —
+parseable and validatable without executing user code.
+
+CWL v1.2 fits well: declarative YAML/JSON, data-flow DAG, a real type system for
+inputs/outputs, `DockerRequirement` and `ResourceRequirement`, scatter/gather, and
+conditional (`when`) execution. It is vendor-neutral with existing parsers, validators,
+and a conformance suite. Its gaps for GoWe are that it describes *command-line tools*, not
+*service calls*, has no concept of remote job polling, and assumes local file paths.
+
+## Decision
+
+We will use **CWL v1.2 as GoWe's sole workflow and tool definition format**. A workflow is
+a `class: Workflow` document; a tool is a `class: CommandLineTool` or
+`class: ExpressionTool`. GoWe MUST parse and validate against the CWL v1.2 profile it
+supports (see `SPECIFICATION.md`) and MUST track upstream CWL conformance. GoWe's own
+concerns — routing, polling, workspace mapping — are kept out of the definition and layered
+in via hints (ADR-0002) and the executor/scheduler layers.
+
+## Consequences
+
+**Positive**
+- Workflows validate and run locally under `cwltool` before being submitted to GoWe.
+- We inherit an existing type system, test suite (378 conformance tests), and user base.
+- Definitions carry no execution logic, scheduling, or credentials — clean separation.
+
+**Negative**
+- We must implement a substantial CWL executor (bindings, globbing, JS expressions, IWDR,
+  secondary files) and keep pace with the spec — a large, ongoing surface.
+- CWL's command-line assumption forces workarounds for service-style backends (BV-BRC).
+
+**Neutral**
+- Conformance to CWL becomes a first-class, measured obligation (`CONFORMANCE.md`).
+
+## Alternatives considered
+
+- **A GoWe-native DSL** — full control, but no ecosystem, no existing validators, and a new
+  language for users to learn. Rejected.
+- **WDL / Nextflow / Snakemake** — capable, but less aligned with BV-BRC's container model
+  and weaker fit for "definition as inert data validated ahead of run." Rejected.
+- **API-only workflow construction** — no portable, inspectable artifact; workflows could
+  not be tested outside GoWe. Rejected.
+
+## References
+
+- Docs: [`GoWe-Vocabulary.md`](../GoWe-Vocabulary.md), [`CWL-Specs.md`](../CWL-Specs.md), [`../../CONFORMANCE.md`](../../CONFORMANCE.md)
+- Code: `internal/parser/`, `internal/cwltool/`, `internal/cwlexpr/`, `pkg/cwl/`

--- a/docs/adr/0002-extend-cwl-via-namespaced-hints.md
+++ b/docs/adr/0002-extend-cwl-via-namespaced-hints.md
@@ -1,0 +1,66 @@
+# 0002. Extend CWL via namespaced hints, not a sidecar config
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-09
+- **Deciders**: GoWe core
+- **Related**: ADR-0001 (CWL adoption), ADR-0005 (executor selection), ADR-0008 (dataset affinity); [`cwl-hints.md`](../cwl-hints.md)
+
+## Context
+
+CWL describes *what* to compute but deliberately says nothing about *where* or *how* to
+place work. GoWe needs per-step routing metadata: which executor to use, which worker group
+to target, which BV-BRC app backs a tool, which container image to substitute, and which
+large datasets a step depends on. This metadata has to travel with the workflow (a separate
+sidecar file drifts out of sync and breaks portability), yet it must not break other CWL
+engines or make definitions non-portable.
+
+CWL offers two extension surfaces. `requirements` are mandatory — an engine MUST support
+them or reject the document. `hints` are advisory — an engine SHOULD support them but MAY
+ignore unknown ones. CWL also supports `$namespaces` so custom fields can be prefixed and
+unambiguous.
+
+## Decision
+
+We will express all GoWe-specific extensions as **namespaced hints** under
+`$namespaces: { gowe: https://github.com/wilke/GoWe# }`, placed in `hints` (not
+`requirements`). Two hint objects are defined:
+
+- `gowe:Execution` — executor routing: `executor`, `worker_group`, `bvbrc_app_id`,
+  `docker_image`, `gpu`, `inject_bvbrc_token`. **Recognized only in `hints`.**
+- `gowe:ResourceData` — dataset affinity (see ADR-0008). Accepted in `hints` or
+  `requirements`.
+
+Because they are namespaced hints, other engines (cwltool, Toil) MUST be able to ignore
+them safely, keeping the workflow portable. The parser also accepts a legacy `goweHint`
+alias for backward compatibility; new files SHOULD use `gowe:Execution`.
+
+## Consequences
+
+**Positive**
+- Routing metadata lives with the workflow, versioned alongside it — no sidecar drift.
+- Workflows stay runnable under stock CWL engines, which skip unknown hints.
+- The extension points are explicit and centralized in one parser path.
+
+**Negative**
+- Hints are advisory by CWL's own semantics, so a workflow that *depends* on GoWe routing
+  behaves differently (though validly) on another engine — a portability caveat users must
+  understand.
+- Namespaced YAML keys are more verbose than a bespoke config block.
+
+**Neutral**
+- `gowe:Execution` being hints-only (never `requirements`) is a deliberate asymmetry with
+  `gowe:ResourceData`; documented in the hints reference.
+
+## Alternatives considered
+
+- **A sidecar `gowe.yaml`** — cleaner CWL, but two files to keep in sync and no single
+  portable artifact. Rejected.
+- **Put extensions in `requirements`** — would make GoWe workflows fail hard on other
+  engines, defeating portability. Rejected.
+- **Server-side routing config keyed by step name** — decouples routing from the workflow
+  but hides intent from the author and breaks when steps are renamed. Rejected.
+
+## References
+
+- Docs: [`cwl-hints.md`](../cwl-hints.md)
+- Code: `internal/parser/parser.go` (`extractStepHints`, `gowe:Execution` / `gowe:ResourceData`), `pkg/model/workflow.go` (`StepHints`)

--- a/docs/adr/0003-three-level-state-hierarchy.md
+++ b/docs/adr/0003-three-level-state-hierarchy.md
@@ -1,0 +1,62 @@
+# 0003. Model execution as a three-level state hierarchy
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-18
+- **Deciders**: GoWe core
+- **Related**: ADR-0004 (workers), ADR-0005 (executors); [`GoWe-Vocabulary.md`](../GoWe-Vocabulary.md) Parts 2–3
+
+## Context
+
+A run has to track state at several granularities at once. A user submits one workflow and
+wants a single answer ("did my run succeed?"). But a scatter step fans out into many
+parallel units, each of which can independently succeed, fail, or be retried, and each unit
+may map to more than one concrete execution attempt. Collapsing all of this into one flat
+list of "tasks" loses the step boundary (needed for dependency resolution and `when`
+skipping) and the run boundary (needed for finalization); collapsing it into two levels
+forces scatter fan-out and retry to share a state machine, which muddies both.
+
+## Decision
+
+We will model execution as **three nested entities, each with its own state machine**:
+
+- **Submission** — one run of a workflow. `PENDING → RUNNING → COMPLETED | FAILED | CANCELLED`.
+- **StepInstance** — one instance of a step within a submission; a scatter step produces **N**
+  instances. `WAITING → READY → DISPATCHED → RUNNING → COMPLETED | FAILED | SKIPPED`.
+- **Task** — the concrete unit of work handed to an executor.
+  `PENDING → SCHEDULED → QUEUED → RUNNING → SUCCESS | FAILED | SKIPPED`, with
+  `FAILED → RETRYING → QUEUED` for retries.
+
+State flows strictly upward: Task terminality drives StepInstance advancement, and
+StepInstance terminality drives Submission finalization. Each entity's valid transitions
+are enforced in `pkg/model` (`state.go`, `step_instance.go`, `task.go`); illegal
+transitions MUST be rejected.
+
+## Consequences
+
+**Positive**
+- Scatter is expressed cleanly: N StepInstances, each owning its Tasks — no special-casing.
+- Dependency resolution and `when`-skipping operate at the StepInstance level, where the
+  DAG edges actually live.
+- Retries live at the Task level and don't perturb step- or run-level state.
+
+**Negative**
+- Three state machines and their cross-level transition rules are more to implement, test,
+  and keep consistent than a flat model.
+- Aggregating Task/StepInstance state up to a correct Submission verdict is non-trivial
+  (e.g. "all instances terminal, any failed with no retries ⇒ FAILED").
+
+**Neutral**
+- Terminology is fixed and normative (Submission / StepInstance / Task); "job", "run", and
+  "pipeline" are disambiguated in the vocabulary.
+
+## Alternatives considered
+
+- **Flat Task list per submission** — simplest, but no home for the step boundary or scatter
+  grouping; dependency and conditional logic become fragile. Rejected.
+- **Two levels (Submission + Task)** — forces scatter fan-out and retry attempts to share
+  one state machine. Rejected in favor of an explicit StepInstance layer.
+
+## References
+
+- Code: `pkg/model/state.go`, `pkg/model/submission.go`, `pkg/model/step_instance.go`, `pkg/model/task.go`
+- Docs: [`GoWe-Vocabulary.md`](../GoWe-Vocabulary.md)

--- a/docs/adr/0004-pull-based-worker-model.md
+++ b/docs/adr/0004-pull-based-worker-model.md
@@ -1,0 +1,61 @@
+# 0004. Distribute work with a pull-based worker model
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-18
+- **Deciders**: GoWe core
+- **Related**: ADR-0005 (executor registry), ADR-0006 (store), ADR-0008 (dataset affinity); [`Remote-Worker-Analysis.md`](../Remote-Worker-Analysis.md)
+
+## Context
+
+GoWe runs work on remote machines that the server does not control and often cannot reach:
+HPC login/compute nodes, GPU boxes behind NAT or firewalls, lab workstations. Those hosts
+have heterogeneous capabilities (Docker vs Apptainer vs none, GPUs, pre-staged multi-TB
+datasets). A push model requires the server to open connections *to* each worker, hold a
+registry of reachable addresses, and know each worker's live capacity — all of which break
+down when workers are unaddressable or come and go.
+
+## Decision
+
+We will use a **pull model: workers poll the server for work; the server never pushes**.
+A worker registers, then loops:
+
+1. `GET /api/v1/workers/{id}/work` — request the next matching task (HTTP 204 = none).
+2. Execute via `internal/toolexec` (mounts, GPU, injected secrets that MUST NOT be sent to
+   the server).
+3. `PUT …/tasks/{tid}/status` then `PUT …/tasks/{tid}/complete` — report progress and result.
+4. `PUT /api/v1/workers/{id}/heartbeat` — periodic liveness.
+
+Task claiming is a server-side atomic checkout (`store.CheckoutTask`) that matches on
+container-runtime capability, worker group, and dataset affinity (ADR-0008) and flips the
+task to `RUNNING` for exactly one worker. Workers authenticate with an `X-Worker-Key`.
+The scheduler MUST detect stalled claims (missed heartbeats, zero-progress `QUEUED` tasks)
+and return them for re-dispatch.
+
+## Consequences
+
+**Positive**
+- Workers behind NAT/firewalls need only outbound HTTPS; no inbound reachability required.
+- Horizontal scaling is trivial — start more workers; they self-select matching work.
+- Capability/dataset matching happens at claim time against ground truth the worker reports.
+
+**Negative**
+- Polling adds latency (a task waits up to one poll interval, ~5 s) and steady request load.
+- Liveness is inferred from heartbeats, so failure detection is delayed and needs a
+  stuck-task reaper to avoid orphaned claims.
+- Exactly-once dispatch depends on the atomicity of the checkout query.
+
+**Neutral**
+- The server becomes the single source of truth and the only stateful component; workers are
+  stateless and disposable.
+
+## Alternatives considered
+
+- **Server pushes to workers** — requires addressable, reachable workers and server-held
+  capacity tracking; fails for HPC/NAT. Rejected.
+- **A message broker (NATS/RabbitMQ/Redis)** — solves distribution but adds an operational
+  dependency and still needs capability-aware routing; overkill at current scale. Rejected.
+
+## References
+
+- Code: `internal/worker/`, `internal/server/handler_workers.go`, `internal/store/` (`CheckoutTask`), `internal/toolexec/`
+- Docs: [`Remote-Worker-Analysis.md`](../Remote-Worker-Analysis.md), [`Execution-Modes.md`](../Execution-Modes.md)

--- a/docs/adr/0005-pluggable-executor-registry.md
+++ b/docs/adr/0005-pluggable-executor-registry.md
@@ -1,0 +1,62 @@
+# 0005. Dispatch through a pluggable executor registry with ordered selection
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-18
+- **Deciders**: GoWe core
+- **Related**: ADR-0002 (hints), ADR-0004 (workers), ADR-0007 (BV-BRC); [`Execution-Modes.md`](../Execution-Modes.md)
+
+## Context
+
+The same CWL task must be runnable in very different environments — a local process for
+development, a Docker or Apptainer container, a remote pull-worker, or a BV-BRC app service —
+without changing the workflow definition. Which environment applies depends on operator
+policy, per-step hints, the presence of a `DockerRequirement`, and whether workers are
+online. That routing logic must live in exactly one place and be overridable, or it will
+scatter across handlers and the scheduler.
+
+## Decision
+
+We will define a single **`Executor` interface** — `Submit`, `Status`, `Cancel`, `Logs` —
+and a **registry** of backends implementing it: `local`, `docker`, `apptainer`, `worker`,
+`bvbrc`. The scheduler resolves the backend per task by a fixed, documented order (first
+match wins):
+
+1. Server `--default-executor` override, if set.
+2. `gowe:Execution.executor` hint (`worker` | `bvbrc` | `local`). `container` is *not* a
+   routing value — it describes how to run, not where.
+3. `gowe:Execution.bvbrc_app_id` ⇒ `bvbrc`.
+4. `DockerRequirement` (or `gowe:Execution.docker_image`) ⇒ auto-promote to `worker` when
+   workers are online, else run locally.
+5. Default ⇒ `local`.
+
+Adding a backend MUST require only a new `Executor` implementation plus registration — no
+changes to the scheduler's core loop.
+
+## Consequences
+
+**Positive**
+- One uniform contract; the scheduler treats all backends identically.
+- Routing precedence is explicit and testable in one function, not emergent.
+- New backends (e.g. an HPC/SLURM executor) slot in without touching scheduling.
+
+**Negative**
+- The selection order is subtle (the Docker→worker auto-promotion is state-dependent on
+  worker availability) and must be documented carefully to avoid surprise.
+- A four-method interface is a lowest common denominator; backend-specific capabilities
+  (async polling vs synchronous run) leak through `Status`/`Logs` semantics.
+
+**Neutral**
+- Sync (`local`, `docker`, `apptainer`) and async (`worker`, `bvbrc`) backends coexist
+  behind the same interface; the scheduler's poll phase handles async status.
+
+## Alternatives considered
+
+- **Hard-code executor choice per step in the workflow** — leaks placement into the
+  definition and defeats "write once, run anywhere." Rejected (placement stays in hints/policy).
+- **One monolithic executor with mode switches** — becomes a god-object; hard to test and
+  extend. Rejected in favor of the registry.
+
+## References
+
+- Code: `internal/executor/registry.go`, `internal/executor/executor.go`, `internal/executor/{local,docker,apptainer,worker,bvbrc}.go`
+- Docs: [`Execution-Modes.md`](../Execution-Modes.md), [`cwl-hints.md`](../cwl-hints.md)

--- a/docs/adr/0006-sqlite-single-writer-persistence.md
+++ b/docs/adr/0006-sqlite-single-writer-persistence.md
@@ -1,0 +1,58 @@
+# 0006. Persist state in pure-Go SQLite, single writer, WAL
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-18
+- **Deciders**: GoWe core
+- **Related**: ADR-0004 (workers rely on atomic checkout); [`GoWe-Implementation-Plan.md`](../GoWe-Implementation-Plan.md) performance section
+
+## Context
+
+GoWe's server needs durable state for workflows, submissions, step instances, tasks, and
+workers, plus an atomic "claim the next task" operation for the pull model (ADR-0004). The
+deployment target ranges from a single binary on a laptop or login node to a small
+production server — not (yet) a horizontally-scaled cluster. Two constraints stand out:
+build/ops simplicity (this should be a single static Go binary with no external services),
+and correctness of concurrent task checkout under many polling workers.
+
+## Decision
+
+We will persist to **SQLite via `modernc.org/sqlite` (pure Go, no CGO)**, configured as a
+**single writer** (`SetMaxOpenConns(1)`) in **WAL mode** with foreign keys enforced.
+Schema lives in `internal/store/migrations.go` and evolves through idempotent
+`ALTER TABLE ADD COLUMN` migrations (`addColumnIfNotExists`). Task checkout MUST be a single
+atomic statement over `tasks` (backed by a compound index on `(state, executor_type)`) so
+exactly one worker can claim a queued task.
+
+## Consequences
+
+**Positive**
+- The server is a single static binary — no CGO, no database server to run or back up
+  separately; the store is one file.
+- WAL gives concurrent readers alongside the one writer — good for polling workers and the
+  scheduler reading state.
+- Serializing writes through one connection sidesteps "database is locked" and makes atomic
+  checkout straightforward.
+
+**Negative**
+- A single writer caps write throughput and means the server does not scale horizontally as
+  written — a deliberate ceiling for the current target, not a permanent one.
+- SQLite ties durable state to one host's disk; HA/failover would require a different store.
+
+**Neutral**
+- Migrating to Postgres later is a bounded change behind the `store` interface — though that
+  interface is currently large and a candidate to split (TaskStore/WorkerStore/SubmissionStore).
+
+## Alternatives considered
+
+- **CGO SQLite (`mattn/go-sqlite3`)** — mature, but reintroduces CGO and cross-compilation
+  pain. Rejected for the pure-Go driver.
+- **Postgres from day one** — scales and offers real concurrency, but adds an external
+  service to every deployment including single-node/laptop use. Deferred behind the store
+  interface.
+- **Embedded KV (bbolt/Badger)** — no SQL, so the atomic conditional checkout and ad-hoc
+  queries become hand-rolled. Rejected.
+
+## References
+
+- Code: `internal/store/`, `internal/store/migrations.go`
+- Docs: [`GoWe-Implementation-Plan.md`](../GoWe-Implementation-Plan.md) (performance assessment)

--- a/docs/adr/0007-generic-bvbrc-executor-over-operators.md
+++ b/docs/adr/0007-generic-bvbrc-executor-over-operators.md
@@ -1,0 +1,63 @@
+# 0007. Use one generic BV-BRC executor, not per-app operators
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-09
+- **Deciders**: GoWe core
+- **Related**: ADR-0001 (CWL), ADR-0005 (executor registry); [`GoWe-Vocabulary.md`](../GoWe-Vocabulary.md) ("Operator — Not Needed"), [`BVBRC-API.md`](../BVBRC-API.md)
+
+## Context
+
+GoWe routes some steps to BV-BRC apps (e.g. `GenomeAssembly2`) via JSON-RPC. Airflow-style
+frameworks model each external service as a hand-written, typed *Operator* class. That
+pattern exists because clouds like AWS/GCP do not expose a single machine-readable schema
+for each operation. BV-BRC is different: it self-describes. `AppService.enumerate_apps`
+lists apps, and `AppService.query_app_description(app_id)` returns an app's full
+`AppParameter[]` schema — types, required flags, defaults, enums, docs — at runtime.
+
+Hard-coding a Go Operator per app would duplicate what BV-BRC already publishes, go stale
+whenever BV-BRC changes an app or parameter, require hand-maintaining 20+ definitions, and
+limit users to only the apps we had wrapped.
+
+## Decision
+
+We will implement **a single generic `bvbrc` executor** that discovers app schemas
+dynamically. For a task carrying `gowe:Execution.bvbrc_app_id`, it MUST:
+
+1. `query_app_description(app_id)` to fetch the live `AppParameter[]` schema (cached with a
+   TTL; cache invalidated on validation error).
+2. Validate the task's resolved inputs against that schema.
+3. Map CWL `File` locations to BV-BRC workspace paths.
+4. `start_app(app_id, params, workspace)` and poll `query_tasks` to terminal state.
+
+No per-app Go types are introduced; a new BV-BRC app becomes usable by referencing its
+`app_id` in a CWL tool, with no GoWe code change.
+
+## Consequences
+
+**Positive**
+- Every BV-BRC app is reachable immediately — no wrapper to write per app.
+- Validation is always against the live schema, so it can't drift from the service.
+- One executor to maintain instead of a growing operator catalogue.
+
+**Negative**
+- Validation and parameter mapping are dynamic, so some errors surface at run time rather
+  than compile time.
+- Correctness depends on BV-BRC's schema being accurate and available; schema fetches add
+  latency and a caching concern (TTL, invalidation).
+
+**Neutral**
+- App schemas are a cached, runtime-fetched artifact in the model, distinct from static
+  workflow/tool definitions.
+
+## Alternatives considered
+
+- **Per-app typed operators** — compile-time safety, but duplicates BV-BRC's schema, goes
+  stale, and caps users to wrapped apps. Rejected (this ADR's core decision).
+- **A one-time codegen of tool wrappers from `enumerate_apps`** — avoids hand-writing but
+  still snapshots a moving schema and needs regeneration on every BV-BRC change. Rejected in
+  favor of live fetch.
+
+## References
+
+- Code: `internal/executor/bvbrc.go`, `internal/bvbrc/`, `pkg/bvbrc/`
+- Docs: [`GoWe-Vocabulary.md`](../GoWe-Vocabulary.md), [`BVBRC-API.md`](../BVBRC-API.md), [`BVBRC-App-Specs-Summary.md`](../BVBRC-App-Specs-Summary.md)

--- a/docs/adr/0008-dataset-affinity-and-staging-modes.md
+++ b/docs/adr/0008-dataset-affinity-and-staging-modes.md
@@ -1,0 +1,66 @@
+# 0008. Route by dataset affinity; stage data by mode
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-18
+- **Deciders**: GoWe core
+- **Related**: ADR-0004 (pull workers), ADR-0002 (hints); [`cwl-hints.md`](../cwl-hints.md), [`Execution-Modes.md`](../Execution-Modes.md)
+
+## Context
+
+Bioinformatics steps depend on large reference data — model weights, sequence databases —
+ranging from tens of GB to multi-TB (AlphaFold ~2 TB). Some of it is impractical to move at
+task time and is pre-staged on specific workers; some could in principle be fetched but is
+far cheaper to reuse where it already exists. Separately, task *outputs* must be placed
+somewhere other components can read them, and the right placement differs by deployment:
+in-place for a standalone run, a shared filesystem for distributed workers, or an object/
+workspace service for BV-BRC. Neither concern belongs in the CWL tool logic.
+
+## Decision
+
+We will express reference-data needs as a **`gowe:ResourceData` hint** listing datasets by
+`id` (plus optional `path`, `size`, `mode`, `source`), and route on it in two modes:
+
+- **`prestage`** — the scheduler MUST dispatch only to a worker advertising that dataset;
+  the task waits if none is available.
+- **`cache`** (default) — the scheduler SHOULD prefer a worker with the dataset but MAY
+  dispatch elsewhere.
+
+Workers advertise datasets via `--pre-stage-dir` (auto-scan; dirname = id) or
+`--dataset id=path`; `store.CheckoutTask` matches advertised ids against the hint.
+Independently, **output staging is a pluggable backend** (`pkg/staging`) selected by URI
+scheme — `local` (in-place), `file://` (shared FS), with `http(s)://`, `shock://`, `ws://`
+(BV-BRC workspace), and `s3://` defined — supporting copy, symlink, and reference modes.
+`--extra-bind` injects arbitrary host paths into containers **without** affecting scheduling.
+
+## Consequences
+
+**Positive**
+- Multi-TB datasets that can't be moved are honored declaratively, in the workflow, without
+  encoding host layout into tools.
+- The same workflow runs standalone, distributed, or on BV-BRC by changing the staging
+  backend, not the definition.
+- `cache` vs `prestage` lets authors trade strict placement against scheduling flexibility.
+
+**Negative**
+- Affinity narrows the pool of eligible workers, so a `prestage` task can starve if its
+  worker is busy or offline — a scheduling-fairness edge to watch.
+- Dataset ids are a coordination contract between workflow authors and worker operators;
+  a typo silently prevents matching.
+- Several staging backends (`http`, `shock`, `s3`, `ws`) are defined but not yet fully
+  test-covered (see `Execution-Modes.md`).
+
+**Neutral**
+- Scheduling affinity (`gowe:ResourceData`) and plumbing (`--extra-bind`) are intentionally
+  separate concepts; only the former influences placement.
+
+## Alternatives considered
+
+- **Treat reference data as ordinary CWL `File` inputs** — would try to stage TBs per task
+  and lose the "already present, don't move it" semantics. Rejected.
+- **A single hard-wired staging mode** — cannot serve laptop, HPC, and BV-BRC deployments
+  from one definition. Rejected for the pluggable backend.
+
+## References
+
+- Code: `pkg/staging/`, `internal/store/` (`CheckoutTask` dataset matching), `internal/toolexec/` (binds), `internal/worker/`
+- Docs: [`cwl-hints.md`](../cwl-hints.md) (`gowe:ResourceData`), [`Execution-Modes.md`](../Execution-Modes.md)

--- a/docs/adr/0009-delegated-identity-and-optional-worker-keys.md
+++ b/docs/adr/0009-delegated-identity-and-optional-worker-keys.md
@@ -1,0 +1,71 @@
+# 0009. Delegate identity to external providers; gate workers with optional shared keys
+
+- **Status**: Accepted (back-filled 2026-07-06)
+- **Date**: 2026-02-18
+- **Deciders**: GoWe core
+- **Related**: ADR-0001 (CWL), ADR-0004 (pull workers), ADR-0007 (BV-BRC); [`SPECIFICATION.md`](../../SPECIFICATION.md) §13
+
+## Context
+
+GoWe serves BV-BRC and MG-RAST users who already hold accounts and tokens with those
+services. The engine has to (a) authenticate API callers, (b) authorize a small set of admin
+actions, and (c) let remote pull-workers (ADR-0004) join from HPC/NAT networks — without
+standing up its own password store or identity provider. It also has to submit BV-BRC jobs
+*as the requesting user*, not as a shared service account (ADR-0007), which means the user's
+own credential must reach the BV-BRC executor. Two questions fall out: how do end users
+authenticate, and how do workers authenticate.
+
+## Decision
+
+**Delegate user identity; keep worker auth simple and optional.**
+
+- **Users** present a provider-issued, pipe-delimited token — BV-BRC via `Authorization`,
+  MG-RAST via `X-MG-RAST-Token`. The server parses the token for username and expiry, rejects
+  empty/expired tokens, and **auto-provisions** a local user record keyed by
+  `(username, provider)`. GoWe stores **no passwords**. Roles are `user` / `admin` /
+  `anonymous`; admin membership comes from config (stored role, `--admins`, `GOWE_ADMINS`,
+  config file). Anonymous access is **opt-in** (`--allow-anonymous`) and MUST be scoped by
+  `--anonymous-executors`.
+- **Workers** authenticate with an **optional** shared `X-Worker-Key` that maps to a set of
+  allowed groups; if no keys are configured, worker endpoints are open. The key is never
+  logged in the clear (hash only).
+- **Delegation**: when `gowe:Execution.inject_bvbrc_token` is set, the submitter's own token
+  is injected into the task container as `BVBRC_TOKEN`, so downstream BV-BRC work runs under
+  the user's identity.
+
+## Consequences
+
+**Positive**
+- No identity provider, password store, or credential-reset flow to build or operate.
+- Users reuse the credentials they already have; onboarding is zero-config.
+- Workers join with a single shared secret (or none in a trusted network) — no PKI to stand up.
+- BV-BRC jobs are correctly attributed to the requesting user.
+
+**Negative**
+- Trust is only as strong as the provider token and our validation: GoWe **parses** the token
+  for username/expiry but does not cryptographically verify a provider signature, so it relies
+  on transport security and provider issuance.
+- The shared worker key is coarse — no per-worker identity, no rotation; a leaked key affects
+  every worker that shares it.
+- Delegation requires carrying and storing the user's token, which today lands **plaintext**
+  in `submissions.user_token` (SQLite). This and the two items above are tracked as hardening
+  work; see [`SPECIFICATION.md`](../../SPECIFICATION.md) §13.7.
+
+**Neutral**
+- Anonymous mode exists as a convenience for local/dev use; it is off by default and executor-scoped.
+
+## Alternatives considered
+
+- **Run our own identity/password store** — full control, but duplicates the providers, adds a
+  credential-management burden, and fragments where users' identities live. Rejected.
+- **OAuth/OIDC against the providers** — cleaner token semantics and signature verification,
+  but heavier to implement and not uniformly offered by the target services. Deferred as a
+  possible future upgrade to token validation.
+- **mTLS / per-worker certificates** — strong, rotatable per-worker identity, but requires PKI
+  issuance and operations that outweigh the benefit at current scale. Noted as the hardening
+  path if shared keys prove insufficient.
+
+## References
+
+- Code: `internal/server/auth.go`, `internal/server/worker_auth.go`, `internal/server/admin_config.go`, `pkg/model/user.go`, `internal/worker/worker.go`, `internal/executor/bvbrc.go`
+- Docs: [`SPECIFICATION.md`](../../SPECIFICATION.md) §13

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,47 @@
+# Architecture Decision Records
+
+This directory records the significant architectural decisions behind GoWe — the *why*
+behind choices that are otherwise only visible as their consequences in the code.
+
+An **Architecture Decision Record (ADR)** captures a single decision: the context that
+forced it, the option chosen, and the consequences accepted. ADRs are immutable once
+accepted — when a decision changes, we add a new ADR that supersedes the old one rather
+than editing history.
+
+## Status of this log
+
+ADRs 0001–0009 were **back-filled on 2026-07-06** from decisions already embodied in the
+codebase and in [`GoWe-Vocabulary.md`](../GoWe-Vocabulary.md) and
+[`GoWe-Implementation-Plan.md`](../GoWe-Implementation-Plan.md). They document the current
+design; they were not written before implementation. New decisions from here on SHOULD be
+recorded before or as they are made.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-adopt-cwl-v1.2-as-workflow-definition-format.md) | Adopt CWL v1.2 as the workflow definition format | Accepted |
+| [0002](0002-extend-cwl-via-namespaced-hints.md) | Extend CWL via namespaced hints, not a sidecar config | Accepted |
+| [0003](0003-three-level-state-hierarchy.md) | Model execution as a three-level state hierarchy | Accepted |
+| [0004](0004-pull-based-worker-model.md) | Distribute work with a pull-based worker model | Accepted |
+| [0005](0005-pluggable-executor-registry.md) | Dispatch through a pluggable executor registry with ordered selection | Accepted |
+| [0006](0006-sqlite-single-writer-persistence.md) | Persist state in pure-Go SQLite, single writer, WAL | Accepted |
+| [0007](0007-generic-bvbrc-executor-over-operators.md) | Use one generic BV-BRC executor, not per-app operators | Accepted |
+| [0008](0008-dataset-affinity-and-staging-modes.md) | Route by dataset affinity; stage data by mode | Accepted |
+| [0009](0009-delegated-identity-and-optional-worker-keys.md) | Delegate identity to external providers; gate workers with optional shared keys | Accepted |
+
+## Writing a new ADR
+
+1. Copy [`0000-template.md`](0000-template.md) to `NNNN-short-title.md`, using the next
+   free number.
+2. Fill in Context → Decision → Consequences. Keep it to one decision.
+3. Set the status to `Proposed`; move to `Accepted` once agreed. If it replaces an earlier
+   ADR, set that one's status to `Superseded by ADR-NNNN` and link both ways.
+4. Add a row to the index above.
+
+## Conventions
+
+- **RFC 2119** keywords (MUST, SHOULD, MAY) carry their normative meaning.
+- Reference code by path (e.g. `internal/scheduler/loop.go`) so the record stays anchored
+  to the implementation.
+- Numbers are permanent and never reused, even if an ADR is later rejected.

--- a/docs/architecture-dossier.html
+++ b/docs/architecture-dossier.html
@@ -1,0 +1,794 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="GoWe — architecture dossier for the CWL v1.2 workflow engine.">
+<title>GoWe — Architecture Dossier</title>
+<style>
+  :root{
+    --paper:#F4F4F1; --card:#FFFFFF; --card-2:#FBFBF8;
+    --ink:#1C1C18; --ink-2:#3A3A31; --slate:#6B6B60; --muted:#9A9A8C;
+    --line:#E6E5DD; --line-2:#D3D2C7;
+    --accent:#177368; --accent-deep:#0E574E; --accent-wash:#E7F1ED;
+    --s-wait:#8A8B7E; --s-ready:#177368; --s-flight:#4B54B0;
+    --s-run:#2A63C4; --s-ok:#3B7D3B; --s-bad:#C1443C; --s-skip:#9A6B15;
+    --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono",Menlo,Consolas,monospace;
+    --maxw:1080px;
+    scroll-behavior:smooth;
+  }
+  @media (prefers-reduced-motion:reduce){:root{scroll-behavior:auto}}
+  *{box-sizing:border-box}
+  body{margin:0}
+  .page{background:var(--paper); color:var(--ink); font-family:var(--serif);
+    -webkit-font-smoothing:antialiased; line-height:1.5;
+    padding:clamp(22px,4vw,60px) clamp(16px,4vw,44px) 90px;}
+  .wrap{max-width:var(--maxw); margin:0 auto}
+  .mono{font-family:var(--mono)}
+  .sr-only{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0)}
+
+  .eyebrow{font-family:var(--mono); font-size:11.5px; letter-spacing:.22em;
+    text-transform:uppercase; color:var(--accent); font-weight:600}
+  h1{font-family:var(--serif); font-weight:600; font-size:clamp(40px,7.5vw,76px);
+    line-height:1.0; letter-spacing:-.015em; margin:20px 0 0; text-wrap:balance;
+    color:var(--ink)}
+  .lede{font-size:clamp(17px,2.3vw,21px); line-height:1.5; color:var(--ink-2);
+    max-width:34ch; margin:22px 0 0; text-wrap:pretty}
+  @media(min-width:720px){.lede{max-width:52ch}}
+
+  /* ---- KPI stat cards ---- */
+  .stats{display:grid; grid-template-columns:repeat(5,1fr); gap:12px; margin:38px 0 0}
+  @media(max-width:720px){.stats{grid-template-columns:repeat(2,1fr)}}
+  .stat{background:var(--card); border:1px solid var(--line-2); border-radius:6px;
+    padding:16px 16px 14px}
+  .stat.hi{background:var(--accent-wash); border-color:#BcD8CF}
+  .stat .n{font-family:var(--serif); font-size:34px; line-height:1; font-weight:600;
+    color:var(--ink); font-variant-numeric:tabular-nums}
+  .stat.hi .n{color:var(--accent-deep)}
+  .stat .l{font-family:var(--mono); font-size:10.5px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--muted); margin-top:12px; line-height:1.4}
+  .stat.hi .l{color:var(--accent-deep)}
+
+  .rule{height:1px; background:var(--line-2); margin:40px 0 0}
+
+  /* ---- dossier two-column ---- */
+  .dossier{display:grid; grid-template-columns:236px 1fr; gap:52px; margin-top:36px;
+    align-items:start}
+  @media(max-width:860px){.dossier{grid-template-columns:1fr; gap:28px}}
+  .toc{position:sticky; top:22px}
+  @media(max-width:860px){.toc{position:static}}
+  .toc .tl{font-family:var(--mono); font-size:10.5px; letter-spacing:.18em;
+    text-transform:uppercase; color:var(--muted); margin:0 0 12px; padding-left:14px}
+  .toc a{display:grid; grid-template-columns:20px 1fr; gap:10px; text-decoration:none;
+    color:var(--slate); font-family:var(--mono); font-size:12.5px; line-height:1.4;
+    padding:9px 12px 9px 14px; border-left:2px solid transparent; align-items:start}
+  .toc a .tn{color:var(--muted); font-variant-numeric:tabular-nums}
+  .toc a:hover{color:var(--ink)}
+  .toc a.active{color:var(--accent-deep); border-left-color:var(--accent);
+    background:var(--accent-wash)}
+  .toc a.active .tn{color:var(--accent)}
+
+  .content{min-width:0}
+  .intro{font-size:17px; line-height:1.6; color:var(--ink-2); max-width:64ch; margin:0}
+  .intro b{font-weight:600; color:var(--ink)}
+  .callout{margin:22px 0 0; padding:18px 22px; background:var(--accent-wash);
+    border-left:3px solid var(--accent); border-radius:0 6px 6px 0;
+    font-size:15px; line-height:1.6; color:var(--ink-2); max-width:66ch}
+  .callout b{color:var(--accent-deep); font-weight:600}
+  .callout code, .intro code{font-family:var(--mono); font-size:12.5px;
+    background:rgba(23,115,104,.09); color:var(--accent-deep); padding:1px 6px;
+    border-radius:3px}
+  .callout a{color:var(--accent-deep); text-decoration:underline; text-underline-offset:2px}
+
+  /* ---- sections ---- */
+  section{margin-top:clamp(44px,6vw,72px); scroll-margin-top:22px}
+  .shead{display:flex; align-items:baseline; gap:14px; padding-bottom:12px;
+    border-bottom:1px solid var(--line-2); margin-bottom:22px}
+  .shead .sn{font-family:var(--mono); font-size:12px; color:var(--accent);
+    font-weight:600; font-variant-numeric:tabular-nums}
+  .shead h2{font-family:var(--serif); font-weight:600; font-size:clamp(23px,3vw,30px);
+    letter-spacing:-.01em; margin:0; color:var(--ink)}
+  .shead .ss{margin-left:auto; font-family:var(--mono); font-size:11px; color:var(--muted);
+    letter-spacing:.03em; text-align:right; align-self:center}
+  @media(max-width:560px){.shead .ss{display:none}}
+  .snote{font-size:14.5px; line-height:1.6; color:var(--slate); max-width:64ch; margin:14px 2px 0}
+  .snote b{color:var(--ink-2); font-weight:600}
+  .snote code{font-family:var(--mono); font-size:12px; color:var(--accent-deep)}
+
+  .card{background:var(--card); border:1px solid var(--line); border-radius:6px}
+
+  /* ---- deployment ---- */
+  .deploy{display:grid; grid-template-columns:1fr auto 1fr auto 1fr; align-items:stretch; padding:8px}
+  @media(max-width:720px){.deploy{grid-template-columns:1fr}}
+  .proc{padding:18px 18px 16px; display:flex; flex-direction:column}
+  .proc .pt{font-family:var(--mono); font-size:13.5px; font-weight:600; color:var(--ink);
+    display:flex; align-items:center; gap:9px}
+  .proc .pk{font-family:var(--mono); font-size:10px; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--muted); margin-top:3px}
+  .proc .pd{font-size:14px; line-height:1.5; color:var(--slate); margin-top:11px}
+  .proc ul{margin:11px 0 0; padding:0; list-style:none; display:grid; gap:5px}
+  .proc li{font-size:11.5px; color:var(--ink-2); font-family:var(--mono); padding-left:14px; position:relative}
+  .proc li::before{content:"·"; position:absolute; left:3px; color:var(--accent)}
+  .proc .glyph{width:26px;height:26px;border-radius:5px;display:inline-flex;align-items:center;
+    justify-content:center; font-size:13px; flex-shrink:0}
+  .link{display:flex; flex-direction:column; align-items:center; justify-content:center; padding:0 6px; min-width:118px}
+  @media(max-width:720px){.link{min-width:0; padding:14px 0; flex-direction:row; gap:10px}}
+  .link .ll{font-family:var(--mono); font-size:10px; color:var(--accent-deep);
+    text-transform:uppercase; letter-spacing:.06em; text-align:center; line-height:1.5}
+  .link .lw{font-family:var(--mono); font-size:9.5px; color:var(--muted); margin-top:3px}
+  .link .bar{width:100%; height:2px; background:var(--line-2); position:relative; margin:8px 0}
+  @media(max-width:720px){.link .bar{width:2px; height:34px; margin:0}}
+  .link .bar::after{content:"\25BA"; position:absolute; right:-2px; top:50%; transform:translateY(-50%);
+    color:var(--line-2); font-size:9px}
+
+  /* ---- flow spine ---- */
+  .spine{padding:8px 0}
+  .node{display:grid; grid-template-columns:150px 1fr; align-items:stretch}
+  @media(max-width:720px){.node{grid-template-columns:96px 1fr}}
+  .node .rail{position:relative; display:flex; justify-content:center}
+  .node .rail::before{content:""; position:absolute; top:0; bottom:0; width:2px; background:var(--line-2)}
+  .node:first-child .rail::before{top:50%}
+  .node:last-child .rail::before{bottom:50%}
+  .node .marker{position:relative; z-index:1; align-self:center; width:13px; height:13px;
+    border-radius:50%; background:var(--card); border:2px solid var(--accent)}
+  .node.io .marker{border-color:var(--muted); border-radius:2px}
+  .node .stage{font-family:var(--mono); font-size:11px; color:var(--slate); align-self:center;
+    text-align:right; padding-right:18px}
+  .node .body{padding:14px 0 14px 22px; border-left:1px dashed var(--line-2); margin-left:-7px}
+  .node .body h3{font-family:var(--mono); margin:0; font-size:13.5px; font-weight:600;
+    letter-spacing:-.01em; display:flex; align-items:center; gap:10px; flex-wrap:wrap; color:var(--ink)}
+  .node .body h3 code{font-size:12px; color:var(--accent-deep); background:var(--accent-wash);
+    padding:2px 7px; border-radius:3px; font-weight:500}
+  .node .body p{margin:6px 0 0; font-size:14px; line-height:1.5; color:var(--slate); max-width:62ch}
+
+  /* ---- state tracks ---- */
+  .tracks{display:grid; gap:14px}
+  .legend{display:flex; gap:14px; flex-wrap:wrap; margin:0 0 18px; font-family:var(--mono);
+    font-size:11px; color:var(--slate)}
+  .legend span{display:inline-flex; align-items:center; gap:6px}
+  .legend i{width:9px;height:9px;border-radius:2px;display:inline-block}
+  .track{padding:16px 18px}
+  .track-lab{display:flex; align-items:baseline; gap:10px; margin-bottom:13px; flex-wrap:wrap}
+  .track-lab b{font-family:var(--mono); font-size:13.5px; font-weight:600}
+  .track-lab code{font-family:var(--mono); font-size:11px; color:var(--muted)}
+  .track-lab .lvl{font-family:var(--mono); font-size:10.5px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--muted); margin-left:auto}
+  .states{display:flex; flex-wrap:wrap; align-items:center; gap:6px 4px}
+  .st{font-family:var(--mono); font-size:11.5px; font-weight:560; padding:4px 9px;
+    border-radius:3px; white-space:nowrap; border:1px solid; letter-spacing:.02em}
+  .arw{color:var(--line-2); font-size:12px; padding:0 1px}
+  .fork{display:inline-flex; flex-direction:column; gap:4px; vertical-align:middle}
+  .st.wait{color:#5F6056;border-color:#D9D9CE;background:#F0F0E9}
+  .st.ready{color:#0E574E;border-color:#B7D8CF;background:#E7F1ED}
+  .st.flight{color:#3A42A0;border-color:#C8CBEE;background:#EDEEF9}
+  .st.run{color:#22539C;border-color:#C4D3EE;background:#E9F0F9}
+  .st.ok{color:#2F6A2F;border-color:#C4DFC0;background:#EAF3E6}
+  .st.bad{color:#A83A33;border-color:#EDC7C3;background:#FAECEA}
+  .st.skip{color:#7E5810;border-color:#E5D3A9;background:#F8F1DE}
+  .shortcut{display:flex; align-items:center; gap:7px; flex-wrap:wrap; margin-top:11px;
+    padding-top:11px; border-top:1px dashed var(--line-2)}
+  .arw.dash{color:var(--s-flight); font-size:11px; letter-spacing:-1px}
+  .shortcut .note{font-size:13.5px; color:var(--slate)}
+  .shortcut .note code{font-family:var(--mono); font-size:11px; color:var(--ink-2)}
+
+  /* ---- ladders ---- */
+  .cols{display:grid; grid-template-columns:1fr 1fr; gap:20px}
+  @media(max-width:640px){.cols{grid-template-columns:1fr}}
+  .ladder{list-style:none; margin:0; padding:6px 0}
+  .ladder li{display:grid; grid-template-columns:auto 1fr; gap:14px; padding:11px 18px;
+    align-items:start; border-top:1px solid var(--line)}
+  .ladder li:first-child{border-top:0}
+  .ladder .k{font-family:var(--mono); font-size:11px; font-weight:600; color:var(--accent-deep);
+    background:var(--accent-wash); border:1px solid #Bcd8cf; border-radius:3px; padding:2px 7px;
+    min-width:36px; text-align:center; font-variant-numeric:tabular-nums}
+  .ladder .t{font-size:14.5px; line-height:1.5}
+  .ladder .t b{font-weight:600}
+  .ladder .t code{font-family:var(--mono); font-size:12px; color:var(--ink-2)}
+  .ladder .t p{margin:3px 0 0; color:var(--slate); font-size:13px}
+
+  /* ---- backends ---- */
+  .backs{display:grid; grid-template-columns:repeat(5,1fr); gap:10px}
+  @media(max-width:720px){.backs{grid-template-columns:repeat(2,1fr)}}
+  .back{padding:13px 12px}
+  .back .bn{font-family:var(--mono); font-size:13px; font-weight:600; color:var(--ink)}
+  .back .bd{font-size:12px; line-height:1.45; color:var(--slate); margin-top:5px}
+  .back .badge{font-family:var(--mono); font-size:9.5px; letter-spacing:.08em; text-transform:uppercase;
+    padding:2px 6px; border-radius:3px; display:inline-block; margin-top:9px; font-weight:600}
+  .badge.sync{background:#EAF3E6; color:#2F6A2F}
+  .badge.async{background:#EDEEF9; color:#3A42A0}
+
+  /* ---- worker loop ---- */
+  .loop{display:grid; grid-template-columns:repeat(4,1fr); padding:6px 0}
+  @media(max-width:720px){.loop{grid-template-columns:1fr 1fr}}
+  .lstep{padding:15px 16px; position:relative}
+  .lstep:not(:last-child)::after{content:"\2192"; position:absolute; right:-7px; top:50%;
+    transform:translateY(-50%); color:var(--line-2); font-size:15px; z-index:2}
+  .lstep .ln{font-family:var(--mono); font-size:10px; letter-spacing:.09em; text-transform:uppercase; color:var(--muted)}
+  .lstep .lt{font-family:var(--mono); font-size:13.5px; font-weight:600; margin-top:6px; color:var(--ink)}
+  .lstep .lp{font-size:12.5px; line-height:1.45; color:var(--slate); margin-top:5px}
+  .lstep .lep{font-family:var(--mono); font-size:10.5px; color:var(--accent-deep); margin-top:9px;
+    display:block; word-break:break-all}
+
+  /* ---- package table ---- */
+  .tbl-wrap{overflow-x:auto; border:1px solid var(--line); border-radius:6px}
+  table{border-collapse:collapse; width:100%; min-width:520px; background:var(--card)}
+  th,td{text-align:left; padding:10px 16px; font-size:13.5px; border-bottom:1px solid var(--line)}
+  thead th{font-family:var(--mono); font-size:10.5px; letter-spacing:.08em; text-transform:uppercase;
+    color:var(--muted); font-weight:600; background:var(--card-2)}
+  tbody tr:last-child td{border-bottom:0}
+  td.pkg{font-family:var(--mono); font-size:12.5px; color:var(--accent-deep); font-weight:500; white-space:nowrap}
+  td.role{color:var(--slate)}
+
+  /* ---- code ---- */
+  pre{font-family:var(--mono); font-size:12px; line-height:1.65; margin:0; padding:18px 20px;
+    background:#181A16; color:#D6DBCF; border-radius:6px; overflow-x:auto}
+  pre .c{color:#7E8574} pre .k{color:#7FD0BE} pre .v{color:#B9CF92} pre .n{color:#C7B0EA}
+
+  /* ---- hints reference ---- */
+  .subhead{font-family:var(--mono); font-size:11px; letter-spacing:.1em; text-transform:uppercase;
+    color:var(--accent-deep); margin:28px 0 12px; display:flex; gap:9px; align-items:baseline; flex-wrap:wrap}
+  .subhead .sx{color:var(--muted); text-transform:none; letter-spacing:.02em; font-size:10.5px}
+  td.ty{font-family:var(--mono); font-size:11px; color:var(--muted); white-space:nowrap}
+  .reqgrid{display:grid; grid-template-columns:repeat(2,1fr); gap:0 22px; margin-top:6px}
+  @media(max-width:640px){.reqgrid{grid-template-columns:1fr}}
+  .reqgrid div{font-size:12.5px; color:var(--slate); line-height:1.45; border-top:1px solid var(--line); padding:9px 0}
+  .reqgrid code{font-family:var(--mono); font-size:11.5px; color:var(--accent-deep); display:block; margin-bottom:2px}
+  .pill-note{display:flex; gap:10px; align-items:flex-start; margin-top:12px; font-size:13px; color:var(--slate); line-height:1.5}
+  .pill-note .tag{font-family:var(--mono); font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+    padding:2px 7px; border-radius:3px; font-weight:600; flex-shrink:0; margin-top:1px}
+
+  /* ---- inputs & storage ---- */
+  td code{font-family:var(--mono); font-size:12px; color:var(--ink-2)}
+  .spill{font-family:var(--mono); font-size:9.5px; letter-spacing:.07em; text-transform:uppercase;
+    padding:2px 7px; border-radius:3px; font-weight:600; display:inline-block; white-space:nowrap}
+  .spill.sup{background:#EAF3E6; color:#2F6A2F}
+  .spill.def{background:#F8F1DE; color:#7E5810}
+  .spill.plan{background:#F0F0E9; color:#5F6056}
+  .subcard{padding:16px 18px}
+  .subcard .eyebrow{color:var(--slate); letter-spacing:.14em}
+  .subcard pre{margin-top:12px; font-size:11.5px}
+  .affin{display:flex; gap:8px; flex-wrap:wrap; margin-top:11px}
+  .affin .st{cursor:default}
+
+  /* ---- credentials ---- */
+  .callout.warn{background:#F8F1DE; border-left-color:#C79A2E}
+  .callout.warn b{color:#7E5810}
+  .callout.warn code{background:rgba(153,107,21,.1); color:#7E5810}
+  .callout.warn a{color:#7E5810}
+  .planes{display:grid; grid-template-columns:repeat(2,1fr); gap:12px}
+  @media(max-width:640px){.planes{grid-template-columns:1fr}}
+  .plane{padding:15px 16px}
+  .plane .ph{font-family:var(--mono); font-size:13px; font-weight:600; color:var(--ink);
+    display:flex; gap:9px; align-items:center; flex-wrap:wrap}
+  .ptag{font-family:var(--mono); font-size:9px; letter-spacing:.07em; text-transform:uppercase;
+    padding:2px 6px; border-radius:3px; font-weight:600}
+  .ptag.in{background:var(--accent-wash); color:var(--accent-deep)}
+  .ptag.wk{background:#E9F0F9; color:#22539C}
+  .ptag.local{background:#F8F1DE; color:#7E5810}
+  .ptag.del{background:#EDEEF9; color:#3A42A0}
+  .plane .pdesc{font-size:13px; line-height:1.5; color:var(--slate); margin-top:9px}
+  .plane .pdesc code{font-family:var(--mono); font-size:11px; color:var(--ink-2)}
+  .plane .ppath{font-family:var(--mono); font-size:10.5px; color:var(--accent-deep); margin-top:9px; display:block}
+  .boundary{position:relative}
+  .boundary .noreturn{font-family:var(--mono); font-size:11px; color:#7E5810; text-align:center;
+    margin:10px 2px 0; letter-spacing:.02em}
+  .boundary .noreturn b{color:#7E5810; font-weight:600}
+  .zone .pt .ptag{font-size:9px}
+
+  .foot{margin-top:70px; padding-top:20px; border-top:1px solid var(--line-2); display:flex;
+    flex-wrap:wrap; gap:12px 24px; justify-content:space-between; font-family:var(--mono);
+    font-size:11px; color:var(--muted)}
+  .foot a{color:var(--accent-deep); text-decoration:none}
+</style>
+</head>
+<body>
+<div class="page">
+<h2 class="sr-only">GoWe architecture dossier: deployment, execution model, scheduler, executors, and CWL routing hints.</h2>
+<div class="wrap">
+
+  <header>
+    <div class="eyebrow">GoWe · Architecture Dossier</div>
+    <h1>Parsing, Scheduling&nbsp;&amp; Placement</h1>
+    <p class="lede">A per-layer deep dive into the CWL&nbsp;v1.2 workflow engine — how a
+      workflow parses into a DAG, ticks through a scheduler, and lands on one of five
+      execution backends.</p>
+
+    <div class="stats">
+      <div class="stat hi"><div class="n">4</div><div class="l">Entry binaries</div></div>
+      <div class="stat"><div class="n">5</div><div class="l">Executor backends</div></div>
+      <div class="stat"><div class="n">6</div><div class="l">Scheduler phases</div></div>
+      <div class="stat"><div class="n">3</div><div class="l">State levels</div></div>
+      <div class="stat"><div class="n">378</div><div class="l">CWL conformance tests</div></div>
+    </div>
+  </header>
+
+  <div class="rule"></div>
+
+  <div class="dossier">
+    <nav class="toc" aria-label="Contents">
+      <p class="tl">Contents</p>
+      <a href="#s0" class="active"><span class="tn">0</span><span>Deployment topology</span></a>
+      <a href="#s1"><span class="tn">1</span><span>Core execution path</span></a>
+      <a href="#s2"><span class="tn">2</span><span>Three-level state hierarchy</span></a>
+      <a href="#s3"><span class="tn">3</span><span>The scheduler tick</span></a>
+      <a href="#s4"><span class="tn">4</span><span>Executor registry</span></a>
+      <a href="#s5"><span class="tn">5</span><span>Worker pull model</span></a>
+      <a href="#s6"><span class="tn">6</span><span>Credentials &amp; auth</span></a>
+      <a href="#s7"><span class="tn">7</span><span>Package map</span></a>
+      <a href="#s8"><span class="tn">8</span><span>Routing hints</span></a>
+      <a href="#s9"><span class="tn">9</span><span>Inputs &amp; storage</span></a>
+    </nav>
+
+    <div class="content">
+      <p class="intro">GoWe compiles Common Workflow Language into a DAG, drives it through a
+        tick-based scheduler, and dispatches concrete work units across five interchangeable
+        backends — <b>local, Docker, Apptainer, remote pull-workers, and BV-BRC</b>. Each
+        section below takes one layer: what it does, the entities it moves, and the exact
+        states, phases, and endpoints involved.</p>
+
+      <div class="callout">
+        Companion to <a href="#">SPECIFICATION.md</a> (the normative contract) and
+        <b>docs/adr/</b> (the decisions behind this design). Scope: the Go implementation as
+        it stands today. Every state, phase, and route below was verified against the source —
+        state constants in <code>pkg/model</code>, the tick loop in
+        <code>internal/scheduler/loop.go</code>, and routes in <code>internal/server</code>.
+      </div>
+
+      <section id="s0">
+        <div class="shead"><span class="sn">00</span><h2>Deployment topology</h2>
+          <span class="ss">three processes · one HTTP contract</span></div>
+        <div class="card">
+          <div class="deploy">
+            <div class="proc">
+              <div class="pt"><span class="glyph" style="background:#EDEEF9;color:#3A42A0">◧</span>gowe</div>
+              <div class="pk">cmd/cli · client</div>
+              <div class="pd">Submits workflows and inspects runs. Stateless — every action is an
+                <code class="mono" style="color:var(--accent-deep)">/api/v1</code> call.</div>
+              <ul><li>POST /submissions</li><li>GET /submissions/{id}</li><li>SSE run updates</li></ul>
+            </div>
+            <div class="link"><div class="ll">REST + SSE</div><div class="bar"></div><div class="lw">on demand</div></div>
+            <div class="proc" style="background:var(--card-2)">
+              <div class="pt"><span class="glyph" style="background:var(--accent-wash);color:var(--accent-deep)">◆</span>gowe-server</div>
+              <div class="pk">cmd/server · control plane</div>
+              <div class="pd">The only stateful process: HTTP API, the scheduler tick loop, and the
+                SQLite store live here together.</div>
+              <ul><li>scheduler · ~2s tick</li><li>store · SQLite / WAL</li><li>queues worker tasks</li></ul>
+            </div>
+            <div class="link"><div class="ll">pull / poll</div><div class="bar"></div><div class="lw">~5s · X-Worker-Key</div></div>
+            <div class="proc">
+              <div class="pt"><span class="glyph" style="background:#E9F0F9;color:#22539C">▤</span>gowe-worker</div>
+              <div class="pk">cmd/worker · executor pool</div>
+              <div class="pd">Zero or many. Each polls for tasks it can run, executes in a container,
+                and reports results back.</div>
+              <ul><li>GET /workers/{id}/work</li><li>docker · apptainer · gpu</li><li>PUT …/complete</li></ul>
+            </div>
+          </div>
+        </div>
+        <p class="snote">A fourth binary, <code>cwl-runner</code>, needs none of this — it executes a
+          CWL document in-process with no server or store, for standalone and conformance runs.</p>
+      </section>
+
+      <section id="s1">
+        <div class="shead"><span class="sn">01</span><h2>Core execution path</h2>
+          <span class="ss">CWL → model → scheduler → task → backend</span></div>
+        <div class="card"><div class="spine">
+          <div class="node io"><div class="rail"><span class="stage">input</span><span class="marker"></span></div>
+            <div class="body"><h3>CWL document <code>.cwl</code></h3>
+              <p>A workflow definition plus its inputs — the unit a user submits.</p></div></div>
+          <div class="node"><div class="rail"><span class="stage">parse</span><span class="marker"></span></div>
+            <div class="body"><h3><code>internal/parser</code> → <code>model.Workflow</code></h3>
+              <p>Parses and validates CWL, builds the step DAG, extracts <code>gowe:</code> routing hints.</p></div></div>
+          <div class="node"><div class="rail"><span class="stage">submit</span><span class="marker"></span></div>
+            <div class="body"><h3><code>model.Submission</code></h3>
+              <p>One run of a workflow with concrete inputs — top of the state hierarchy, persisted to SQLite.</p></div></div>
+          <div class="node"><div class="rail"><span class="stage">schedule</span><span class="marker"></span></div>
+            <div class="body"><h3><code>internal/scheduler</code> — tick loop <code>~2s</code></h3>
+              <p>A six-phase tick advances the whole hierarchy: resolve dependencies, dispatch, retry, poll, finalize.</p></div></div>
+          <div class="node"><div class="rail"><span class="stage">expand</span><span class="marker"></span></div>
+            <div class="body"><h3><code>StepInstance</code> · per step, per submission</h3>
+              <p>One instance per step; a scatter step fans out into <b>N</b> instances, each carrying its own tasks.</p></div></div>
+          <div class="node"><div class="rail"><span class="stage">work unit</span><span class="marker"></span></div>
+            <div class="body"><h3><code>Task</code></h3>
+              <p>The concrete, schedulable unit of work handed to an executor.</p></div></div>
+          <div class="node"><div class="rail"><span class="stage">dispatch</span><span class="marker"></span></div>
+            <div class="body"><h3><code>internal/executor</code> — registry</h3>
+              <p>Selects a backend per task, then calls its <code>Submit · Status · Cancel · Logs</code> interface.</p></div></div>
+          <div class="node io"><div class="rail"><span class="stage">run</span><span class="marker"></span></div>
+            <div class="body"><h3>Backend executes → outputs staged back</h3>
+              <p>local · docker · apptainer · worker · bvbrc</p></div></div>
+        </div></div>
+      </section>
+
+      <section id="s2">
+        <div class="shead"><span class="sn">02</span><h2>Three-level state hierarchy</h2>
+          <span class="ss">pkg/model · state machines</span></div>
+        <div class="legend">
+          <span><i style="background:#8A8B7E"></i>waiting</span>
+          <span><i style="background:#177368"></i>ready</span>
+          <span><i style="background:#4B54B0"></i>in-flight</span>
+          <span><i style="background:#2A63C4"></i>running</span>
+          <span><i style="background:#3B7D3B"></i>terminal · ok</span>
+          <span><i style="background:#C1443C"></i>terminal · fail</span>
+          <span><i style="background:#9A6B15"></i>skipped</span>
+        </div>
+        <div class="tracks">
+          <div class="card track">
+            <div class="track-lab"><b>Submission</b><code>submission.go</code><span class="lvl">Level 1 · the run</span></div>
+            <div class="states">
+              <span class="st wait">PENDING</span><span class="arw">→</span>
+              <span class="st run">RUNNING</span><span class="arw">→</span>
+              <span class="fork"><span class="st ok">COMPLETED</span><span class="st bad">FAILED</span><span class="st bad">CANCELLED</span></span>
+            </div>
+          </div>
+          <div class="card track">
+            <div class="track-lab"><b>StepInstance</b><code>step_instance.go</code><span class="lvl">Level 2 · per step · scatter = N</span></div>
+            <div class="states">
+              <span class="st wait">WAITING</span><span class="arw">→</span>
+              <span class="st ready">READY</span><span class="arw">→</span>
+              <span class="st flight">DISPATCHED</span><span class="arw">→</span>
+              <span class="st run">RUNNING</span><span class="arw">→</span>
+              <span class="fork"><span class="st ok">COMPLETED</span><span class="st bad">FAILED</span><span class="st skip">SKIPPED</span></span>
+            </div>
+          </div>
+          <div class="card track">
+            <div class="track-lab"><b>Task</b><code>task.go</code><span class="lvl">Level 3 · the work unit</span></div>
+            <div class="states">
+              <span class="st wait">PENDING</span><span class="arw">→</span>
+              <span class="st ready">SCHEDULED</span><span class="arw">→</span>
+              <span class="st flight">QUEUED</span><span class="arw">→</span>
+              <span class="st run">RUNNING</span><span class="arw">→</span>
+              <span class="fork"><span class="st ok">SUCCESS</span><span class="st bad">FAILED</span><span class="st skip">RETRYING</span><span class="st skip">SKIPPED</span></span>
+            </div>
+            <div class="shortcut">
+              <span class="st wait">PENDING</span><span class="arw dash">╌╌╌╌╌►</span><span class="st flight">QUEUED</span>
+              <span class="note">worker-bound tasks skip <code>SCHEDULED</code> and enqueue directly for checkout</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="s3">
+        <div class="shead"><span class="sn">03</span><h2>The scheduler tick</h2>
+          <span class="ss">~2s loop · six phases (+ sub-phases)</span></div>
+        <div class="cols">
+          <ol class="ladder card">
+            <li><span class="k">1</span><span class="t"><b>Advance waiting</b> — <code>WAITING → READY</code> once every dependency is met.
+              <p>1.5 · pre-stage workspace inputs for pending submissions (server mode).</p></span></li>
+            <li><span class="k">2</span><span class="t"><b>Dispatch</b> — resolve inputs, create <code>Task</code>s, submit to executors.
+              <p>2.5 · re-submit <code>RETRYING</code> tasks.</p></span></li>
+            <li><span class="k">3</span><span class="t"><b>Poll</b> — query <code>QUEUED</code>/<code>RUNNING</code> async tasks for status.
+              <p>3.5 · detect stuck queued worker tasks by progress.</p></span></li>
+          </ol>
+          <ol class="ladder card">
+            <li><span class="k">4</span><span class="t"><b>Advance steps</b> — move <code>DISPATCHED</code>/<code>RUNNING</code> instances forward when all their tasks are terminal.</span></li>
+            <li><span class="k">5</span><span class="t"><b>Finalize</b> — settle submissions once every step instance is terminal.
+              <p>5.5 · post-stage outputs to the workspace (server mode).</p></span></li>
+            <li><span class="k">6</span><span class="t"><b>Retries</b> — send newly-<code>FAILED</code> tasks to <code>RETRYING</code> while attempts remain.</span></li>
+          </ol>
+        </div>
+      </section>
+
+      <section id="s4">
+        <div class="shead"><span class="sn">04</span><h2>Executor registry</h2>
+          <span class="ss">selection is ordered · first match wins</span></div>
+        <div class="cols">
+          <ol class="ladder card">
+            <li><span class="k">1st</span><span class="t"><b>Server override</b> — <code>--default-executor</code> forces the backend.</span></li>
+            <li><span class="k">2nd</span><span class="t"><b>CWL hint</b> — <code>gowe:Execution.executor</code>: <code>worker</code> · <code>bvbrc</code> · <code>local</code>.</span></li>
+            <li><span class="k">3rd</span><span class="t"><b>DockerRequirement</b> — auto-promoted to <code>worker</code> when workers are online, else <code>local</code>.</span></li>
+            <li><span class="k">4th</span><span class="t"><b>Default</b> — <code>local</code>.</span></li>
+          </ol>
+          <div>
+            <div class="backs">
+              <div class="card back"><div class="bn">local</div><div class="bd">In-process, on the scheduler host.</div><span class="badge sync">sync</span></div>
+              <div class="card back"><div class="bn">docker</div><div class="bd">Container via Docker runtime.</div><span class="badge sync">sync</span></div>
+              <div class="card back"><div class="bn">apptainer</div><div class="bd">Rootless <code>.sif</code>, HPC-friendly.</div><span class="badge sync">sync</span></div>
+              <div class="card back"><div class="bn">worker</div><div class="bd">Remote pull-workers claim tasks.</div><span class="badge async">async</span></div>
+              <div class="card back"><div class="bn">bvbrc</div><div class="bd">BV-BRC app service submission.</div><span class="badge async">async</span></div>
+            </div>
+            <p class="snote">Every backend implements the same four-method contract —
+              <code>Submit · Status · Cancel · Logs</code> — so the scheduler treats them uniformly.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="s5">
+        <div class="shead"><span class="sn">05</span><h2>Worker pull model</h2>
+          <span class="ss">no push · workers poll ~5s and claim</span></div>
+        <div class="card"><div class="loop">
+          <div class="lstep"><div class="ln">01 · poll · ~5s</div><div class="lt">Ask for work</div>
+            <div class="lp">Every ~5s the worker requests a task matched on runtime, group, and dataset affinity.</div>
+            <span class="lep">GET /workers/{id}/work</span></div>
+          <div class="lstep"><div class="ln">02 · execute</div><div class="lt">Run it</div>
+            <div class="lp">Executes through <code>toolexec</code> — mounts, GPU, injected secrets (never sent to the server).</div>
+            <span class="lep">internal/toolexec</span></div>
+          <div class="lstep"><div class="ln">03 · report</div><div class="lt">Stage &amp; report</div>
+            <div class="lp">Stages outputs, then posts status and the final result back to the server.</div>
+            <span class="lep">PUT …/status · PUT …/complete</span></div>
+          <div class="lstep"><div class="ln">04 · heartbeat</div><div class="lt">Stay alive</div>
+            <div class="lp">Periodic heartbeat keeps the worker registered; the scheduler flags stalled claims.</div>
+            <span class="lep">PUT /workers/{id}/heartbeat</span></div>
+        </div></div>
+        <p class="snote">Dataset affinity: <code>prestage</code> = require a match · <code>cache</code> = prefer one.
+          Container capability and worker group must match before a task is handed out.</p>
+      </section>
+
+      <section id="s6">
+        <div class="shead"><span class="sn">06</span><h2>Credentials &amp; auth</h2>
+          <span class="ss">four planes · one trust boundary</span></div>
+        <p class="snote">GoWe keeps <b>four credential planes</b> separate, and one rule holds them
+          together: <b>execution secrets never travel back to the server</b>. Identity is delegated to
+          external providers — GoWe stores no passwords.</p>
+
+        <div class="planes" style="margin-top:18px">
+          <div class="card plane">
+            <div class="ph">User / API token <span class="ptag in">client → server</span></div>
+            <div class="pdesc">A BV-BRC or MG-RAST pipe-delimited token on <code>Authorization</code> or
+              <code>X-MG-RAST-Token</code>. Parsed for username + expiry; the account is auto-created on
+              first use.</div>
+            <span class="ppath">internal/server/auth.go</span>
+          </div>
+          <div class="card plane">
+            <div class="ph">Worker key <span class="ptag wk">worker → server</span></div>
+            <div class="pdesc">A shared <code>X-Worker-Key</code> mapped to allowed worker groups. Optional —
+              open access if unset — and logged only as a <code>SHA-256</code> hash, never in the clear.</div>
+            <span class="ppath">internal/server/worker_auth.go</span>
+          </div>
+          <div class="card plane">
+            <div class="ph">Worker secrets <span class="ptag local">worker-local</span></div>
+            <div class="pdesc"><code>--secret NAME=value</code> / <code>--secret-file</code> injected into every
+              container's env. Held in worker memory only — never sent to the server; values never logged.</div>
+            <span class="ppath">internal/worker → internal/toolexec</span>
+          </div>
+          <div class="card plane">
+            <div class="ph">Delegated BV-BRC token <span class="ptag del">server → container</span></div>
+            <div class="pdesc">The submitter's own token, injected as <code>BVBRC_TOKEN</code> when
+              <code>gowe:Execution.inject_bvbrc_token</code> is set — so BV-BRC jobs run under the user's identity.</div>
+            <span class="ppath">scheduler/loop.go → worker.go</span>
+          </div>
+        </div>
+
+        <div class="card boundary" style="margin-top:14px">
+          <div class="deploy">
+            <div class="proc zone">
+              <div class="pt"><span class="glyph" style="background:#EDEEF9;color:#3A42A0">◧</span>Client</div>
+              <div class="pk">gowe CLI · browser</div>
+              <div class="pd">Holds the user's provider token; sends it per request.</div>
+              <ul><li>Authorization: Bearer …</li></ul>
+            </div>
+            <div class="link"><div class="ll">provider token</div><div class="bar"></div><div class="lw">per request</div></div>
+            <div class="proc zone" style="background:var(--card-2)">
+              <div class="pt"><span class="glyph" style="background:var(--accent-wash);color:var(--accent-deep)">◆</span>Server</div>
+              <div class="pk">auth middleware · store</div>
+              <div class="pd">Validates the token, applies roles, persists the run. No passwords at rest.</div>
+              <ul><li>roles: user · admin · anon</li><li>worker-key registry</li><li>user_token in submissions</li></ul>
+            </div>
+            <div class="link"><div class="ll">worker-key + task</div><div class="bar"></div><div class="lw">may carry deleg. token</div></div>
+            <div class="proc zone">
+              <div class="pt"><span class="glyph" style="background:#F8F1DE;color:#7E5810">▤</span>Worker → container</div>
+              <div class="pk">toolexec · runtime</div>
+              <div class="pd">Injects <code>--secret</code> env and any delegated token into the container.</div>
+              <ul><li>secrets = env only</li><li>BVBRC_TOKEN injected</li></ul>
+            </div>
+          </div>
+          <p class="noreturn">◀ &nbsp;<b>Return path carries results only</b> — injected secrets and container env never flow back to the server.</p>
+        </div>
+
+        <div class="callout warn">
+          <b>Current-state caveats.</b> The design is sound, but a few things are worth knowing before
+          production: the submitter's BV-BRC token is persisted <b>plaintext</b> in
+          <code>submissions.user_token</code> (SQLite); the worker key is a <b>shared</b> secret with no
+          per-worker rotation; and server TLS is <b>not enforced by default</b>
+          (<code>Secure:false</code>, a standing TODO) — front the server with a TLS terminator. Anonymous
+          access is opt-in and should always be scoped with <code>--anonymous-executors</code>.
+        </div>
+      </section>
+
+      <section id="s7">
+        <div class="shead"><span class="sn">07</span><h2>Package map</h2>
+          <span class="ss">where each responsibility lives</span></div>
+        <div class="tbl-wrap"><table>
+          <thead><tr><th>Package</th><th>Role</th></tr></thead>
+          <tbody>
+            <tr><td class="pkg">internal/parser</td><td class="role">CWL v1.2 parsing, validation, DAG construction, hint extraction.</td></tr>
+            <tr><td class="pkg">internal/scheduler</td><td class="role">Tick loop, dependency resolution, dispatch, retry logic.</td></tr>
+            <tr><td class="pkg">internal/executor</td><td class="role">Registry + 5 backends (local, docker, apptainer, worker, bvbrc).</td></tr>
+            <tr><td class="pkg">internal/cwltool</td><td class="role">Full CommandLineTool executor — bindings, globbing, JS, IWDR.</td></tr>
+            <tr><td class="pkg">internal/toolexec</td><td class="role">Shared execution: command building, mounts, GPU, secrets.</td></tr>
+            <tr><td class="pkg">internal/cwlexpr</td><td class="role">CWL expression evaluation via the goja JS engine.</td></tr>
+            <tr><td class="pkg">internal/cwlrunner</td><td class="role">Standalone runner (no server) behind <code>bin/cwl-runner</code>.</td></tr>
+            <tr><td class="pkg">internal/worker</td><td class="role">Remote worker loop: poll, execute, stage outputs, heartbeat.</td></tr>
+            <tr><td class="pkg">internal/server</td><td class="role">HTTP handlers (go-chi), middleware, auth, SSE.</td></tr>
+            <tr><td class="pkg">internal/store</td><td class="role">SQLite persistence (pure Go, WAL, single writer).</td></tr>
+            <tr><td class="pkg">pkg/model</td><td class="role">Domain entities with state machines and valid transitions.</td></tr>
+            <tr><td class="pkg">pkg/cwl</td><td class="role">CWL v1.2 type definitions (loose for bundler, strict in parser).</td></tr>
+            <tr><td class="pkg">pkg/staging</td><td class="role">File staging: copy, symlink, reference modes.</td></tr>
+          </tbody>
+        </table></div>
+      </section>
+
+      <section id="s8">
+        <div class="shead"><span class="sn">08</span><h2>Routing hints — reference</h2>
+          <span class="ss">gowe:* extensions · portable by design</span></div>
+        <p class="snote">CWL has two extension surfaces: <b>requirements</b> (the engine MUST support them
+          or reject the document) and <b>hints</b> (SHOULD support, MAY ignore). GoWe puts its
+          placement metadata in <b>namespaced hints</b> — so <code>cwltool</code>, Toil, and others skip
+          unknown <code>gowe:*</code> keys instead of failing, and the workflow stays one portable artifact.</p>
+
+        <div class="cols" style="margin-top:18px">
+          <div>
+            <pre><span class="n">$namespaces:</span>
+  <span class="k">gowe:</span> <span class="v">https://github.com/wilke/GoWe#</span>
+
+<span class="n">hints:</span>
+  <span class="k">gowe:Execution:</span>
+    <span class="k">executor:</span> <span class="v">worker</span>        <span class="c"># local · worker · bvbrc</span>
+    <span class="k">worker_group:</span> <span class="v">esmfold</span>
+    <span class="k">bvbrc_app_id:</span> <span class="v">GenomeAssembly2</span>
+    <span class="k">docker_image:</span> <span class="v">override.sif</span>
+    <span class="k">gpu:</span> <span class="v">true</span>
+    <span class="k">inject_bvbrc_token:</span> <span class="v">true</span>
+
+  <span class="k">gowe:ResourceData:</span>
+    <span class="k">datasets:</span>
+      - <span class="k">id:</span> <span class="v">boltz</span>
+        <span class="k">path:</span> <span class="v">/local_databases/boltz</span>
+        <span class="k">mode:</span> <span class="v">prestage</span>    <span class="c"># require | cache=prefer</span></pre>
+          </div>
+          <div class="card subcard">
+            <div class="eyebrow">Placement rule</div>
+            <div class="pill-note"><span class="tag ptag in">gowe:*</span>
+              <span>GoWe extensions go in <code>hints</code> — advisory and portable. They steer
+                <b>where</b> and <b>how</b> a step runs.</span></div>
+            <div class="pill-note"><span class="tag ptag wk">CWL std</span>
+              <span>Container / resource needs use standard <code>DockerRequirement</code> and
+                <code>ResourceRequirement</code>, honored as CWL intends.</span></div>
+            <p class="snote" style="margin-top:12px"><b>Caveat:</b> because hints are advisory, a workflow
+              that <i>depends</i> on GoWe routing runs differently (though validly) on another engine.</p>
+          </div>
+        </div>
+
+        <div class="subhead">gowe:Execution <span class="sx">— steers placement · recognized only in <code>hints</code></span></div>
+        <div class="tbl-wrap"><table>
+          <thead><tr><th>Field</th><th>Type</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="pkg">executor</td><td class="ty">string</td><td class="role">Route to a backend: <code>local</code>, <code>worker</code>, or <code>bvbrc</code>.</td></tr>
+            <tr><td class="pkg">worker_group</td><td class="ty">string</td><td class="role">Target a worker pool (e.g. <code>esmfold</code>); overrides the submission-level <code>--group</code>.</td></tr>
+            <tr><td class="pkg">bvbrc_app_id</td><td class="ty">string</td><td class="role">BV-BRC application id; implies <code>executor: bvbrc</code>.</td></tr>
+            <tr><td class="pkg">docker_image</td><td class="ty">string</td><td class="role">Container image <b>override</b> — wins over <code>DockerRequirement</code>; feeds Docker <i>and</i> Apptainer.</td></tr>
+            <tr><td class="pkg">gpu</td><td class="ty">bool</td><td class="role">Request GPU passthrough on the executing worker.</td></tr>
+            <tr><td class="pkg">inject_bvbrc_token</td><td class="ty">bool</td><td class="role">Inject the submitter's token as <code>BVBRC_TOKEN</code> — job runs under the user's identity.</td></tr>
+          </tbody>
+        </table></div>
+
+        <div class="subhead">gowe:ResourceData <span class="sx">— reference-data affinity · <code>hints</code> or <code>requirements</code></span></div>
+        <div class="tbl-wrap"><table>
+          <thead><tr><th>Field</th><th>Req</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td class="pkg">id</td><td class="ty">yes</td><td class="role">Dataset identifier — must match a dataset a worker advertises.</td></tr>
+            <tr><td class="pkg">path</td><td class="ty">no</td><td class="role">Expected mount path inside the container.</td></tr>
+            <tr><td class="pkg">size</td><td class="ty">no</td><td class="role">Approximate size, informational only (e.g. <code>2TB</code>).</td></tr>
+            <tr><td class="pkg">mode</td><td class="ty">no</td><td class="role"><code>prestage</code> = require a worker with it; <code>cache</code> = prefer (default).</td></tr>
+            <tr><td class="pkg">source</td><td class="ty">no</td><td class="role">Reserved for future on-demand caching (<code>shock://</code>, <code>s3://</code>).</td></tr>
+          </tbody>
+        </table></div>
+
+        <div class="subhead">Standard CWL requirements <span class="sx">— honored, not GoWe-specific</span></div>
+        <div class="reqgrid">
+          <div><code>DockerRequirement</code>Container image (<code>dockerPull</code>); GoWe extends <code>.sif</code>/Apptainer resolution.</div>
+          <div><code>ResourceRequirement</code>CPU / RAM / disk requests.</div>
+          <div><code>InitialWorkDirRequirement</code>Stage files &amp; dirs into the working directory (IWDR).</div>
+          <div><code>InlineJavascriptRequirement</code>Enable <code>$(…)</code> / <code>${…}</code> expressions (goja).</div>
+          <div><code>EnvVarRequirement</code>Set environment variables.</div>
+          <div><code>ShellCommandRequirement</code>Interpret the command line through a shell.</div>
+          <div><code>SchemaDefRequirement</code>Custom input type definitions.</div>
+          <div><code>LoadListingRequirement</code>Control <code>Directory</code> listing depth.</div>
+          <div><code>NetworkAccess</code>Toggle network (Apptainer can't isolate unprivileged — test 227).</div>
+          <div><code>ToolTimeLimit</code>Maximum runtime for a tool.</div>
+          <div><code>ScatterFeatureRequirement</code>Enable scatter/gather over arrays.</div>
+          <div><code>SubworkflowFeatureRequirement</code>Allow a step to run a sub-workflow.</div>
+        </div>
+
+        <p class="snote" style="margin-top:22px"><b>On <code>docker_image</code>:</b> CWL's own
+          <code>DockerRequirement.dockerPull</code> is honored when present — this hint doesn't replace it.
+          It's an override that takes precedence, letting one step swap images at deploy time. Despite the
+          name, the value drives both runtimes: a <code>.sif</code> suffix resolves to a local Apptainer
+          image, anything else is pulled as <code>docker://</code>.</p>
+      </section>
+
+      <section id="s9">
+        <div class="shead"><span class="sn">09</span><h2>Inputs &amp; storage</h2>
+          <span class="ss">job inputs · six schemes · reference data</span></div>
+        <p class="snote">Two concerns share this layer: how a run's <b>inputs</b> arrive, and how
+          <b>File / Directory data</b> moves in and out. A file's <code>location</code> scheme selects the
+          backend — staging (<code>pkg/staging</code>) is pluggable and dispatches by URI scheme.</p>
+
+        <div class="legend" style="margin-top:16px">
+          <span><i style="background:#3B7D3B"></i>supported</span>
+          <span><i style="background:#9A6B15"></i>defined · implemented, not CI-verified</span>
+          <span><i style="background:#8A8B7E"></i>planned</span>
+        </div>
+        <div class="tbl-wrap"><table>
+          <thead><tr><th>Scheme</th><th>Backend</th><th>Behavior</th><th>Status</th></tr></thead>
+          <tbody>
+            <tr><td class="pkg">local · <span style="color:var(--muted)">none</span></td><td><code>file.go</code></td>
+              <td class="role">In place, no copy — the <code>cwl-runner</code> default.</td><td><span class="spill sup">supported</span></td></tr>
+            <tr><td class="pkg">file://</td><td><code>shared.go</code></td>
+              <td class="role">Copy to a shared filesystem path — distributed workers.</td><td><span class="spill sup">supported</span></td></tr>
+            <tr><td class="pkg">http(s)://</td><td><code>http stager</code></td>
+              <td class="role">HTTP PUT/POST upload; custom headers, auth, retry.</td><td><span class="spill def">defined</span></td></tr>
+            <tr><td class="pkg">shock://</td><td><code>shock.go</code></td>
+              <td class="role">Shock data service — <code>shock://host/node/{id}</code>.</td><td><span class="spill def">defined</span></td></tr>
+            <tr><td class="pkg">ws://</td><td><code>workspace.go</code></td>
+              <td class="role">BV-BRC Workspace — the default for BV-BRC runs.</td><td><span class="spill def">defined</span></td></tr>
+            <tr><td class="pkg">s3://</td><td><code>s3.go</code></td>
+              <td class="role">S3-compatible object storage.</td><td><span class="spill plan">planned</span></td></tr>
+          </tbody>
+        </table></div>
+        <p class="snote"><b>Why <code>ws://</code> is "defined", not "supported".</b> The BV-BRC path is
+          built end to end — submit, poll, output mapping, and server-side pre/post-staging — but it
+          can't run in the conformance suite (it needs a live BV-BRC service and a real token), and it
+          carries edges only visible against real infrastructure: wildcard-glob outputs, large-file
+          streaming, and recursive directory download. Full round-trip in
+          <code>docs/BVBRC-Workspace-Deep-Dive.md</code>.</p>
+
+        <div class="cols" style="margin-top:20px">
+          <div class="card subcard">
+            <div class="eyebrow">Job inputs</div>
+            <p class="snote" style="margin-top:10px">Supplied at submit time as a YAML/JSON job document —
+              not a configured backend. Relative <code>File</code> paths resolve against the job file's directory.</p>
+<pre><span class="c"># CLI</span>
+gowe submit workflow.cwl <span class="k">--inputs</span> <span class="v">job.yaml</span>
+
+<span class="c"># API</span>
+<span class="k">POST</span> <span class="v">/api/v1/submissions</span>  <span class="c">{ inputs: … }</span></pre>
+          </div>
+          <div class="card subcard">
+            <div class="eyebrow">Reference data</div>
+            <p class="snote" style="margin-top:10px">Large read-only datasets (databases, model weights) are
+              <b>not</b> <code>File</code> inputs. Declared with <code>gowe:ResourceData</code> and matched to
+              workers by affinity:</p>
+            <div class="affin">
+              <span class="st ready">prestage = require</span>
+              <span class="st wait">cache = prefer</span>
+            </div>
+            <p class="snote" style="margin-top:11px">Workers advertise datasets via <code>--pre-stage-dir</code>
+              or <code>--dataset id=path</code>.</p>
+          </div>
+        </div>
+        <p class="snote"><b>Server-side staging.</b> The server can pre/post-stage <code>ws://</code> itself
+          (<code>--workspace-staging server</code>, <code>--workspace-url</code>) and proxy uploads to a
+          backend (<code>--upload-backend shock|s3|local</code>); otherwise outputs are staged by the workers.</p>
+      </section>
+
+    </div>
+  </div>
+
+  <footer class="foot">
+    <span>GoWe · CWL v1.2 workflow engine · Go</span>
+    <span>parser → scheduler → executor · <a href="https://github.com/wilke/GoWe">github.com/wilke/GoWe</a></span>
+  </footer>
+
+</div>
+</div>
+
+<script>
+  (function(){
+    var links = Array.prototype.slice.call(document.querySelectorAll('.toc a'));
+    var map = {};
+    links.forEach(function(a){ map[a.getAttribute('href').slice(1)] = a; });
+    var obs = new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){
+          links.forEach(function(a){ a.classList.remove('active'); });
+          var a = map[e.target.id];
+          if(a) a.classList.add('active');
+        }
+      });
+    }, { rootMargin: '-15% 0px -70% 0px', threshold: 0 });
+    document.querySelectorAll('section[id]').forEach(function(s){ obs.observe(s); });
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a documentation baseline for GoWe's architecture — a normative spec, the decision record behind the design, a visual dossier, and two focused deep dives. **Docs only; no code changes.** Everything is grounded in and verified against the current implementation (state constants in `pkg/model`, the tick loop in `internal/scheduler/loop.go`, auth in `internal/server`, the BV-BRC path in `internal/executor/bvbrc.go` and `pkg/staging/workspace.go`, and routes in `internal/server`).

## What's included

- **`SPECIFICATION.md`** (draft-3) — normative reference: terminology, the CWL v1.2 profile, `gowe:*` hint extensions, the three-level state hierarchy, scheduler tick phases, executor selection, the worker pull protocol, **inputs & storage (§10)**, persistence, the HTTP API surface, and a full **security section (§13)** — credential planes, trust boundary, auth schemes, roles, and known limitations.
- **`docs/adr/`** — an ADR log (index + template) back-filling **nine** decisions: CWL adoption, namespaced hints, three-level state hierarchy, pull-based workers, executor registry, SQLite single-writer, generic BV-BRC executor, dataset affinity + staging, and delegated identity + optional worker keys.
- **`docs/architecture-dossier.html`** — a self-contained visual dossier (ten sections, sticky contents rail, scroll-spy). Inline CSS/JS, UTF-8, system fonts — open it directly in a browser, no build step.
- **`docs/BVBRC-Workspace-Deep-Dive.md`** — the BV-BRC submission/result round-trip and a precise account of why `ws://` is "defined" (implemented, not CI-verified) rather than "supported".
- **`README.md`** — a "Deep-dive documentation" pointer at the top of the Architecture section linking all of the above.

## Follow-ups (already queued as separate tasks)

The spec's §13.7 and the BV-BRC deep dive document known gaps; four hardening tasks are queued to land on top of this baseline:

- Encrypt BV-BRC tokens at rest (currently plaintext in `submissions.user_token`)
- Per-worker keys with rotation (currently a shared `X-Worker-Key`)
- Server-native TLS (currently `Secure:false`, plain HTTP)
- Harden `ws://` staging (wildcard-glob output resolution, streaming upload, recursive directory download)

## Notes

- No code changes — safe to review as pure documentation.
- The dossier HTML is self-contained and offline-openable; no external requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)