### PR TITLE
security: encrypt provider tokens at rest (AES-256-GCM)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -504,6 +504,14 @@ external providers — GoWe stores no user passwords. Rationale for the auth mod
   MUST be revised, and the least-privilege trade-off recorded in an ADR.)
 - Response bodies MUST NOT expose stored tokens: submission token fields are serialized with
   `json:"-"`.
+- Provider tokens MUST be encrypted at rest. A server-held key (`GOWE_TOKEN_KEY`, or
+  `--token-key-file`) enables AES-256-GCM envelope encryption of the submitter's token in
+  `submissions.user_token` and of any bearer credential embedded in `tasks.runtime_hints`.
+  Ciphertext is decrypted only in memory on the delegated-execution path and MUST NOT be
+  logged. When no key is configured the server MUST fail closed — refusing to persist a
+  delegated token — unless the operator explicitly opts into legacy plaintext with
+  `--allow-plaintext-tokens`. Rows written before a key was configured are read transparently
+  and re-encrypted on startup.
 
 ### 13.6 Transport security
 
@@ -534,8 +542,6 @@ These are current-state gaps, not normative requirements. They are documented so
 can compensate and so the project can track hardening. Each SHOULD be addressed before a
 security-sensitive production deployment:
 
-- **Tokens at rest are plaintext.** The submitter's BV-BRC token is persisted unencrypted in
-  `submissions.user_token` (SQLite). Protect the database file accordingly.
 - **Worker keys are shared secrets.** Keys are stored plaintext in config/env with no
   per-worker identity or rotation; a leaked key affects every worker sharing it.
 - **Anonymous mode widens exposure.** If `--allow-anonymous` is enabled, always scope it with

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # GoWe Specification
 
-> **Status**: Living specification · **Version**: draft-4 (2026-07-06)
+> **Status**: Living specification · **Version**: draft-5 (2026-07-06)
 > **Applies to**: GoWe server, worker, CLI, and `cwl-runner`
 > **Companion documents**: [`docs/adr/`](docs/adr/) (why), [`docs/cwl-hints.md`](docs/cwl-hints.md)
 > (hint reference), [`docs/GoWe-Vocabulary.md`](docs/GoWe-Vocabulary.md) (concepts),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/me/gowe/internal/scheduler"
 	"github.com/me/gowe/internal/server"
 	"github.com/me/gowe/internal/store"
+	"github.com/me/gowe/internal/tokencrypt"
 	"github.com/me/gowe/pkg/model"
 	"github.com/me/gowe/pkg/staging"
 )
@@ -60,6 +61,10 @@ func main() {
 	admins := flag.String("admins", "", "Comma-separated list of admin usernames (also: GOWE_ADMINS env)")
 	configFile := flag.String("config", "", "Path to server config file (for admins, worker keys)")
 	workerKeyFile := flag.String("worker-keys", "", "Path to worker keys JSON file")
+
+	// Provider-token encryption at rest
+	tokenKeyFile := flag.String("token-key-file", "", "Path to a file holding the token-encryption key (base64 or hex, 32 bytes); overrides GOWE_TOKEN_KEY")
+	allowPlaintextTokens := flag.Bool("allow-plaintext-tokens", false, "Permit storing provider tokens in plaintext when no encryption key is set (migration/dev only)")
 
 	// File upload proxy options
 	uploadBackend := flag.String("upload-backend", "", "Enable file upload proxy with backend: shock, s3, local")
@@ -144,6 +149,33 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("database ready", "path", dbPath)
+
+	// Configure provider-token encryption at rest. A configured key encrypts the
+	// submitter's token in submissions.user_token and any bearer credential in
+	// tasks.runtime_hints. With no key, delegated submissions (those carrying a
+	// provider token) are refused unless --allow-plaintext-tokens is set.
+	tokenCipher, err := loadTokenCipher(*tokenKeyFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "token encryption key: %v\n", err)
+		os.Exit(1)
+	}
+	switch {
+	case tokenCipher != nil:
+		st.ConfigureTokenEncryption(tokenCipher, true)
+		if nSub, nTask, rerr := st.ReencryptPlaintextTokens(context.Background()); rerr != nil {
+			logger.Warn("re-encrypting existing plaintext tokens", "error", rerr)
+		} else if nSub > 0 || nTask > 0 {
+			logger.Info("upgraded existing plaintext tokens to encrypted", "submissions", nSub, "tasks", nTask)
+		}
+		logger.Info("provider-token encryption at rest enabled")
+	case *allowPlaintextTokens:
+		st.ConfigureTokenEncryption(nil, false)
+		logger.Warn("provider tokens will be stored in PLAINTEXT (--allow-plaintext-tokens); set GOWE_TOKEN_KEY to encrypt at rest")
+	default:
+		// Fail closed: no key, no explicit opt-in.
+		st.ConfigureTokenEncryption(nil, true)
+		logger.Warn("no token-encryption key configured; delegated submissions carrying a provider token will be refused — set GOWE_TOKEN_KEY (or pass --allow-plaintext-tokens to allow plaintext)")
+	}
 
 	// Create executor registry and register executors.
 	reg := executor.NewRegistry(logger)
@@ -401,4 +433,23 @@ func withHSTS(next http.Handler) http.Handler {
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		next.ServeHTTP(w, r)
 	})
+}
+
+// loadTokenCipher builds the at-rest token cipher from --token-key-file (if set)
+// or the GOWE_TOKEN_KEY environment variable. Returns (nil, nil) when neither is
+// configured, so the caller can decide the no-key policy. A present-but-invalid
+// key is a hard error.
+func loadTokenCipher(keyFile string) (*tokencrypt.Cipher, error) {
+	if keyFile != "" {
+		data, err := os.ReadFile(keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("read token key file: %w", err)
+		}
+		key, err := tokencrypt.DecodeKey(string(data))
+		if err != nil {
+			return nil, err
+		}
+		return tokencrypt.New(key)
+	}
+	return tokencrypt.FromEnv()
 }

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -190,6 +190,34 @@ HF_TOKEN=<token>
 
 Workers load these via `--secret-file`. Secret values are injected into containers at runtime and never sent to the server, stored in task data, or exposed in API responses or logs.
 
+### Provider-token encryption at rest
+
+The server encrypts each submitter's BV-BRC/MG-RAST token before persisting it (in
+`submissions.user_token` and any bearer credential inside `tasks.runtime_hints`), using
+AES-256-GCM under a server-held key. Configure the key with **one** of:
+
+- `GOWE_TOKEN_KEY` — a 32-byte key, base64 or hex encoded, in the server's environment.
+- `--token-key-file <path>` — a file (mode `600`) whose contents are the encoded key; takes
+  precedence over the env var.
+
+Generate a key:
+
+```bash
+openssl rand -base64 32   # 32-byte AES-256 key
+```
+
+Behavior:
+
+- **Key set** → tokens are encrypted at rest; any legacy plaintext rows are re-encrypted on
+  startup. Decrypted values live only in memory on the delegated-execution path and are never
+  logged.
+- **No key** → the server **fails closed**: submissions that carry a delegated provider token
+  are rejected at persistence time. Pass `--allow-plaintext-tokens` only for local/dev or a
+  staged migration; it stores tokens unencrypted (a startup warning is logged).
+
+Rotating the key requires decrypting with the old key and re-encrypting with the new one;
+there is no in-place multi-key support yet, so rotate during a maintenance window.
+
 ## GPU Assignment
 
 GPU 0 is reserved for interactive/other use. The start script assigns workers to GPUs starting at index 1:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -202,7 +202,7 @@ End-to-end CGA → CodonTree + cgMLST + WG-SNP pipeline. Verified working on H37
 | AlphaFold `--af2-data-dir` | Open | `predict-structure alphafold` needs to default data dir internally |
 | `predict-structure-app` on BV-BRC | Open | `App-PredictStructure` not deployed on BV-BRC cluster yet |
 | Anonymous shared visibility | Accepted | All anonymous users share submissions (session-scoped IDs deferred) |
-| Token encryption at rest | Deferred | `user_token` plaintext in SQLite |
+| Token encryption at rest | Done | AES-256-GCM for `submissions.user_token` and task bearer creds via `GOWE_TOKEN_KEY`; fails closed without a key (SPEC §13.5) |
 
 ## Conformance Test Baselines
 

--- a/docs/adr/0009-delegated-identity-and-optional-worker-keys.md
+++ b/docs/adr/0009-delegated-identity-and-optional-worker-keys.md
@@ -47,9 +47,12 @@ authenticate, and how do workers authenticate.
   on transport security and provider issuance.
 - The shared worker key is coarse — no per-worker identity, no rotation; a leaked key affects
   every worker that shares it.
-- Delegation requires carrying and storing the user's token, which today lands **plaintext**
-  in `submissions.user_token` (SQLite). This and the two items above are tracked as hardening
-  work; see [`SPECIFICATION.md`](../../SPECIFICATION.md) §13.7.
+- Delegation requires carrying and storing the user's token. This is now **encrypted at rest**
+  (AES-256-GCM under a server-held `GOWE_TOKEN_KEY`) in both `submissions.user_token` and the
+  bearer credential embedded in `tasks.runtime_hints`; with no key the server fails closed on
+  delegated submissions unless `--allow-plaintext-tokens` is set. The remaining shared-worker-key
+  and transport items above are tracked as hardening work; see
+  [`SPECIFICATION.md`](../../SPECIFICATION.md) §13.5–§13.7.
 
 **Neutral**
 - Anonymous mode exists as a convenience for local/dev use; it is off by default and executor-scoped.

--- a/internal/scheduler/token_inject_test.go
+++ b/internal/scheduler/token_inject_test.go
@@ -1,0 +1,93 @@
+package scheduler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/me/gowe/internal/store"
+	"github.com/me/gowe/internal/tokencrypt"
+	"github.com/me/gowe/pkg/model"
+)
+
+// TestDelegatedTokenInjectionRoundTrip verifies the end-to-end delegation path:
+// a submitter token is encrypted at rest, decrypted transparently on read, and
+// then injected as a bearer credential into a task's runtime hints (which the
+// worker later exposes as BVBRC_TOKEN). This is the security-critical path the
+// encryption work must not break.
+func TestDelegatedTokenInjectionRoundTrip(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	st, err := store.NewSQLiteStore(":memory:", logger)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	ctx := context.Background()
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 3)
+	}
+	cipher, err := tokencrypt.New(key)
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	st.ConfigureTokenEncryption(cipher, true)
+
+	const token = "bvbrc|un=alice|expiry=9999999999|sig=abc123"
+	sub := &model.Submission{
+		ID:           "sub_deleg",
+		WorkflowID:   "wf_1",
+		WorkflowName: "wf",
+		State:        model.SubmissionStatePending,
+		Inputs:       map[string]any{},
+		UserToken:    token,
+		AuthProvider: "bvbrc",
+		CreatedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	if err := st.CreateSubmission(ctx, sub); err != nil {
+		t.Fatalf("create submission: %v", err)
+	}
+
+	// Reload from the store — this is how the scheduler obtains the submission,
+	// with the token decrypted back to plaintext in memory.
+	loaded, err := st.GetSubmission(ctx, "sub_deleg")
+	if err != nil {
+		t.Fatalf("get submission: %v", err)
+	}
+	if loaded.UserToken != token {
+		t.Fatalf("token not decrypted on read: got %q", loaded.UserToken)
+	}
+
+	// Inject via the scheduler's delegation path (wsStager nil is fine).
+	l := &Loop{}
+	task := &model.Task{
+		ID:           "task_deleg",
+		ExecutorType: model.ExecutorTypeBVBRC,
+	}
+	l.addUserToken(task, loaded)
+
+	if task.RuntimeHints == nil ||
+		task.RuntimeHints.StagerOverrides == nil ||
+		task.RuntimeHints.StagerOverrides.HTTPCredential == nil {
+		t.Fatal("expected injected HTTP credential in runtime hints")
+	}
+	cred := task.RuntimeHints.StagerOverrides.HTTPCredential
+	if cred.Type != "bearer" || cred.Token != token {
+		t.Fatalf("injected credential mismatch: type=%q token=%q", cred.Type, cred.Token)
+	}
+
+	// Persisting the task must not fail (and, per store tests, encrypts the
+	// embedded token at rest). The in-memory task keeps the plaintext token.
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if task.RuntimeHints.StagerOverrides.HTTPCredential.Token != token {
+		t.Fatalf("CreateTask mutated in-memory token: %q", task.RuntimeHints.StagerOverrides.HTTPCredential.Token)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -8,8 +8,10 @@ import (
 	"log/slog"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/me/gowe/internal/tokencrypt"
 	"github.com/me/gowe/pkg/model"
 
 	_ "modernc.org/sqlite"
@@ -42,6 +44,17 @@ func parseTimeOrZero(value string) (time.Time, error) {
 type SQLiteStore struct {
 	db     *sql.DB
 	logger *slog.Logger
+
+	// cipher, when non-nil, encrypts persisted provider tokens at rest
+	// (submissions.user_token and any bearer credential embedded in a task's
+	// runtime hints). Configured via ConfigureTokenEncryption; see tokens.go.
+	cipher *tokencrypt.Cipher
+	// refusePlaintextTokens, when true and cipher is nil, makes the store fail
+	// closed rather than write a provider token in the clear.
+	refusePlaintextTokens bool
+	// plaintextWarnOnce guards a single startup warning when tokens are being
+	// persisted without encryption.
+	plaintextWarnOnce sync.Once
 }
 
 // NewSQLiteStore opens (or creates) a SQLite database at dbPath and returns a Store.
@@ -435,13 +448,20 @@ func (s *SQLiteStore) CreateSubmission(ctx context.Context, sub *model.Submissio
 		tokenExpiry = sub.TokenExpiry.Unix()
 	}
 
+	// Encrypt the submitter's provider token before it touches disk. The
+	// in-memory sub.UserToken stays plaintext for the delegation path.
+	storedToken, err := s.encryptToken(sub.UserToken)
+	if err != nil {
+		return err
+	}
+
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO submissions (id, workflow_id, workflow_name, state, inputs, outputs, labels, submitted_by, created_at, completed_at, user_token, token_expiry, auth_provider, parent_task_id, output_destination, output_state)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sub.ID, sub.WorkflowID, sub.WorkflowName, string(sub.State),
 		string(inputsJSON), string(outputsJSON), string(labelsJSON),
 		sub.SubmittedBy, sub.CreatedAt.Format(time.RFC3339Nano), completedAt,
-		sub.UserToken, tokenExpiry, sub.AuthProvider, sub.ParentTaskID,
+		storedToken, tokenExpiry, sub.AuthProvider, sub.ParentTaskID,
 		sub.OutputDestination, sub.OutputState,
 	)
 	return err
@@ -473,6 +493,9 @@ func (s *SQLiteStore) GetSubmission(ctx context.Context, id string) (*model.Subm
 	}
 
 	sub.State = model.SubmissionState(state)
+	if sub.UserToken, err = s.decryptToken(sub.UserToken); err != nil {
+		return nil, fmt.Errorf("decrypt user token: %w", err)
+	}
 	if err := unmarshalJSON(inputsJSON, &sub.Inputs, "inputs"); err != nil {
 		return nil, err
 	}
@@ -595,6 +618,10 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 		}
 
 		sub.State = model.SubmissionState(state)
+		if sub.UserToken, err = s.decryptToken(sub.UserToken); err != nil {
+			slog.Error("skipping submission row with undecryptable token", "id", sub.ID, "error", err)
+			continue
+		}
 		if err := unmarshalJSON(inputsJSON, &sub.Inputs, "inputs"); err != nil {
 			slog.Error("skipping corrupt submission row", "id", sub.ID, "error", err)
 			continue
@@ -1054,9 +1081,9 @@ func (s *SQLiteStore) CreateTask(ctx context.Context, task *model.Task) error {
 	if err != nil {
 		return fmt.Errorf("marshal job: %w", err)
 	}
-	runtimeHintsJSON, err := json.Marshal(task.RuntimeHints)
+	runtimeHintsJSON, err := s.marshalRuntimeHints(task.RuntimeHints)
 	if err != nil {
-		return fmt.Errorf("marshal runtime_hints: %w", err)
+		return err
 	}
 
 	var startedAt, completedAt *string
@@ -1200,9 +1227,9 @@ func (s *SQLiteStore) UpdateTask(ctx context.Context, task *model.Task) error {
 	if err != nil {
 		return fmt.Errorf("marshal job: %w", err)
 	}
-	runtimeHintsJSON, err := json.Marshal(task.RuntimeHints)
+	runtimeHintsJSON, err := s.marshalRuntimeHints(task.RuntimeHints)
 	if err != nil {
-		return fmt.Errorf("marshal runtime_hints: %w", err)
+		return err
 	}
 
 	var startedAt, completedAt *string
@@ -1429,6 +1456,9 @@ func (s *SQLiteStore) scanTask(row scanner) (*model.Task, error) {
 	if err := unmarshalJSON(runtimeHintsJSON, &task.RuntimeHints, "runtime_hints"); err != nil {
 		return nil, err
 	}
+	if err := s.revealRuntimeHints(task.RuntimeHints); err != nil {
+		return nil, fmt.Errorf("decrypt runtime_hints token: %w", err)
+	}
 	if task.CreatedAt, err = parseTimeOrZero(createdAt); err != nil {
 		return nil, err
 	}
@@ -1496,6 +1526,10 @@ func (s *SQLiteStore) scanTasks(rows *sql.Rows) ([]*model.Task, error) {
 		}
 		if err := unmarshalJSON(runtimeHintsJSON, &task.RuntimeHints, "runtime_hints"); err != nil {
 			slog.Error("skipping corrupt task row", "id", task.ID, "error", err)
+			continue
+		}
+		if err := s.revealRuntimeHints(task.RuntimeHints); err != nil {
+			slog.Error("skipping task row with undecryptable token", "id", task.ID, "error", err)
 			continue
 		}
 		if t, err := parseTimeOrZero(createdAt); err != nil {
@@ -1847,6 +1881,10 @@ func (s *SQLiteStore) CheckoutTask(ctx context.Context, workerID string, workerG
 		}
 		if err := unmarshalJSON(runtimeHintsJSON, &task.RuntimeHints, "runtime_hints"); err != nil {
 			slog.Error("skipping corrupt task row in checkout", "id", task.ID, "error", err)
+			continue
+		}
+		if err := s.revealRuntimeHints(task.RuntimeHints); err != nil {
+			slog.Error("skipping task row with undecryptable token in checkout", "id", task.ID, "error", err)
 			continue
 		}
 		if t, err := parseTimeOrZero(createdAt); err != nil {

--- a/internal/store/tokens.go
+++ b/internal/store/tokens.go
@@ -1,0 +1,222 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/me/gowe/internal/tokencrypt"
+	"github.com/me/gowe/pkg/model"
+)
+
+// ConfigureTokenEncryption sets the at-rest encryption policy for persisted
+// provider tokens: the submitter's BV-BRC/MG-RAST token in
+// submissions.user_token and any HTTP bearer credential embedded in a task's
+// runtime hints (tasks.runtime_hints).
+//
+//   - cipher != nil:  tokens are encrypted before persistence and decrypted on
+//     read. Rows written in plaintext before encryption was enabled are read
+//     transparently and can be upgraded with ReencryptPlaintextTokens.
+//   - cipher == nil && refusePlaintext:  the store fails closed — persisting a
+//     non-empty token returns an error instead of writing it in the clear.
+//   - cipher == nil && !refusePlaintext: legacy behavior — tokens are stored in
+//     plaintext (a single warning is logged on first write).
+//
+// In-memory Submission/Task values always carry the plaintext token; encryption
+// is confined to the database boundary so the delegated-execution path (local
+// executor and the worker API) is unchanged.
+func (s *SQLiteStore) ConfigureTokenEncryption(cipher *tokencrypt.Cipher, refusePlaintext bool) {
+	s.cipher = cipher
+	s.refusePlaintextTokens = refusePlaintext
+}
+
+// encryptToken prepares a token for persistence per the configured policy.
+func (s *SQLiteStore) encryptToken(token string) (string, error) {
+	if token == "" {
+		return "", nil
+	}
+	if s.cipher != nil {
+		return s.cipher.Encrypt(token)
+	}
+	if s.refusePlaintextTokens {
+		return "", fmt.Errorf("refusing to persist provider token in plaintext: no encryption key configured (set %s, or start the server with --allow-plaintext-tokens to override)", tokencrypt.EnvKeyVar)
+	}
+	s.plaintextWarnOnce.Do(func() {
+		s.logger.Warn("persisting provider tokens in plaintext at rest; set " + tokencrypt.EnvKeyVar + " to encrypt them")
+	})
+	return token, nil
+}
+
+// decryptToken reverses encryptToken for a value read from the database.
+// Without a cipher, a plaintext value passes through, but a value that is
+// marked as encrypted is an error (the key is missing/misconfigured) rather
+// than something to hand downstream as if it were a real token.
+func (s *SQLiteStore) decryptToken(stored string) (string, error) {
+	if stored == "" {
+		return "", nil
+	}
+	if s.cipher != nil {
+		return s.cipher.Decrypt(stored)
+	}
+	if tokencrypt.IsEncrypted(stored) {
+		return "", fmt.Errorf("stored token is encrypted but no key is configured (set %s)", tokencrypt.EnvKeyVar)
+	}
+	return stored, nil
+}
+
+// marshalRuntimeHints marshals task runtime hints for persistence, encrypting an
+// embedded HTTP bearer token when required by policy.
+func (s *SQLiteStore) marshalRuntimeHints(h *model.RuntimeHints) (string, error) {
+	stored, err := s.runtimeHintsForStorage(h)
+	if err != nil {
+		return "", err
+	}
+	b, err := json.Marshal(stored)
+	if err != nil {
+		return "", fmt.Errorf("marshal runtime_hints: %w", err)
+	}
+	return string(b), nil
+}
+
+// runtimeHintsForStorage returns a value equivalent to h but with any embedded
+// HTTP bearer token encrypted for storage. The input is never mutated, so
+// callers keep operating on the live, plaintext token in memory. Returns h
+// unchanged when there is no token to protect.
+func (s *SQLiteStore) runtimeHintsForStorage(h *model.RuntimeHints) (*model.RuntimeHints, error) {
+	if h == nil || h.StagerOverrides == nil || h.StagerOverrides.HTTPCredential == nil {
+		return h, nil
+	}
+	if h.StagerOverrides.HTTPCredential.Token == "" {
+		return h, nil
+	}
+	enc, err := s.encryptToken(h.StagerOverrides.HTTPCredential.Token)
+	if err != nil {
+		return nil, err
+	}
+	// Copy only along the path we mutate; everything else is shared.
+	hc := *h
+	so := *h.StagerOverrides
+	cred := *h.StagerOverrides.HTTPCredential
+	cred.Token = enc
+	so.HTTPCredential = &cred
+	hc.StagerOverrides = &so
+	return &hc, nil
+}
+
+// revealRuntimeHints decrypts an embedded HTTP bearer token in freshly-scanned
+// task runtime hints, in place. Safe because each read produces a fresh object.
+func (s *SQLiteStore) revealRuntimeHints(h *model.RuntimeHints) error {
+	if h == nil || h.StagerOverrides == nil || h.StagerOverrides.HTTPCredential == nil {
+		return nil
+	}
+	cred := h.StagerOverrides.HTTPCredential
+	if cred.Token == "" {
+		return nil
+	}
+	pt, err := s.decryptToken(cred.Token)
+	if err != nil {
+		return err
+	}
+	cred.Token = pt
+	return nil
+}
+
+// ReencryptPlaintextTokens upgrades provider tokens that were written in
+// plaintext (before encryption was enabled) to ciphertext, in both
+// submissions.user_token and tasks.runtime_hints. It is a no-op when no cipher
+// is configured. Per-row failures are logged (never the token value) and
+// skipped so one bad row does not abort startup. Returns the number of
+// submission and task rows rewritten.
+func (s *SQLiteStore) ReencryptPlaintextTokens(ctx context.Context) (subs int, tasks int, err error) {
+	if s.cipher == nil {
+		return 0, 0, nil
+	}
+
+	type update struct{ id, val string }
+
+	// --- submissions.user_token ---
+	// Collect first, then write: with a single writer connection we must finish
+	// iterating before issuing UPDATEs.
+	var subUpdates []update
+	rows, err := s.db.QueryContext(ctx, `SELECT id, user_token FROM submissions WHERE user_token != ''`)
+	if err != nil {
+		return 0, 0, fmt.Errorf("scan submissions: %w", err)
+	}
+	for rows.Next() {
+		var id, tok string
+		if err := rows.Scan(&id, &tok); err != nil {
+			rows.Close()
+			return subs, tasks, fmt.Errorf("scan submission token: %w", err)
+		}
+		if tokencrypt.IsEncrypted(tok) {
+			continue
+		}
+		enc, encErr := s.cipher.Encrypt(tok)
+		if encErr != nil {
+			s.logger.Error("re-encrypt submission token", "id", id, "error", encErr)
+			continue
+		}
+		subUpdates = append(subUpdates, update{id, enc})
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return subs, tasks, err
+	}
+	for _, u := range subUpdates {
+		if _, err := s.db.ExecContext(ctx, `UPDATE submissions SET user_token=? WHERE id=?`, u.val, u.id); err != nil {
+			s.logger.Error("update submission token", "id", u.id, "error", err)
+			continue
+		}
+		subs++
+	}
+
+	// --- tasks.runtime_hints (embedded bearer token) ---
+	var taskUpdates []update
+	trows, err := s.db.QueryContext(ctx, `SELECT id, runtime_hints FROM tasks WHERE runtime_hints LIKE '%http_credential%'`)
+	if err != nil {
+		return subs, tasks, fmt.Errorf("scan tasks: %w", err)
+	}
+	for trows.Next() {
+		var id, hintsJSON string
+		if err := trows.Scan(&id, &hintsJSON); err != nil {
+			trows.Close()
+			return subs, tasks, fmt.Errorf("scan task hints: %w", err)
+		}
+		var h model.RuntimeHints
+		if err := json.Unmarshal([]byte(hintsJSON), &h); err != nil {
+			continue
+		}
+		if h.StagerOverrides == nil || h.StagerOverrides.HTTPCredential == nil {
+			continue
+		}
+		tok := h.StagerOverrides.HTTPCredential.Token
+		if tok == "" || tokencrypt.IsEncrypted(tok) {
+			continue
+		}
+		enc, encErr := s.cipher.Encrypt(tok)
+		if encErr != nil {
+			s.logger.Error("re-encrypt task token", "id", id, "error", encErr)
+			continue
+		}
+		h.StagerOverrides.HTTPCredential.Token = enc
+		nb, mErr := json.Marshal(&h)
+		if mErr != nil {
+			s.logger.Error("marshal re-encrypted task hints", "id", id, "error", mErr)
+			continue
+		}
+		taskUpdates = append(taskUpdates, update{id, string(nb)})
+	}
+	trows.Close()
+	if err := trows.Err(); err != nil {
+		return subs, tasks, err
+	}
+	for _, u := range taskUpdates {
+		if _, err := s.db.ExecContext(ctx, `UPDATE tasks SET runtime_hints=? WHERE id=?`, u.val, u.id); err != nil {
+			s.logger.Error("update task runtime_hints", "id", u.id, "error", err)
+			continue
+		}
+		tasks++
+	}
+
+	return subs, tasks, nil
+}

--- a/internal/store/tokens_test.go
+++ b/internal/store/tokens_test.go
@@ -1,0 +1,220 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/me/gowe/internal/tokencrypt"
+	"github.com/me/gowe/pkg/model"
+)
+
+func testTokenCipher(t *testing.T) *tokencrypt.Cipher {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i * 7)
+	}
+	c, err := tokencrypt.New(key)
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	return c
+}
+
+func tokenSubmission(id, token string) *model.Submission {
+	return &model.Submission{
+		ID:           id,
+		WorkflowID:   "wf_1",
+		WorkflowName: "wf",
+		State:        model.SubmissionStatePending,
+		Inputs:       map[string]any{},
+		UserToken:    token,
+		AuthProvider: "bvbrc",
+		CreatedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+}
+
+func tokenTask(id, token string) *model.Task {
+	return &model.Task{
+		ID:           id,
+		SubmissionID: "sub_1",
+		StepID:       "step",
+		State:        model.TaskStateQueued,
+		ExecutorType: model.ExecutorTypeWorker,
+		Inputs:       map[string]any{},
+		Outputs:      map[string]any{},
+		ScatterIndex: -1,
+		CreatedAt:    time.Now().UTC().Truncate(time.Second),
+		RuntimeHints: &model.RuntimeHints{
+			InjectBVBRCToken: true,
+			StagerOverrides: &model.StagerOverrides{
+				HTTPCredential: &model.HTTPCredential{Type: "bearer", Token: token},
+			},
+		},
+	}
+}
+
+func rawSubmissionToken(t *testing.T, st *SQLiteStore, id string) string {
+	t.Helper()
+	var tok string
+	if err := st.db.QueryRowContext(context.Background(),
+		`SELECT user_token FROM submissions WHERE id=?`, id).Scan(&tok); err != nil {
+		t.Fatalf("raw query submission token: %v", err)
+	}
+	return tok
+}
+
+func rawTaskHints(t *testing.T, st *SQLiteStore, id string) string {
+	t.Helper()
+	var h string
+	if err := st.db.QueryRowContext(context.Background(),
+		`SELECT runtime_hints FROM tasks WHERE id=?`, id).Scan(&h); err != nil {
+		t.Fatalf("raw query task hints: %v", err)
+	}
+	return h
+}
+
+func TestSubmissionTokenEncryptedAtRest(t *testing.T) {
+	st := testStore(t)
+	st.ConfigureTokenEncryption(testTokenCipher(t), true)
+	ctx := context.Background()
+
+	const secret = "bvbrc|un=me|SIG=deadbeef"
+	if err := st.CreateSubmission(ctx, tokenSubmission("sub_enc", secret)); err != nil {
+		t.Fatalf("create submission: %v", err)
+	}
+
+	raw := rawSubmissionToken(t, st, "sub_enc")
+	if !tokencrypt.IsEncrypted(raw) {
+		t.Fatalf("stored token is not encrypted: %q", raw)
+	}
+	if strings.Contains(raw, secret) {
+		t.Fatalf("stored token leaks plaintext: %q", raw)
+	}
+
+	got, err := st.GetSubmission(ctx, "sub_enc")
+	if err != nil {
+		t.Fatalf("get submission: %v", err)
+	}
+	if got.UserToken != secret {
+		t.Fatalf("decrypted token mismatch: got %q want %q", got.UserToken, secret)
+	}
+
+	// ListSubmissions must decrypt too.
+	subs, _, err := st.ListSubmissions(ctx, model.ListOptions{})
+	if err != nil {
+		t.Fatalf("list submissions: %v", err)
+	}
+	if len(subs) != 1 || subs[0].UserToken != secret {
+		t.Fatalf("list did not decrypt token: %+v", subs)
+	}
+}
+
+func TestSubmissionTokenFailClosedWithoutKey(t *testing.T) {
+	st := testStore(t)
+	st.ConfigureTokenEncryption(nil, true) // no cipher, refuse plaintext
+	ctx := context.Background()
+
+	if err := st.CreateSubmission(ctx, tokenSubmission("sub_fail", "a-token")); err == nil {
+		t.Fatal("expected fail-closed error persisting token without a key, got nil")
+	}
+	// A submission with no token must still succeed.
+	if err := st.CreateSubmission(ctx, tokenSubmission("sub_empty", "")); err != nil {
+		t.Fatalf("empty-token submission should succeed: %v", err)
+	}
+}
+
+func TestSubmissionTokenPlaintextAllowed(t *testing.T) {
+	st := testStore(t)
+	st.ConfigureTokenEncryption(nil, false) // legacy plaintext mode
+	ctx := context.Background()
+
+	if err := st.CreateSubmission(ctx, tokenSubmission("sub_plain", "plain-token")); err != nil {
+		t.Fatalf("create submission: %v", err)
+	}
+	if raw := rawSubmissionToken(t, st, "sub_plain"); raw != "plain-token" {
+		t.Fatalf("expected plaintext at rest, got %q", raw)
+	}
+}
+
+func TestTaskRuntimeHintsTokenEncryptedAtRest(t *testing.T) {
+	st := testStore(t)
+	st.ConfigureTokenEncryption(testTokenCipher(t), true)
+	ctx := context.Background()
+
+	const secret = "worker-bearer-token"
+	task := tokenTask("task_enc", secret)
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	// The caller's in-memory task must NOT be mutated to ciphertext.
+	if task.RuntimeHints.StagerOverrides.HTTPCredential.Token != secret {
+		t.Fatalf("CreateTask mutated in-memory token: %q", task.RuntimeHints.StagerOverrides.HTTPCredential.Token)
+	}
+
+	raw := rawTaskHints(t, st, "task_enc")
+	if strings.Contains(raw, secret) {
+		t.Fatalf("stored runtime_hints leaks plaintext token: %q", raw)
+	}
+	if !strings.Contains(raw, "enc:v1:") {
+		t.Fatalf("stored runtime_hints token not encrypted: %q", raw)
+	}
+
+	got, err := st.GetTask(ctx, "task_enc")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.RuntimeHints.StagerOverrides.HTTPCredential.Token != secret {
+		t.Fatalf("decrypted task token mismatch: got %q", got.RuntimeHints.StagerOverrides.HTTPCredential.Token)
+	}
+}
+
+func TestReencryptPlaintextTokens(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	// Write rows in legacy plaintext mode.
+	st.ConfigureTokenEncryption(nil, false)
+	if err := st.CreateSubmission(ctx, tokenSubmission("sub_mig", "legacy-sub-token")); err != nil {
+		t.Fatalf("create submission: %v", err)
+	}
+	if err := st.CreateTask(ctx, tokenTask("task_mig", "legacy-task-token")); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	// Enable encryption and migrate.
+	st.ConfigureTokenEncryption(testTokenCipher(t), true)
+	nSub, nTask, err := st.ReencryptPlaintextTokens(ctx)
+	if err != nil {
+		t.Fatalf("reencrypt: %v", err)
+	}
+	if nSub != 1 || nTask != 1 {
+		t.Fatalf("expected (1,1) rewritten, got (%d,%d)", nSub, nTask)
+	}
+
+	if raw := rawSubmissionToken(t, st, "sub_mig"); !tokencrypt.IsEncrypted(raw) {
+		t.Fatalf("submission token not upgraded: %q", raw)
+	}
+	if raw := rawTaskHints(t, st, "task_mig"); strings.Contains(raw, "legacy-task-token") {
+		t.Fatalf("task token not upgraded: %q", raw)
+	}
+
+	// Values still readable as plaintext.
+	sub, err := st.GetSubmission(ctx, "sub_mig")
+	if err != nil || sub.UserToken != "legacy-sub-token" {
+		t.Fatalf("submission not readable post-migration: %v / %q", err, sub.UserToken)
+	}
+	task, err := st.GetTask(ctx, "task_mig")
+	if err != nil || task.RuntimeHints.StagerOverrides.HTTPCredential.Token != "legacy-task-token" {
+		t.Fatalf("task not readable post-migration: %v", err)
+	}
+
+	// Idempotent: a second pass rewrites nothing.
+	nSub2, nTask2, err := st.ReencryptPlaintextTokens(ctx)
+	if err != nil || nSub2 != 0 || nTask2 != 0 {
+		t.Fatalf("second migration not idempotent: (%d,%d) err=%v", nSub2, nTask2, err)
+	}
+}

--- a/internal/tokencrypt/tokencrypt.go
+++ b/internal/tokencrypt/tokencrypt.go
@@ -1,0 +1,141 @@
+// Package tokencrypt provides authenticated envelope encryption for short
+// secrets — specifically the provider (BV-BRC / MG-RAST) tokens GoWe must
+// persist so it can later run delegated jobs under the submitter's identity.
+//
+// Values are encrypted with AES-256-GCM under a single server-held key and
+// stored as a self-describing string:
+//
+//	enc:v1:<base64(nonce || ciphertext || tag)>
+//
+// The marker prefix lets readers distinguish ciphertext from legacy plaintext
+// rows written before encryption was enabled, so an operator can turn the key
+// on without a hard cutover: unmarked values pass through unchanged until they
+// are re-encrypted.
+package tokencrypt
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// EnvKeyVar is the environment variable that carries the encryption key,
+// encoded as base64 (standard or raw) or hex and decoding to exactly 32 bytes.
+const EnvKeyVar = "GOWE_TOKEN_KEY"
+
+// marker prefixes an encrypted value. The version segment allows the on-disk
+// format to evolve without ambiguity.
+const marker = "enc:v1:"
+
+// keyLen is the AES-256 key length in bytes.
+const keyLen = 32
+
+// Cipher encrypts and decrypts short secrets with AES-256-GCM. It is safe for
+// concurrent use. The zero value is not usable; construct one with New.
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+// New constructs a Cipher from a 32-byte key (AES-256).
+func New(key []byte) (*Cipher, error) {
+	if len(key) != keyLen {
+		return nil, fmt.Errorf("tokencrypt: key must be %d bytes for AES-256, got %d", keyLen, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("tokencrypt: new cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("tokencrypt: new gcm: %w", err)
+	}
+	return &Cipher{aead: aead}, nil
+}
+
+// DecodeKey decodes a key that is base64 (standard or raw-standard) or hex and
+// must yield exactly 32 bytes. It is used by config/env loaders.
+func DecodeKey(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, errors.New("tokencrypt: empty key")
+	}
+	if b, err := base64.StdEncoding.DecodeString(s); err == nil && len(b) == keyLen {
+		return b, nil
+	}
+	if b, err := base64.RawStdEncoding.DecodeString(s); err == nil && len(b) == keyLen {
+		return b, nil
+	}
+	if b, err := hex.DecodeString(s); err == nil && len(b) == keyLen {
+		return b, nil
+	}
+	return nil, fmt.Errorf("tokencrypt: key must decode (base64 or hex) to %d bytes", keyLen)
+}
+
+// FromEnv builds a Cipher from EnvKeyVar. It returns (nil, nil) when the
+// variable is unset or blank so callers can treat encryption as optional; a
+// set-but-invalid key is a hard error (fail loudly on misconfiguration).
+func FromEnv() (*Cipher, error) {
+	raw := os.Getenv(EnvKeyVar)
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	key, err := DecodeKey(raw)
+	if err != nil {
+		return nil, err
+	}
+	return New(key)
+}
+
+// IsEncrypted reports whether v was produced by Encrypt (has the marker prefix).
+func IsEncrypted(v string) bool {
+	return strings.HasPrefix(v, marker)
+}
+
+// Encrypt returns a marked, authenticated ciphertext for plaintext. Empty input
+// returns empty output (there is nothing to protect). Each call draws a fresh
+// random nonce, so encrypting the same token twice yields different ciphertexts.
+func (c *Cipher) Encrypt(plaintext string) (string, error) {
+	if plaintext == "" {
+		return "", nil
+	}
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("tokencrypt: read nonce: %w", err)
+	}
+	sealed := c.aead.Seal(nonce, nonce, []byte(plaintext), nil)
+	return marker + base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+// Decrypt reverses Encrypt. A value without the marker is treated as legacy
+// plaintext and returned unchanged, so rows written before encryption was
+// enabled keep working until they are re-encrypted. Empty input returns empty.
+// A marked-but-corrupt or wrong-key value returns an error.
+func (c *Cipher) Decrypt(v string) (string, error) {
+	if v == "" {
+		return "", nil
+	}
+	if !IsEncrypted(v) {
+		return v, nil // legacy plaintext passthrough
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(v, marker))
+	if err != nil {
+		return "", fmt.Errorf("tokencrypt: decode ciphertext: %w", err)
+	}
+	ns := c.aead.NonceSize()
+	if len(raw) < ns {
+		return "", errors.New("tokencrypt: ciphertext too short")
+	}
+	nonce, ct := raw[:ns], raw[ns:]
+	pt, err := c.aead.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return "", fmt.Errorf("tokencrypt: authenticate/decrypt: %w", err)
+	}
+	return string(pt), nil
+}

--- a/internal/tokencrypt/tokencrypt_test.go
+++ b/internal/tokencrypt/tokencrypt_test.go
@@ -1,0 +1,155 @@
+package tokencrypt
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func testCipher(t *testing.T) *Cipher {
+	t.Helper()
+	key := make([]byte, keyLen)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	c, err := New(key)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestNewRejectsBadKeyLength(t *testing.T) {
+	for _, n := range []int{0, 16, 31, 33, 64} {
+		if _, err := New(make([]byte, n)); err == nil {
+			t.Errorf("New(%d-byte key): expected error, got nil", n)
+		}
+	}
+}
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	c := testCipher(t)
+	for _, pt := range []string{"a", "bvbrc|token|expiry=123|sig=abc", strings.Repeat("x", 4096)} {
+		enc, err := c.Encrypt(pt)
+		if err != nil {
+			t.Fatalf("Encrypt: %v", err)
+		}
+		if !IsEncrypted(enc) {
+			t.Fatalf("ciphertext missing marker: %q", enc)
+		}
+		if strings.Contains(enc, pt) {
+			t.Fatalf("ciphertext leaks plaintext: %q", enc)
+		}
+		got, err := c.Decrypt(enc)
+		if err != nil {
+			t.Fatalf("Decrypt: %v", err)
+		}
+		if got != pt {
+			t.Fatalf("round-trip mismatch: got %q want %q", got, pt)
+		}
+	}
+}
+
+func TestEmptyIsNoop(t *testing.T) {
+	c := testCipher(t)
+	enc, err := c.Encrypt("")
+	if err != nil || enc != "" {
+		t.Fatalf("Encrypt(\"\") = %q, %v; want \"\", nil", enc, err)
+	}
+	dec, err := c.Decrypt("")
+	if err != nil || dec != "" {
+		t.Fatalf("Decrypt(\"\") = %q, %v; want \"\", nil", dec, err)
+	}
+}
+
+func TestNonceIsRandomised(t *testing.T) {
+	c := testCipher(t)
+	a, _ := c.Encrypt("same-secret")
+	b, _ := c.Encrypt("same-secret")
+	if a == b {
+		t.Fatalf("expected distinct ciphertexts for repeated Encrypt, got identical: %q", a)
+	}
+}
+
+func TestDecryptLegacyPlaintextPassthrough(t *testing.T) {
+	c := testCipher(t)
+	// A value without the marker is a pre-encryption row; return it unchanged.
+	got, err := c.Decrypt("legacy-plain-token")
+	if err != nil {
+		t.Fatalf("Decrypt(plaintext): %v", err)
+	}
+	if got != "legacy-plain-token" {
+		t.Fatalf("passthrough mismatch: got %q", got)
+	}
+}
+
+func TestDecryptWrongKeyFails(t *testing.T) {
+	c := testCipher(t)
+	enc, _ := c.Encrypt("secret")
+
+	other, err := New([]byte("0123456789abcdef0123456789abcdef")) // 32 bytes, different key
+	if err != nil {
+		t.Fatalf("New other: %v", err)
+	}
+	if _, err := other.Decrypt(enc); err == nil {
+		t.Fatal("Decrypt with wrong key: expected error, got nil")
+	}
+}
+
+func TestDecryptTamperedFails(t *testing.T) {
+	c := testCipher(t)
+	enc, _ := c.Encrypt("secret")
+	raw, _ := base64.StdEncoding.DecodeString(strings.TrimPrefix(enc, marker))
+	raw[len(raw)-1] ^= 0xFF // flip a tag bit
+	tampered := marker + base64.StdEncoding.EncodeToString(raw)
+	if _, err := c.Decrypt(tampered); err == nil {
+		t.Fatal("Decrypt of tampered ciphertext: expected error, got nil")
+	}
+}
+
+func TestDecodeKey(t *testing.T) {
+	key := make([]byte, keyLen)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	cases := []string{
+		base64.StdEncoding.EncodeToString(key),
+		base64.RawStdEncoding.EncodeToString(key),
+		hex.EncodeToString(key),
+	}
+	for _, enc := range cases {
+		got, err := DecodeKey(enc)
+		if err != nil {
+			t.Fatalf("DecodeKey(%q): %v", enc, err)
+		}
+		if string(got) != string(key) {
+			t.Fatalf("DecodeKey(%q) mismatch", enc)
+		}
+	}
+	for _, bad := range []string{"", "short", hex.EncodeToString(make([]byte, 16))} {
+		if _, err := DecodeKey(bad); err == nil {
+			t.Errorf("DecodeKey(%q): expected error", bad)
+		}
+	}
+}
+
+func TestFromEnv(t *testing.T) {
+	t.Setenv(EnvKeyVar, "")
+	c, err := FromEnv()
+	if err != nil || c != nil {
+		t.Fatalf("FromEnv unset: got (%v, %v); want (nil, nil)", c, err)
+	}
+
+	key := make([]byte, keyLen)
+	t.Setenv(EnvKeyVar, base64.StdEncoding.EncodeToString(key))
+	c, err = FromEnv()
+	if err != nil || c == nil {
+		t.Fatalf("FromEnv valid: got (%v, %v); want cipher, nil", c, err)
+	}
+
+	t.Setenv(EnvKeyVar, "not-a-valid-key")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv invalid: expected error, got nil")
+	}
+}

--- a/scripts/run-conformance-server-local.sh
+++ b/scripts/run-conformance-server-local.sh
@@ -164,6 +164,13 @@ fi
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
 
+# Provider-token encryption key. Since #138 the server fails closed on a
+# token-carrying submission when no key is set; the conformance CLI forwards a
+# real provider token from the environment, so a key is required. Fixed
+# throwaway key over a disposable test DB — never a real secret. Also exercises
+# the at-rest encryption round-trip.
+export GOWE_TOKEN_KEY="$(printf '%s' 'gowe-conformance-test-key-32byte' | base64)"
+
 # Start server with local executor and fast polling for tests
 log_info "Starting server with local executor..."
 ./bin/gowe-server \

--- a/scripts/run-conformance-server-worker.sh
+++ b/scripts/run-conformance-server-worker.sh
@@ -172,6 +172,14 @@ done
 
 # --- Start server ---
 
+# Provider-token encryption key. Since #138 the server fails closed on a
+# token-carrying submission when no key is set; the conformance CLI forwards a
+# real provider token from the environment, so a key is required. Fixed
+# throwaway key over a disposable test DB — never a real secret. Also exercises
+# the at-rest encryption round-trip. Workers execute the plaintext token in
+# memory; only the DB column is encrypted.
+export GOWE_TOKEN_KEY="$(printf '%s' 'gowe-conformance-test-key-32byte' | base64)"
+
 log_info "Starting server..."
 ./bin/gowe-server \
     --addr ":${PORT}" \

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -75,11 +75,32 @@ if [[ -f "$LOG_DIR/server.log" ]]; then
     mv "$LOG_DIR/server.log" "$LOG_DIR/server.log.$(date +%Y%m%d-%H%M%S)"
 fi
 
+# Provider-token encryption key (GH #138). The server fails closed on a
+# token-carrying submission when no key is configured, so real BV-BRC
+# submissions require one. Generate a persistent 32-byte key on first run and
+# reuse it thereafter so tokens encrypted earlier stay decryptable across
+# restarts. Keep this file secret. Set ALLOW_PLAINTEXT_TOKENS=1 to opt out and
+# store tokens in the clear instead (not recommended).
+TOKEN_KEY_FILE="${TOKEN_KEY_FILE:-$BASE_DIR/gowe/token.key}"
+TOKEN_FLAGS=()
+if [[ "${ALLOW_PLAINTEXT_TOKENS:-0}" == "1" ]]; then
+    TOKEN_FLAGS=(--allow-plaintext-tokens)
+    echo "  WARNING: provider tokens will be stored in PLAINTEXT (ALLOW_PLAINTEXT_TOKENS=1)"
+else
+    if [[ ! -s "$TOKEN_KEY_FILE" ]]; then
+        ( umask 077; head -c 32 /dev/urandom | base64 > "$TOKEN_KEY_FILE" )
+        echo "  generated token-encryption key: $TOKEN_KEY_FILE"
+    fi
+    chmod 600 "$TOKEN_KEY_FILE" 2>/dev/null || true
+    TOKEN_FLAGS=(--token-key-file "$TOKEN_KEY_FILE")
+fi
+
 ./bin/gowe-server \
     --addr ":${GOWE_PORT}" \
     --db "$DB_PATH" \
     --default-executor worker \
     "${ANON_FLAGS[@]}" \
+    "${TOKEN_FLAGS[@]}" \
     --scheduler-poll "$SCHEDULER_POLL" \
     --upload-backend local \
     --upload-local-dir "$UPLOAD_DIR" \


### PR DESCRIPTION
## Problem

The submitter's BV-BRC/MG-RAST provider token was persisted **in plaintext** in the SQLite store, so a leaked DB file exposed users' provider credentials. This is the caveat documented in `SPECIFICATION.md` §13.5/§13.7 and ADR-0009 (from #135).

The token actually lives in **two** at-rest locations:
- `submissions.user_token`
- the bearer credential inside `tasks.runtime_hints`, once `scheduler.addUserToken` injects it before `CreateTask`

Encrypting only the submissions column would have left a second plaintext copy, so this change covers both.

## Approach

Envelope encryption (AES-256-GCM) confined to the store boundary. In-memory `Submission`/`Task` values and the worker API payload stay plaintext, so the delegated-execution path (local executor + worker `BVBRC_TOKEN` injection) is unchanged — only the DB columns hold ciphertext (self-describing `enc:v1:` marker, random per-value nonce).

- **`internal/tokencrypt`** — AES-256-GCM cipher: `Encrypt`/`Decrypt` (legacy-plaintext passthrough), `DecodeKey` (base64/hex → 32 bytes), `FromEnv`.
- **`internal/store`** — encrypt on write (`CreateSubmission`, `Create`/`UpdateTask`), decrypt on read (`GetSubmission`, `ListSubmissions`, `scanTask`, `scanTasks`, worker checkout). Copy-on-write for the nested task credential so the live token is never mutated. `ReencryptPlaintextTokens` upgrades existing plaintext rows on startup.
- **`cmd/server`** — key from `GOWE_TOKEN_KEY` or `--token-key-file`; **fails closed** by default (refuses to persist a delegated token with no key) unless `--allow-plaintext-tokens`. Token is never logged.

## Behavior change

⚠️ With **no key configured**, authenticated submissions that carry a provider token are now **rejected** unless `GOWE_TOKEN_KEY` (or `--token-key-file`) is set, or `--allow-plaintext-tokens` is passed. This is the intended fail-closed posture but is an operational change for existing deployments.

## Tests

- `tokencrypt`: round-trip, wrong-key/tamper rejection, nonce randomness, key decoding, `FromEnv`.
- `store`: encrypted-at-rest for both columns, fail-closed, plaintext mode, idempotent migration, no in-memory mutation.
- `scheduler`: encrypt → decrypt-on-read → delegated-injection round-trip.

## Docs

- `SPECIFICATION.md` §13.5 — new normative "tokens MUST be encrypted at rest" requirement; §13.7 — plaintext caveat **dropped**.
- ADR-0009, `docs/STATUS.md`, `docs/PRODUCTION.md` (key generation + operator behavior) updated.

## Notes

- Based on `docs/architecture-spec-adrs` (#135) so the §13.7 caveat-drop applies on its documented baseline.
- `internal/worker` has a pre-existing macOS-only build issue (`syscall.Sysinfo` is Linux-only) unrelated to this change; the tree cross-compiles clean for linux and all other packages test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)