### PR TITLE
feat(security): per-worker keys — issuance, revocation, hashed-at-rest

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # GoWe Specification
 
-> **Status**: Living specification · **Version**: draft-5 (2026-07-06)
+> **Status**: Living specification · **Version**: draft-6 (2026-07-06)
 > **Applies to**: GoWe server, worker, CLI, and `cwl-runner`
 > **Companion documents**: [`docs/adr/`](docs/adr/) (why), [`docs/cwl-hints.md`](docs/cwl-hints.md)
 > (hint reference), [`docs/GoWe-Vocabulary.md`](docs/GoWe-Vocabulary.md) (concepts),
@@ -469,7 +469,7 @@ external providers — GoWe stores no user passwords. Rationale for the auth mod
 |--------|--------------|---------------------|------------|
 | User token | `Authorization: Bearer <token>` or `X-MG-RAST-Token` | Provider-issued pipe-delimited token: non-empty username and unexpired `expiry` | User/API endpoints |
 | Anonymous | *(no token)* + server `--allow-anonymous` | Nothing; request runs as the anonymous user | User/API endpoints, if enabled |
-| Worker key | `X-Worker-Key` | Key present in the configured key set; yields allowed groups | Worker endpoints |
+| Worker key | `X-Worker-Key` | Key is present, enabled, and unexpired; yields allowed groups | Worker endpoints |
 
 - When a token is presented, the server MUST reject it if the username is empty or the token
   is expired (`401`).
@@ -477,8 +477,17 @@ external providers — GoWe stores no user passwords. Rationale for the auth mod
   user account keyed by `(username, provider)`.
 - When no user keys/tokens apply and anonymous access is disabled, protected endpoints MUST
   return `401`.
-- Worker-key enforcement is **optional**: if no keys are configured, worker endpoints are
-  open. Operators SHOULD configure keys in any multi-tenant or networked deployment.
+- Worker keys come in two forms, and the server MUST accept either: **per-worker keys** minted
+  and revoked through the admin API (§13.4), and **static keys** configured from a file or the
+  `GOWE_WORKER_KEYS` env var. Each key maps to a set of allowed groups; an empty set means any
+  group.
+- A worker key MUST be rejected (`401`) if it is disabled/revoked or past its `expires_at`.
+  Per-worker keys are independently issuable and revocable, so revoking one MUST NOT affect any
+  other key.
+- Worker-key enforcement is **optional**: if no keys are configured at all — neither static nor
+  per-worker — worker endpoints are open. Operators SHOULD configure keys in any multi-tenant
+  or networked deployment. If a store error prevents determining whether keys exist, the server
+  MUST fail closed (enforce authentication).
 
 ### 13.4 Authorization and roles
 
@@ -495,6 +504,11 @@ external providers — GoWe stores no user passwords. Rationale for the auth mod
 - Worker secrets are loaded from `--secret`/`--secret-file` into worker memory. Secret
   **names** MAY be logged; secret **values** MUST NOT be logged.
 - The `X-Worker-Key` MUST NOT be logged in the clear; only a hash of it MAY be logged.
+- Per-worker keys MUST be stored hashed at rest: the server persists only the SHA-256 hash of
+  each key, never the raw secret. The raw key is returned to the operator exactly once at
+  issuance and is not retrievable thereafter. A non-secret key prefix and a stable key ID MAY
+  be stored and logged for attribution. Static keys MAY likewise be provided pre-hashed
+  (`sha256:<hex>`) so the raw secret need not reside in config.
 - A BV-BRC token MAY be injected into a task's container as `BVBRC_TOKEN` when, and only when,
   `gowe:Execution.inject_bvbrc_token` is set (or a workspace stager requires it); the injected
   token is the submitter's own, so the job runs under the user's identity. This opt-in gate is
@@ -542,8 +556,12 @@ These are current-state gaps, not normative requirements. They are documented so
 can compensate and so the project can track hardening. Each SHOULD be addressed before a
 security-sensitive production deployment:
 
-- **Worker keys are shared secrets.** Keys are stored plaintext in config/env with no
-  per-worker identity or rotation; a leaked key affects every worker sharing it.
+- **Static worker keys remain plaintext in config.** The recommended path — per-worker keys
+  minted via the admin API (§13.3–§13.4) — gives each worker an individually revocable identity
+  and is **hashed at rest** (§13.5), so a leaked worker's key can be rotated without disrupting
+  the fleet. The legacy static key set (`--worker-keys` / `GOWE_WORKER_KEYS`) is retained for
+  bootstrap and dev; entries stored as raw secrets sit plaintext in config (use `sha256:` hash
+  entries, or prefer per-worker keys, to avoid this).
 - **Anonymous mode widens exposure.** If `--allow-anonymous` is enabled, always scope it with
   `--anonymous-executors`.
 
@@ -552,6 +570,11 @@ security-sensitive production deployment:
 > are marked `Secure` when the connection is HTTPS (see §13.6). Operators MUST still choose one
 > of the two transport-security modes for production; the capability exists but is not
 > automatic on a plain-HTTP listener.
+
+> **Resolved (was a limitation):** Shared worker keys now have a revocable alternative.
+> Per-worker keys minted via the admin API carry an individual identity, are hashed at rest,
+> and can be revoked without disrupting the rest of the fleet (see §13.3–§13.5). The legacy
+> static key set is retained only for bootstrap/dev.
 
 ---
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -248,7 +248,13 @@ func main() {
 	}
 
 	// Configure worker key authentication.
-	workerKeyConfig := server.LoadWorkerKeyConfig(*workerKeyFile)
+	workerKeyConfig, err := server.LoadWorkerKeyConfig(*workerKeyFile)
+	if err != nil {
+		// Fail closed: a configured key source we cannot load would otherwise
+		// silently leave worker auth open. Refuse to start instead.
+		fmt.Fprintf(os.Stderr, "worker key configuration: %v\n", err)
+		os.Exit(1)
+	}
 	if workerKeyConfig.IsEnabled() {
 		serverOpts = append(serverOpts, server.WithWorkerKeyConfig(workerKeyConfig))
 		logger.Info("worker key authentication enabled", "keys", len(workerKeyConfig.Keys))

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -28,7 +28,7 @@ func main() {
 	flag.StringVar(&cfg.ServerURL, "server", "http://localhost:8080", "GoWe server URL")
 	flag.StringVar(&cfg.Name, "name", "", "Worker name (default: hostname)")
 	flag.StringVar(&cfg.Group, "group", "default", "Worker group for task scheduling")
-	flag.StringVar(&cfg.WorkerKey, "worker-key", "", "Shared secret for worker authentication")
+	flag.StringVar(&cfg.WorkerKey, "worker-key", "", "Worker authentication key sent as X-Worker-Key (a per-worker key issued by an admin, or a shared static key)")
 	flag.StringVar(&cfg.Runtime, "runtime", "none", "Container runtime(s), comma-separated (docker, apptainer, none)")
 	flag.StringVar(&cfg.WorkDir, "workdir", "", "Local working directory (default: $TMPDIR/gowe-worker)")
 	flag.StringVar(&cfg.StageOut, "stage-out", "local", "Output staging mode (local, file:///path, http://..., s3://bucket, shock://host)")

--- a/docs/adr/0009-delegated-identity-and-optional-worker-keys.md
+++ b/docs/adr/0009-delegated-identity-and-optional-worker-keys.md
@@ -26,9 +26,11 @@ authenticate, and how do workers authenticate.
   `anonymous`; admin membership comes from config (stored role, `--admins`, `GOWE_ADMINS`,
   config file). Anonymous access is **opt-in** (`--allow-anonymous`) and MUST be scoped by
   `--anonymous-executors`.
-- **Workers** authenticate with an **optional** shared `X-Worker-Key` that maps to a set of
-  allowed groups; if no keys are configured, worker endpoints are open. The key is never
-  logged in the clear (hash only).
+- **Workers** authenticate with an **optional** `X-Worker-Key` that maps to a set of allowed
+  groups; if no keys are configured, worker endpoints are open. The key is never logged in the
+  clear (hash only). Keys come in two forms: **per-worker keys** minted and revoked through the
+  admin API, stored **hashed at rest** and individually attributable/expirable; and legacy
+  **static keys** from a file/env, retained for bootstrap and dev.
 - **Delegation**: when `gowe:Execution.inject_bvbrc_token` is set, the submitter's own token
   is injected into the task container as `BVBRC_TOKEN`, so downstream BV-BRC work runs under
   the user's identity.
@@ -45,14 +47,15 @@ authenticate, and how do workers authenticate.
 - Trust is only as strong as the provider token and our validation: GoWe **parses** the token
   for username/expiry but does not cryptographically verify a provider signature, so it relies
   on transport security and provider issuance.
-- The shared worker key is coarse — no per-worker identity, no rotation; a leaked key affects
-  every worker that shares it.
+- The legacy *static* worker key is coarse — no per-worker identity, no rotation, plaintext in
+  config. This is now mitigated by per-worker keys (issue/revoke via the admin API, hashed at
+  rest, optional expiry), which are the recommended path; the static key set remains only for
+  bootstrap/dev. See `SPECIFICATION.md` §13.3–§13.5 and `docs/tools/worker.md`.
 - Delegation requires carrying and storing the user's token. This is now **encrypted at rest**
   (AES-256-GCM under a server-held `GOWE_TOKEN_KEY`) in both `submissions.user_token` and the
   bearer credential embedded in `tasks.runtime_hints`; with no key the server fails closed on
-  delegated submissions unless `--allow-plaintext-tokens` is set. The remaining shared-worker-key
-  and transport items above are tracked as hardening work; see
-  [`SPECIFICATION.md`](../../SPECIFICATION.md) §13.5–§13.7.
+  delegated submissions unless `--allow-plaintext-tokens` is set. The remaining transport item
+  above is tracked as hardening work; see [`SPECIFICATION.md`](../../SPECIFICATION.md) §13.5–§13.7.
 
 **Neutral**
 - Anonymous mode exists as a convenience for local/dev use; it is off by default and executor-scoped.
@@ -70,5 +73,5 @@ authenticate, and how do workers authenticate.
 
 ## References
 
-- Code: `internal/server/auth.go`, `internal/server/worker_auth.go`, `internal/server/admin_config.go`, `pkg/model/user.go`, `internal/worker/worker.go`, `internal/executor/bvbrc.go`
+- Code: `internal/server/auth.go`, `internal/server/worker_auth.go`, `internal/server/handler_worker_keys.go`, `internal/server/admin_config.go`, `internal/store/worker_keys.go`, `pkg/model/user.go`, `pkg/model/worker_key.go`, `internal/worker/worker.go`, `internal/executor/bvbrc.go`
 - Docs: [`SPECIFICATION.md`](../../SPECIFICATION.md) §13

--- a/docs/tools/server.md
+++ b/docs/tools/server.md
@@ -231,19 +231,27 @@ Token sources (checked in order):
 
 ### Worker Authentication
 
-Workers authenticate using shared secrets and can belong to groups:
+Workers authenticate by sending an `X-Worker-Key` header. The server validates it against two sources; if **neither** has any key, worker endpoints are open (dev convenience — production SHOULD configure keys).
+
+**1. Per-worker keys (recommended, hashed at rest).** Minted and revoked through the admin API (see [Admin](#admin) below). Only the SHA-256 hash of each key is stored, so the datastore never holds the raw secret, and one leaked worker's key can be revoked without disrupting the fleet.
+
+**2. Static keys (file/env, for bootstrap or dev).** A key set can also be configured statically and mapped to allowed groups:
 
 ```json
 // ~/.gowe/worker-keys.json
 {
   "keys": {
     "secret-key-1": {
+      "id": "gpu-cluster",
       "groups": ["default", "gpu-workers"],
       "description": "Production GPU cluster"
     },
-    "secret-key-2": {
+    "sha256:9f86d0818...": {
+      "id": "cpu-workers",
       "groups": ["cpu-workers"],
-      "description": "CPU-only workers"
+      "description": "Stored as a hash instead of the raw secret",
+      "disabled": false,
+      "expires_at": "2026-12-31T00:00:00Z"
     }
   }
 }
@@ -251,9 +259,10 @@ Workers authenticate using shared secrets and can belong to groups:
 
 ```bash
 gowe-server --worker-keys ~/.gowe/worker-keys.json
+# or: GOWE_WORKER_KEYS='{"secret-key-1":["default"]}' gowe-server
 ```
 
-Workers send `X-Worker-Key` header on registration. Tasks can target specific groups via `RuntimeHints.WorkerGroup`.
+Each static entry may carry an `id` (logged for attribution — the raw key is never logged), and optional `disabled` / `expires_at` lifecycle fields. A map key prefixed with `sha256:` is treated as an already-hashed key, so the raw secret need not live in the config file. Tasks target specific groups via `RuntimeHints.WorkerGroup`.
 
 ### Scheduler
 
@@ -868,6 +877,63 @@ curl -X PUT http://localhost:8080/api/v1/admin/users/user@bvbrc/role \
   -H "Authorization: $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"role": "admin"}'
+```
+
+#### `POST /api/v1/admin/worker-keys`
+
+Mint a per-worker key. The raw secret is returned **exactly once**; only its SHA-256 hash is persisted. `groups` scopes which worker groups the key may join (empty = any); `expires_at` is optional.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/admin/worker-keys \
+  -H "Authorization: $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  -d '{"label":"gpu-node-01","groups":["esmfold"],"description":"A100 box","expires_at":"2026-12-31T00:00:00Z"}'
+```
+
+Response (201) — save `key` now, it cannot be retrieved again:
+
+```json
+{
+  "key": "gwk_o4Zk...redacted...",
+  "worker_key": {
+    "id": "wk_1f2e...",
+    "label": "gpu-node-01",
+    "key_prefix": "gwk_o4Zk8Q",
+    "groups": ["esmfold"],
+    "disabled": false,
+    "created_by": "awilke@bvbrc",
+    "created_at": "2026-07-06T12:00:00Z",
+    "expires_at": "2026-12-31T00:00:00Z"
+  },
+  "warning": "store this key now; it cannot be retrieved again"
+}
+```
+
+#### `GET /api/v1/admin/worker-keys`
+
+List all worker keys. Key hashes and raw secrets are never returned — only metadata and the non-secret `key_prefix`.
+
+```bash
+curl http://localhost:8080/api/v1/admin/worker-keys -H "Authorization: $ADMIN_TOKEN"
+```
+
+#### `PATCH /api/v1/admin/worker-keys/{id}`
+
+Enable/disable or edit a key. Disabling is the **reversible** form of revocation. Any subset of fields may be sent; `clear_expiry: true` removes an expiry.
+
+```bash
+# Disable a key without deleting it
+curl -X PATCH http://localhost:8080/api/v1/admin/worker-keys/wk_1f2e... \
+  -H "Authorization: $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  -d '{"disabled": true}'
+```
+
+#### `DELETE /api/v1/admin/worker-keys/{id}`
+
+Permanently revoke (delete) a key. Use this for a compromised worker — other workers' keys are unaffected.
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/admin/worker-keys/wk_1f2e... \
+  -H "Authorization: $ADMIN_TOKEN"
 ```
 
 ## Graceful Shutdown

--- a/docs/tools/worker.md
+++ b/docs/tools/worker.md
@@ -33,7 +33,7 @@ gowe-worker [flags]
 | `--server` | `http://localhost:8080` | GoWe server URL |
 | `--name` | hostname | Worker name for identification |
 | `--group` | `default` | Worker group for targeted scheduling |
-| `--worker-key` | `""` | Shared secret for authentication |
+| `--worker-key` | `""` | Authentication key sent as `X-Worker-Key` — a per-worker key issued by an admin, or a shared static key |
 | `--runtime` | `none` | Container runtime(s), comma-separated: docker, apptainer, none |
 | `--workdir` | `$TMPDIR/gowe-worker` | Local working directory for task execution |
 | `--stage-out` | `local` | Output staging mode (local, file://, http://, https://) |
@@ -237,6 +237,53 @@ gowe-worker \
 
 The server validates worker keys against its configuration (see server.md). Tasks can target specific groups, and workers only receive tasks matching their group.
 
+### Worker keys
+
+A worker authenticates by sending its key in the `X-Worker-Key` header (via `--worker-key`). GoWe supports two kinds of keys, and validates against both:
+
+| Kind | Source | Lifecycle | At-rest storage |
+|------|--------|-----------|-----------------|
+| **Per-worker key** (recommended) | Minted by an admin through the API and handed to one worker | Individually issued, disabled, expired, and revoked without touching other workers | Only the SHA-256 **hash** is stored; the raw secret is shown once at issuance |
+| **Static key** | `--worker-keys` JSON file or `GOWE_WORKER_KEYS` env on the server | Edited by changing the config and restarting | Plaintext in config, unless stored as a `sha256:<hex>` hash entry |
+
+Per-worker keys are the hardened path: because each worker holds a distinct, individually-revocable secret, a single compromised worker can be rotated out (`DELETE`) without disrupting the fleet.
+
+**Issuing a key (admin):**
+
+```bash
+# Mint a key scoped to the "esmfold" group. The raw key is returned ONCE.
+curl -s -X POST http://gowe-server:8080/api/v1/admin/worker-keys \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"label":"gpu-node-01","groups":["esmfold"],"description":"A100 box","expires_at":"2026-12-31T00:00:00Z"}'
+# => {"data":{"key":"gwk_XXXXXXXX...","worker_key":{"id":"wk_...","key_prefix":"gwk_XXXXXX",...}}}
+```
+
+Hand the returned `key` to exactly one worker:
+
+```bash
+gowe-worker --server http://gowe-server:8080 --group esmfold --worker-key "gwk_XXXXXXXX..."
+```
+
+**Managing keys (admin):**
+
+```bash
+# List keys (hashes and raw secrets are never returned)
+curl -H "Authorization: Bearer $ADMIN_TOKEN" http://gowe-server:8080/api/v1/admin/worker-keys
+
+# Temporarily disable a key (reversible)
+curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  -d '{"disabled":true}' http://gowe-server:8080/api/v1/admin/worker-keys/wk_...
+
+# Permanently revoke a leaked key (irreversible)
+curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+  http://gowe-server:8080/api/v1/admin/worker-keys/wk_...
+```
+
+If a worker's key is revoked or expires, its next poll/heartbeat is rejected with `401`; the server's reaper eventually marks it offline and requeues its in-flight tasks.
+
+**Open access for dev:** if no keys are configured at all (no static config **and** no minted keys), worker endpoints are open. This is convenient for local/dev but production deployments SHOULD configure keys (see `SPECIFICATION.md` §13.3).
+
 ### GPU-enabled workers
 
 Enable GPU support for containerized workloads:
@@ -409,7 +456,7 @@ When the worker starts, it registers with the server:
 3. Receives a worker ID from the server
 4. Begins polling for tasks
 
-If `--worker-key` is provided, the worker sends it in the `X-Worker-Key` header.
+If `--worker-key` is provided, the worker sends it in the `X-Worker-Key` header. The server validates it against per-worker keys (hashed at rest) and static keys; see [Worker keys](#worker-keys).
 
 ### Task Lifecycle
 

--- a/internal/server/handler_worker_keys.go
+++ b/internal/server/handler_worker_keys.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/me/gowe/pkg/model"
+)
+
+// createWorkerKeyRequest is the body for minting a new worker key.
+type createWorkerKeyRequest struct {
+	Label       string     `json:"label"`
+	Groups      []string   `json:"groups"`
+	Description string     `json:"description"`
+	ExpiresAt   *time.Time `json:"expires_at"`
+}
+
+// handleCreateWorkerKey mints a new per-worker key. The raw secret is returned
+// exactly once in the response; only its hash is persisted.
+// POST /api/v1/admin/worker-keys
+func (s *Server) handleCreateWorkerKey(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+
+	var req createWorkerKeyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, reqID, http.StatusBadRequest, &model.APIError{
+			Code:    model.ErrValidation,
+			Message: "invalid JSON body: " + err.Error(),
+		})
+		return
+	}
+
+	if req.ExpiresAt != nil && !req.ExpiresAt.After(time.Now()) {
+		respondError(w, reqID, http.StatusBadRequest, &model.APIError{
+			Code:    model.ErrValidation,
+			Message: "expires_at must be in the future",
+		})
+		return
+	}
+
+	raw, hash, prefix, err := model.GenerateWorkerKey()
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+
+	var createdBy string
+	if uc := UserFromContext(r.Context()); uc != nil && uc.User != nil {
+		createdBy = uc.User.Username
+	}
+
+	key := &model.WorkerKey{
+		ID:          "wk_" + uuid.New().String(),
+		Label:       req.Label,
+		KeyHash:     hash,
+		KeyPrefix:   prefix,
+		Groups:      req.Groups,
+		Description: req.Description,
+		CreatedBy:   createdBy,
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   req.ExpiresAt,
+	}
+
+	if err := s.store.CreateWorkerKey(r.Context(), key); err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+
+	s.logger.Info("worker key issued", "key_id", key.ID, "label", key.Label,
+		"groups", key.Groups, "created_by", createdBy)
+
+	// Return the raw key ONCE alongside the metadata. It is never retrievable again.
+	respondCreated(w, reqID, map[string]any{
+		"key":        raw,
+		"worker_key": key,
+		"warning":    "store this key now; it cannot be retrieved again",
+	})
+}
+
+// handleListWorkerKeys lists all worker keys. Hashes and raw secrets are never
+// exposed (model.WorkerKey.KeyHash is json:"-").
+// GET /api/v1/admin/worker-keys
+func (s *Server) handleListWorkerKeys(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+
+	keys, err := s.store.ListWorkerKeys(r.Context())
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+
+	respondOK(w, reqID, map[string]any{
+		"total":       len(keys),
+		"worker_keys": keys,
+	})
+}
+
+// updateWorkerKeyRequest is the body for enabling/disabling or editing a key.
+// Pointer fields distinguish "omitted" from a zero value.
+type updateWorkerKeyRequest struct {
+	Disabled    *bool      `json:"disabled"`
+	Label       *string    `json:"label"`
+	Description *string    `json:"description"`
+	Groups      *[]string  `json:"groups"`
+	ExpiresAt   *time.Time `json:"expires_at"`
+	ClearExpiry bool       `json:"clear_expiry"`
+}
+
+// handleUpdateWorkerKey enables/disables or edits a worker key's metadata.
+// Disabling is the reversible form of revocation.
+// PATCH /api/v1/admin/worker-keys/{id}
+func (s *Server) handleUpdateWorkerKey(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+	id := chi.URLParam(r, "id")
+
+	key, err := s.store.GetWorkerKeyByID(r.Context(), id)
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+	if key == nil {
+		respondError(w, reqID, http.StatusNotFound, model.NewNotFoundError("worker key", id))
+		return
+	}
+
+	var req updateWorkerKeyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, reqID, http.StatusBadRequest, &model.APIError{
+			Code:    model.ErrValidation,
+			Message: "invalid JSON body: " + err.Error(),
+		})
+		return
+	}
+
+	if req.Disabled != nil {
+		key.Disabled = *req.Disabled
+	}
+	if req.Label != nil {
+		key.Label = *req.Label
+	}
+	if req.Description != nil {
+		key.Description = *req.Description
+	}
+	if req.Groups != nil {
+		key.Groups = *req.Groups
+	}
+	if req.ClearExpiry {
+		key.ExpiresAt = nil
+	} else if req.ExpiresAt != nil {
+		if !req.ExpiresAt.After(time.Now()) {
+			respondError(w, reqID, http.StatusBadRequest, &model.APIError{
+				Code:    model.ErrValidation,
+				Message: "expires_at must be in the future",
+			})
+			return
+		}
+		key.ExpiresAt = req.ExpiresAt
+	}
+
+	if err := s.store.UpdateWorkerKey(r.Context(), key); err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+
+	s.logger.Info("worker key updated", "key_id", key.ID, "disabled", key.Disabled)
+	respondOK(w, reqID, key)
+}
+
+// handleRevokeWorkerKey permanently revokes (deletes) a worker key.
+// DELETE /api/v1/admin/worker-keys/{id}
+func (s *Server) handleRevokeWorkerKey(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+	id := chi.URLParam(r, "id")
+
+	// Confirm existence first so a genuine store fault surfaces as 500, not 404.
+	existing, err := s.store.GetWorkerKeyByID(r.Context(), id)
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+	if existing == nil {
+		respondError(w, reqID, http.StatusNotFound, model.NewNotFoundError("worker key", id))
+		return
+	}
+
+	if err := s.store.DeleteWorkerKey(r.Context(), id); err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+
+	s.logger.Info("worker key revoked", "key_id", id)
+	respondOK(w, reqID, map[string]any{
+		"id":      id,
+		"revoked": true,
+	})
+}

--- a/internal/server/handler_worker_keys.go
+++ b/internal/server/handler_worker_keys.go
@@ -41,6 +41,14 @@ func (s *Server) handleCreateWorkerKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// An empty groups list means "any group" (see CanJoinGroup), which would
+	// silently grant a key fleet-wide reach. Default to the least-privilege
+	// "default" group so an omitted scope is narrow, not wildcard; an admin who
+	// genuinely wants a broad key must name the groups explicitly.
+	if len(req.Groups) == 0 {
+		req.Groups = []string{"default"}
+	}
+
 	raw, hash, prefix, err := model.GenerateWorkerKey()
 	if err != nil {
 		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
@@ -145,6 +153,16 @@ func (s *Server) handleUpdateWorkerKey(w http.ResponseWriter, r *http.Request) {
 		key.Description = *req.Description
 	}
 	if req.Groups != nil {
+		// Reject an explicit empty list: it would turn the key into a wildcard
+		// (any group). To broaden a key, name the groups; to narrow it, use
+		// ["default"].
+		if len(*req.Groups) == 0 {
+			respondError(w, reqID, http.StatusBadRequest, &model.APIError{
+				Code:    model.ErrValidation,
+				Message: "groups cannot be set to an empty list (empty means any group); name the groups explicitly",
+			})
+			return
+		}
 		key.Groups = *req.Groups
 	}
 	if req.ClearExpiry {

--- a/internal/server/resolve_refs_test.go
+++ b/internal/server/resolve_refs_test.go
@@ -121,6 +121,19 @@ func (m *mockStore) CancelledTasksForWorker(context.Context, []string) ([]string
 	return nil, nil
 }
 
+func (m *mockStore) CreateWorkerKey(context.Context, *model.WorkerKey) error { return nil }
+func (m *mockStore) GetWorkerKeyByID(context.Context, string) (*model.WorkerKey, error) {
+	return nil, nil
+}
+func (m *mockStore) GetWorkerKeyByHash(context.Context, string) (*model.WorkerKey, error) {
+	return nil, nil
+}
+func (m *mockStore) ListWorkerKeys(context.Context) ([]*model.WorkerKey, error) { return nil, nil }
+func (m *mockStore) UpdateWorkerKey(context.Context, *model.WorkerKey) error    { return nil }
+func (m *mockStore) DeleteWorkerKey(context.Context, string) error              { return nil }
+func (m *mockStore) CountWorkerKeys(context.Context) (int, error)               { return 0, nil }
+func (m *mockStore) TouchWorkerKey(context.Context, string, time.Time) error    { return nil }
+
 func (m *mockStore) GetUser(context.Context, string) (*model.User, error) { return nil, nil }
 func (m *mockStore) GetOrCreateUser(context.Context, string, model.AuthProvider) (*model.User, error) {
 	return nil, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,15 +27,16 @@ type Server struct {
 	validator        *parser.Validator
 	store            store.Store
 	scheduler        scheduler.Scheduler
-	registry         *executor.Registry // optional; used by dry-run to check executor availability
-	bvbrcCaller      bvbrc.RPCCaller    // optional; AppService caller, nil when no BV-BRC token
-	workspaceCaller  bvbrc.RPCCaller    // optional; Workspace service caller
-	testApps         []map[string]any   // optional; static app list for testing without BV-BRC
-	ui               *ui.UI             // UI handler for web interface
-	adminConfig      *AdminConfig       // optional; admin role configuration
-	anonConfig       *AnonymousConfig   // optional; anonymous access configuration
-	workerKeyConfig  *WorkerKeyConfig   // optional; worker key authentication
-	fileUploadConfig *FileUploadConfig  // optional; file upload proxy configuration
+	registry         *executor.Registry      // optional; used by dry-run to check executor availability
+	bvbrcCaller      bvbrc.RPCCaller         // optional; AppService caller, nil when no BV-BRC token
+	workspaceCaller  bvbrc.RPCCaller         // optional; Workspace service caller
+	testApps         []map[string]any        // optional; static app list for testing without BV-BRC
+	ui               *ui.UI                  // UI handler for web interface
+	adminConfig      *AdminConfig            // optional; admin role configuration
+	anonConfig       *AnonymousConfig        // optional; anonymous access configuration
+	workerKeyConfig  *WorkerKeyConfig        // optional; static worker keys (file/env)
+	workerAuth       *WorkerKeyAuthenticator // validates static + DB-backed worker keys
+	fileUploadConfig *FileUploadConfig       // optional; file upload proxy configuration
 }
 
 // Option configures optional Server dependencies.
@@ -106,6 +107,10 @@ func New(cfg config.ServerConfig, st store.Store, sched scheduler.Scheduler, log
 	for _, opt := range opts {
 		opt(s)
 	}
+
+	// Build the worker-key authenticator from static config (file/env) plus the
+	// DB-backed per-worker keys managed via the admin API.
+	s.workerAuth = NewWorkerKeyAuthenticator(s.workerKeyConfig, st, s.logger)
 
 	// Create UI handler. Session cookies are marked Secure when TLS is
 	// terminated in-process, when the operator opts in explicitly, or (behind a
@@ -209,7 +214,7 @@ func (s *Server) routes() {
 
 		// Worker endpoints (separate auth model using X-Worker-Key)
 		r.Route("/workers", func(r chi.Router) {
-			r.Use(workerAuthMiddleware(s.workerKeyConfig, s.logger))
+			r.Use(workerAuthMiddleware(s.workerAuth, s.logger))
 			r.Get("/", s.handleListWorkers)
 			r.Post("/", s.handleRegisterWorker)
 			r.Route("/{id}", func(r chi.Router) {
@@ -293,6 +298,14 @@ func (s *Server) routes() {
 				r.Get("/users", s.handleListUsers)
 				r.Route("/users/{username}", func(r chi.Router) {
 					r.Put("/role", s.handleSetUserRole)
+				})
+				r.Route("/worker-keys", func(r chi.Router) {
+					r.Get("/", s.handleListWorkerKeys)
+					r.Post("/", s.handleCreateWorkerKey)
+					r.Route("/{id}", func(r chi.Router) {
+						r.Patch("/", s.handleUpdateWorkerKey)
+						r.Delete("/", s.handleRevokeWorkerKey)
+					})
 				})
 				r.Route("/labels", func(r chi.Router) {
 					r.Get("/", s.handleListLabelVocabulary)

--- a/internal/server/worker_auth.go
+++ b/internal/server/worker_auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -62,21 +63,29 @@ type WorkerKeyEntry struct {
 const hashSentinelPrefix = "sha256:"
 
 // LoadWorkerKeyConfig loads worker key configuration from multiple sources.
-// Priority: 1. JSON file, 2. Environment variable (GOWE_WORKER_KEYS)
-func LoadWorkerKeyConfig(configFile string) *WorkerKeyConfig {
+// Priority: 1. JSON file, 2. Environment variable (GOWE_WORKER_KEYS).
+//
+// A configured source that cannot be read or parsed is a hard error rather than
+// a silent fallback: degrading to an empty config would leave worker auth open
+// (see Enabled) while the operator believes it is enforced. Callers MUST NOT
+// enable the server on error.
+func LoadWorkerKeyConfig(configFile string) (*WorkerKeyConfig, error) {
 	cfg := &WorkerKeyConfig{
 		Keys: make(map[string]WorkerKeyEntry),
 	}
 
-	// Try loading from config file.
+	// Load from config file, if one was configured.
 	if configFile != "" {
-		if data, err := os.ReadFile(configFile); err == nil {
-			var fileCfg WorkerKeyConfig
-			if err := json.Unmarshal(data, &fileCfg); err == nil {
-				for k, v := range fileCfg.Keys {
-					cfg.Keys[k] = v
-				}
-			}
+		data, err := os.ReadFile(configFile)
+		if err != nil {
+			return nil, fmt.Errorf("read worker-keys file %q: %w", configFile, err)
+		}
+		var fileCfg WorkerKeyConfig
+		if err := json.Unmarshal(data, &fileCfg); err != nil {
+			return nil, fmt.Errorf("parse worker-keys file %q: %w", configFile, err)
+		}
+		for k, v := range fileCfg.Keys {
+			cfg.Keys[k] = v
 		}
 	}
 
@@ -84,15 +93,16 @@ func LoadWorkerKeyConfig(configFile string) *WorkerKeyConfig {
 	// Format: {"key1": ["group1", "group2"], "key2": ["default"]}
 	if envVal := os.Getenv("GOWE_WORKER_KEYS"); envVal != "" {
 		var envKeys map[string][]string
-		if err := json.Unmarshal([]byte(envVal), &envKeys); err == nil {
-			for key, groups := range envKeys {
-				cfg.Keys[key] = WorkerKeyEntry{Groups: groups}
-			}
+		if err := json.Unmarshal([]byte(envVal), &envKeys); err != nil {
+			return nil, fmt.Errorf("parse GOWE_WORKER_KEYS: %w", err)
+		}
+		for key, groups := range envKeys {
+			cfg.Keys[key] = WorkerKeyEntry{Groups: groups}
 		}
 	}
 
 	cfg.build()
-	return cfg
+	return cfg, nil
 }
 
 // build constructs the hash index from Keys. Entries whose map key uses the

--- a/internal/server/worker_auth.go
+++ b/internal/server/worker_auth.go
@@ -9,7 +9,10 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strings"
+	"time"
 
+	"github.com/me/gowe/internal/store"
 	"github.com/me/gowe/pkg/model"
 )
 
@@ -17,7 +20,7 @@ const ctxKeyWorkerAuth ctxKey = "worker_auth"
 
 // WorkerAuthContext holds authenticated worker info for a request.
 type WorkerAuthContext struct {
-	KeyID  string   // Hash of the key (for logging, not the raw key)
+	KeyID  string   // Stable key identifier (or key hash) for attribution/logging
 	Groups []string // Groups this key can join
 }
 
@@ -29,16 +32,34 @@ func WorkerAuthFromContext(ctx context.Context) *WorkerAuthContext {
 	return nil
 }
 
-// WorkerKeyConfig holds worker key to group mappings.
+// WorkerKeyConfig holds statically-configured worker keys (from a JSON file or
+// the GOWE_WORKER_KEYS env var). These are the legacy/bootstrap keys; keys minted
+// via the admin API are stored hashed in the database instead (see model.WorkerKey).
 type WorkerKeyConfig struct {
 	Keys map[string]WorkerKeyEntry `json:"keys"`
+
+	// hashIndex maps sha256(rawKey) -> entry so lookups do not require iterating
+	// or holding the raw key for comparison. Built lazily from Keys.
+	hashIndex map[string]*WorkerKeyEntry
 }
 
-// WorkerKeyEntry defines the groups and metadata for a worker key.
+// WorkerKeyEntry defines the groups, identity, and lifecycle for a worker key.
 type WorkerKeyEntry struct {
+	// ID is a stable, human-attributable identifier/label for the key. It is
+	// logged (never the raw key) so a specific key can be traced and revoked.
+	ID          string   `json:"id,omitempty"`
 	Groups      []string `json:"groups"`
 	Description string   `json:"description,omitempty"`
+	// Disabled revokes the key without removing it from the config.
+	Disabled bool `json:"disabled,omitempty"`
+	// ExpiresAt, when set, makes the key invalid at and after that time.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
+
+// hashSentinelPrefix lets operators store a key by its hash in config instead of
+// the raw secret, e.g. {"sha256:<hex>": {"groups": [...]}}. Keys given as raw
+// secrets are hashed on load, so the raw value never needs to leave config.
+const hashSentinelPrefix = "sha256:"
 
 // LoadWorkerKeyConfig loads worker key configuration from multiple sources.
 // Priority: 1. JSON file, 2. Environment variable (GOWE_WORKER_KEYS)
@@ -70,21 +91,44 @@ func LoadWorkerKeyConfig(configFile string) *WorkerKeyConfig {
 		}
 	}
 
+	cfg.build()
 	return cfg
 }
 
-// ValidateKey checks if a key is valid and returns its allowed groups.
-// Returns nil if the key is invalid.
+// build constructs the hash index from Keys. Entries whose map key uses the
+// "sha256:" sentinel are indexed by that hash directly; raw keys are hashed.
+func (c *WorkerKeyConfig) build() {
+	c.hashIndex = make(map[string]*WorkerKeyEntry, len(c.Keys))
+	for k, entry := range c.Keys {
+		entry := entry // capture per-iteration copy
+		var hash string
+		if strings.HasPrefix(k, hashSentinelPrefix) {
+			hash = strings.TrimPrefix(k, hashSentinelPrefix)
+		} else {
+			hash = model.HashWorkerKey(k)
+		}
+		c.hashIndex[hash] = &entry
+	}
+}
+
+// ValidateKey checks if a key is present in the static config and returns its
+// entry (regardless of lifecycle state). Returns nil if the key is unknown.
 func (c *WorkerKeyConfig) ValidateKey(key string) *WorkerKeyEntry {
-	if entry, ok := c.Keys[key]; ok {
-		return &entry
+	if c == nil {
+		return nil
+	}
+	if c.hashIndex == nil {
+		c.build()
+	}
+	if entry, ok := c.hashIndex[model.HashWorkerKey(key)]; ok {
+		return entry
 	}
 	return nil
 }
 
-// IsEnabled returns true if any worker keys are configured.
+// IsEnabled returns true if any static worker keys are configured.
 func (c *WorkerKeyConfig) IsEnabled() bool {
-	return len(c.Keys) > 0
+	return c != nil && len(c.Keys) > 0
 }
 
 // hashKey creates a short hash of the key for logging purposes.
@@ -93,15 +137,95 @@ func hashKey(key string) string {
 	return hex.EncodeToString(h[:8]) // First 16 hex chars
 }
 
-// workerAuthMiddleware validates X-Worker-Key header for worker endpoints.
-// If no keys are configured, authentication is disabled (open access).
-func workerAuthMiddleware(keyConfig *WorkerKeyConfig, logger *slog.Logger) func(http.Handler) http.Handler {
+// WorkerKeyAuthenticator validates X-Worker-Key values against both statically
+// configured keys and DB-backed per-worker keys (hashed at rest). It centralizes
+// the "no keys configured = open access" policy.
+type WorkerKeyAuthenticator struct {
+	static *WorkerKeyConfig // optional; legacy/bootstrap keys from file/env
+	store  store.Store      // optional; DB-backed minted keys
+	logger *slog.Logger
+}
+
+// NewWorkerKeyAuthenticator builds an authenticator from the (optional) static
+// config and the store.
+func NewWorkerKeyAuthenticator(static *WorkerKeyConfig, st store.Store, logger *slog.Logger) *WorkerKeyAuthenticator {
+	return &WorkerKeyAuthenticator{static: static, store: st, logger: logger}
+}
+
+// Enabled reports whether worker-key enforcement is active. It is active when
+// any static key OR any DB-backed key is configured. On a store error it fails
+// closed (returns true) so a transient DB fault cannot silently open the fleet.
+func (a *WorkerKeyAuthenticator) Enabled(ctx context.Context) bool {
+	if a.static.IsEnabled() {
+		return true
+	}
+	if a.store != nil {
+		n, err := a.store.CountWorkerKeys(ctx)
+		if err != nil {
+			a.logger.Error("count worker keys failed; enforcing auth", "error", err)
+			return true // fail closed
+		}
+		return n > 0
+	}
+	return false
+}
+
+// Authenticate validates a raw worker key and returns the resulting auth context,
+// or nil if the key is unknown, disabled, or expired.
+func (a *WorkerKeyAuthenticator) Authenticate(ctx context.Context, raw string) *WorkerAuthContext {
+	now := time.Now()
+
+	// 1. Static config (file/env). Legacy keys, matched by hash.
+	if a.static != nil {
+		if entry := a.static.ValidateKey(raw); entry != nil {
+			if entry.Disabled {
+				a.logger.Warn("disabled worker key used", "key_id", entry.ID, "key_hash", hashKey(raw))
+				return nil
+			}
+			if entry.ExpiresAt != nil && !now.Before(*entry.ExpiresAt) {
+				a.logger.Warn("expired worker key used", "key_id", entry.ID, "key_hash", hashKey(raw))
+				return nil
+			}
+			id := entry.ID
+			if id == "" {
+				id = hashKey(raw)
+			}
+			return &WorkerAuthContext{KeyID: id, Groups: entry.Groups}
+		}
+	}
+
+	// 2. DB-backed per-worker keys (hashed at rest).
+	if a.store != nil {
+		wk, err := a.store.GetWorkerKeyByHash(ctx, model.HashWorkerKey(raw))
+		if err != nil {
+			a.logger.Error("worker key lookup failed", "error", err)
+			return nil
+		}
+		if wk != nil {
+			if !wk.IsActive(now) {
+				a.logger.Warn("inactive worker key used", "key_id", wk.ID, "disabled", wk.Disabled)
+				return nil
+			}
+			// Record usage; best-effort, never blocks auth.
+			if err := a.store.TouchWorkerKey(ctx, wk.ID, now); err != nil {
+				a.logger.Debug("touch worker key failed", "key_id", wk.ID, "error", err)
+			}
+			return &WorkerAuthContext{KeyID: wk.ID, Groups: wk.Groups}
+		}
+	}
+
+	return nil
+}
+
+// workerAuthMiddleware validates the X-Worker-Key header for worker endpoints.
+// If no keys are configured (static or DB), authentication is disabled (open access).
+func workerAuthMiddleware(auth *WorkerKeyAuthenticator, logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			reqID := RequestIDFromContext(r.Context())
 
 			// If no keys are configured, allow open access.
-			if keyConfig == nil || !keyConfig.IsEnabled() {
+			if auth == nil || !auth.Enabled(r.Context()) {
 				// Create anonymous worker context — allow any group.
 				workerCtx := &WorkerAuthContext{
 					KeyID:  "none",
@@ -122,21 +246,15 @@ func workerAuthMiddleware(keyConfig *WorkerKeyConfig, logger *slog.Logger) func(
 				return
 			}
 
-			// Validate key.
-			entry := keyConfig.ValidateKey(key)
-			if entry == nil {
+			// Validate key against static + DB-backed keys.
+			workerCtx := auth.Authenticate(r.Context(), key)
+			if workerCtx == nil {
 				logger.Warn("invalid worker key", "key_hash", hashKey(key))
 				respondError(w, reqID, http.StatusUnauthorized, &model.APIError{
 					Code:    model.ErrUnauthorized,
 					Message: "invalid worker key",
 				})
 				return
-			}
-
-			// Build worker auth context.
-			workerCtx := &WorkerAuthContext{
-				KeyID:  hashKey(key),
-				Groups: entry.Groups,
 			}
 
 			ctx := context.WithValue(r.Context(), ctxKeyWorkerAuth, workerCtx)

--- a/internal/server/worker_key_auth_test.go
+++ b/internal/server/worker_key_auth_test.go
@@ -1,0 +1,328 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/me/gowe/internal/store"
+	"github.com/me/gowe/pkg/model"
+)
+
+func testAuthStore(t *testing.T) store.Store {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	st, err := store.NewSQLiteStore(":memory:", logger)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := st.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// --- Authenticator: static config ---
+
+func TestAuthenticator_StaticKey(t *testing.T) {
+	cfg := &WorkerKeyConfig{Keys: map[string]WorkerKeyEntry{
+		"secret-abc": {ID: "node-a", Groups: []string{"esmfold"}},
+	}}
+	cfg.build()
+	auth := NewWorkerKeyAuthenticator(cfg, nil, discardLogger())
+	ctx := context.Background()
+
+	if !auth.Enabled(ctx) {
+		t.Fatal("Enabled() = false with static keys configured")
+	}
+	got := auth.Authenticate(ctx, "secret-abc")
+	if got == nil {
+		t.Fatal("Authenticate(valid static key) = nil")
+	}
+	if got.KeyID != "node-a" {
+		t.Errorf("KeyID = %q, want node-a", got.KeyID)
+	}
+	if !got.CanJoinGroup("esmfold") || got.CanJoinGroup("other") {
+		t.Errorf("group scoping wrong: %v", got.Groups)
+	}
+	if auth.Authenticate(ctx, "wrong") != nil {
+		t.Errorf("Authenticate(wrong key) != nil")
+	}
+}
+
+func TestAuthenticator_StaticDisabledAndExpired(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	cfg := &WorkerKeyConfig{Keys: map[string]WorkerKeyEntry{
+		"disabled-key": {ID: "d", Groups: []string{"g"}, Disabled: true},
+		"expired-key":  {ID: "e", Groups: []string{"g"}, ExpiresAt: &past},
+	}}
+	cfg.build()
+	auth := NewWorkerKeyAuthenticator(cfg, nil, discardLogger())
+	ctx := context.Background()
+
+	if auth.Authenticate(ctx, "disabled-key") != nil {
+		t.Errorf("disabled static key authenticated")
+	}
+	if auth.Authenticate(ctx, "expired-key") != nil {
+		t.Errorf("expired static key authenticated")
+	}
+}
+
+func TestWorkerKeyConfig_HashSentinel(t *testing.T) {
+	// Operators can store the hash instead of the raw secret.
+	raw := "super-secret"
+	cfg := &WorkerKeyConfig{Keys: map[string]WorkerKeyEntry{
+		hashSentinelPrefix + model.HashWorkerKey(raw): {ID: "h", Groups: []string{"g"}},
+	}}
+	cfg.build()
+	if entry := cfg.ValidateKey(raw); entry == nil || entry.ID != "h" {
+		t.Errorf("hash-sentinel key not resolved from raw input: %v", entry)
+	}
+}
+
+// --- Authenticator: DB-backed keys ---
+
+func TestAuthenticator_DBKeyLifecycle(t *testing.T) {
+	st := testAuthStore(t)
+	auth := NewWorkerKeyAuthenticator(nil, st, discardLogger())
+	ctx := context.Background()
+
+	// No keys anywhere => open access.
+	if auth.Enabled(ctx) {
+		t.Fatal("Enabled() = true with no keys configured")
+	}
+
+	raw, hash, prefix, _ := model.GenerateWorkerKey()
+	key := &model.WorkerKey{
+		ID: "wk_db1", Label: "db-node", KeyHash: hash, KeyPrefix: prefix,
+		Groups: []string{"esmfold"}, CreatedAt: time.Now().UTC(),
+	}
+	if err := st.CreateWorkerKey(ctx, key); err != nil {
+		t.Fatalf("CreateWorkerKey: %v", err)
+	}
+
+	// Now enforcement is on and the key authenticates.
+	if !auth.Enabled(ctx) {
+		t.Fatal("Enabled() = false after minting a DB key")
+	}
+	got := auth.Authenticate(ctx, raw)
+	if got == nil || got.KeyID != "wk_db1" {
+		t.Fatalf("Authenticate(db key) = %v, want wk_db1", got)
+	}
+
+	// Usage is recorded.
+	stored, _ := st.GetWorkerKeyByID(ctx, "wk_db1")
+	if stored.LastUsedAt == nil {
+		t.Errorf("LastUsedAt not updated after auth")
+	}
+
+	// Disable => revoked.
+	key.Disabled = true
+	if err := st.UpdateWorkerKey(ctx, key); err != nil {
+		t.Fatalf("UpdateWorkerKey: %v", err)
+	}
+	if auth.Authenticate(ctx, raw) != nil {
+		t.Errorf("disabled DB key still authenticates")
+	}
+
+	// A leaked key can be revoked without touching others.
+	raw2, hash2, prefix2, _ := model.GenerateWorkerKey()
+	key2 := &model.WorkerKey{ID: "wk_db2", KeyHash: hash2, KeyPrefix: prefix2, Groups: []string{"g"}, CreatedAt: time.Now().UTC()}
+	if err := st.CreateWorkerKey(ctx, key2); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DeleteWorkerKey(ctx, "wk_db2"); err != nil {
+		t.Fatal(err)
+	}
+	if auth.Authenticate(ctx, raw2) != nil {
+		t.Errorf("revoked DB key still authenticates")
+	}
+}
+
+// --- Middleware behavior ---
+
+func testMiddlewareRouter(auth *WorkerKeyAuthenticator) http.Handler {
+	r := chi.NewRouter()
+	r.Use(requestIDMiddleware)
+	r.Use(workerAuthMiddleware(auth, discardLogger()))
+	r.Get("/work", func(w http.ResponseWriter, r *http.Request) {
+		wc := WorkerAuthFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(wc.KeyID))
+	})
+	return r
+}
+
+func TestWorkerAuthMiddleware(t *testing.T) {
+	cfg := &WorkerKeyConfig{Keys: map[string]WorkerKeyEntry{"good": {ID: "n1", Groups: []string{"g"}}}}
+	cfg.build()
+	auth := NewWorkerKeyAuthenticator(cfg, nil, discardLogger())
+	router := testMiddlewareRouter(auth)
+
+	// Missing header => 401.
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest("GET", "/work", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("missing key: status = %d, want 401", rec.Code)
+	}
+
+	// Wrong header => 401.
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/work", nil)
+	req.Header.Set("X-Worker-Key", "bad")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("bad key: status = %d, want 401", rec.Code)
+	}
+
+	// Correct header => 200 and attributes to key ID.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/work", nil)
+	req.Header.Set("X-Worker-Key", "good")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || rec.Body.String() != "n1" {
+		t.Errorf("good key: status=%d body=%q, want 200/n1", rec.Code, rec.Body.String())
+	}
+}
+
+func TestWorkerAuthMiddleware_OpenAccess(t *testing.T) {
+	// No static config, no DB keys => open access, no header required.
+	st := testAuthStore(t)
+	auth := NewWorkerKeyAuthenticator(nil, st, discardLogger())
+	router := testMiddlewareRouter(auth)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest("GET", "/work", nil))
+	if rec.Code != http.StatusOK || rec.Body.String() != "none" {
+		t.Errorf("open access: status=%d body=%q, want 200/none", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Admin HTTP endpoints (mint / list / disable / revoke) ---
+
+// adminRouter mounts the worker-key admin routes with an injected admin user,
+// bypassing token auth so the handlers can be exercised directly.
+func adminRouter(s *Server) http.Handler {
+	r := chi.NewRouter()
+	r.Use(requestIDMiddleware)
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			admin := &model.User{Username: "admin", Role: model.RoleAdmin}
+			ctx := context.WithValue(req.Context(), ctxKeyUserAuth, &UserContext{User: admin})
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	})
+	r.Route("/api/v1/admin/worker-keys", func(r chi.Router) {
+		r.Get("/", s.handleListWorkerKeys)
+		r.Post("/", s.handleCreateWorkerKey)
+		r.Route("/{id}", func(r chi.Router) {
+			r.Patch("/", s.handleUpdateWorkerKey)
+			r.Delete("/", s.handleRevokeWorkerKey)
+		})
+	})
+	return r
+}
+
+func doAdmin(t *testing.T, router http.Handler, method, path, body string) (*httptest.ResponseRecorder, envelope) {
+	t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = bytes.NewReader([]byte(body))
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	var env envelope
+	_ = json.Unmarshal(rec.Body.Bytes(), &env)
+	return rec, env
+}
+
+func TestAdminWorkerKeyEndpoints(t *testing.T) {
+	srv := testServer()
+	router := adminRouter(srv)
+
+	// Mint a key.
+	rec, env := doAdmin(t, router, "POST", "/api/v1/admin/worker-keys",
+		`{"label":"esmfold-1","groups":["esmfold"],"description":"gpu box"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("mint: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var minted struct {
+		Key       string          `json:"key"`
+		WorkerKey model.WorkerKey `json:"worker_key"`
+	}
+	if err := json.Unmarshal(env.Data, &minted); err != nil {
+		t.Fatalf("decode mint response: %v", err)
+	}
+	if minted.Key == "" {
+		t.Fatal("mint response did not include the raw key")
+	}
+	if minted.WorkerKey.KeyHash != "" {
+		t.Errorf("KeyHash leaked in JSON response: %q", minted.WorkerKey.KeyHash)
+	}
+	keyID := minted.WorkerKey.ID
+
+	// The minted raw key authenticates via the server's authenticator.
+	if got := srv.workerAuth.Authenticate(context.Background(), minted.Key); got == nil || got.KeyID != keyID {
+		t.Fatalf("minted key does not authenticate: %v", got)
+	}
+
+	// List shows the key but never the hash or raw secret.
+	rec, env = doAdmin(t, router, "GET", "/api/v1/admin/worker-keys", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: status=%d", rec.Code)
+	}
+	if bytes.Contains(env.Data, []byte(minted.Key)) {
+		t.Errorf("list response leaked the raw key")
+	}
+
+	// Disable the key.
+	rec, _ = doAdmin(t, router, "PATCH", "/api/v1/admin/worker-keys/"+keyID, `{"disabled":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("disable: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if srv.workerAuth.Authenticate(context.Background(), minted.Key) != nil {
+		t.Errorf("disabled key still authenticates")
+	}
+
+	// Re-enable.
+	doAdmin(t, router, "PATCH", "/api/v1/admin/worker-keys/"+keyID, `{"disabled":false}`)
+	if srv.workerAuth.Authenticate(context.Background(), minted.Key) == nil {
+		t.Errorf("re-enabled key does not authenticate")
+	}
+
+	// Revoke (delete).
+	rec, _ = doAdmin(t, router, "DELETE", "/api/v1/admin/worker-keys/"+keyID, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if srv.workerAuth.Authenticate(context.Background(), minted.Key) != nil {
+		t.Errorf("revoked key still authenticates")
+	}
+
+	// Revoking a missing key => 404.
+	rec, _ = doAdmin(t, router, "DELETE", "/api/v1/admin/worker-keys/wk_missing", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("revoke missing: status=%d, want 404", rec.Code)
+	}
+
+	// Past expiry is rejected.
+	rec, _ = doAdmin(t, router, "POST", "/api/v1/admin/worker-keys",
+		`{"label":"bad","expires_at":"2000-01-01T00:00:00Z"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("past expiry: status=%d, want 400", rec.Code)
+	}
+}

--- a/internal/server/worker_key_auth_test.go
+++ b/internal/server/worker_key_auth_test.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -324,5 +326,72 @@ func TestAdminWorkerKeyEndpoints(t *testing.T) {
 		`{"label":"bad","expires_at":"2000-01-01T00:00:00Z"}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("past expiry: status=%d, want 400", rec.Code)
+	}
+}
+
+// TestLoadWorkerKeyConfig_FailsClosed verifies that a configured-but-unloadable
+// key source is a hard error rather than a silent degrade to open access (F1).
+func TestLoadWorkerKeyConfig_FailsClosed(t *testing.T) {
+	// A configured file that does not exist must error.
+	if _, err := LoadWorkerKeyConfig("/nonexistent/worker-keys.json"); err == nil {
+		t.Error("missing key file: expected error, got nil (would leave auth open)")
+	}
+
+	// A configured file with malformed JSON must error.
+	bad := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	if _, err := LoadWorkerKeyConfig(bad); err == nil {
+		t.Error("malformed key file: expected error, got nil")
+	}
+
+	// No file configured is fine (returns an empty, disabled config).
+	cfg, err := LoadWorkerKeyConfig("")
+	if err != nil {
+		t.Errorf("no file configured: unexpected error %v", err)
+	}
+	if cfg.IsEnabled() {
+		t.Error("empty config should not be enabled")
+	}
+}
+
+// TestCreateWorkerKey_EmptyGroupsDefaultsToDefault verifies that minting a key
+// without groups yields a least-privilege ["default"] scope, not a wildcard (F2).
+func TestCreateWorkerKey_EmptyGroupsDefaultsToDefault(t *testing.T) {
+	router := adminRouter(testServer())
+
+	rec, env := doAdmin(t, router, "POST", "/api/v1/admin/worker-keys", `{"label":"no-groups"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("mint: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var minted struct {
+		WorkerKey model.WorkerKey `json:"worker_key"`
+	}
+	if err := json.Unmarshal(env.Data, &minted); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(minted.WorkerKey.Groups) != 1 || minted.WorkerKey.Groups[0] != "default" {
+		t.Errorf("empty groups should default to [default], got %v", minted.WorkerKey.Groups)
+	}
+}
+
+// TestUpdateWorkerKey_RejectsEmptyGroups verifies a PATCH cannot widen a key to
+// wildcard by clearing its groups (F2).
+func TestUpdateWorkerKey_RejectsEmptyGroups(t *testing.T) {
+	router := adminRouter(testServer())
+
+	_, env := doAdmin(t, router, "POST", "/api/v1/admin/worker-keys",
+		`{"label":"scoped","groups":["esmfold"]}`)
+	var minted struct {
+		WorkerKey model.WorkerKey `json:"worker_key"`
+	}
+	if err := json.Unmarshal(env.Data, &minted); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	rec, _ := doAdmin(t, router, "PATCH", "/api/v1/admin/worker-keys/"+minted.WorkerKey.ID, `{"groups":[]}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PATCH groups=[]: status=%d, want 400", rec.Code)
 	}
 }

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -122,6 +122,24 @@ var schema = []string{
 	`CREATE INDEX IF NOT EXISTS idx_si_submission ON step_instances(submission_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_si_state ON step_instances(state)`,
 
+	// Worker keys for per-worker authentication.
+	// Only the SHA-256 hash of each key is stored (hashed at rest); the raw
+	// secret is shown to the operator once at issuance and never persisted.
+	`CREATE TABLE IF NOT EXISTS worker_keys (
+		id           TEXT PRIMARY KEY,
+		label        TEXT NOT NULL DEFAULT '',
+		key_hash     TEXT NOT NULL UNIQUE,
+		key_prefix   TEXT NOT NULL DEFAULT '',
+		groups       TEXT NOT NULL DEFAULT '[]',
+		description  TEXT NOT NULL DEFAULT '',
+		disabled     INTEGER NOT NULL DEFAULT 0,
+		created_by   TEXT NOT NULL DEFAULT '',
+		created_at   TEXT NOT NULL,
+		expires_at   TEXT,
+		last_used_at TEXT
+	)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_keys_hash ON worker_keys(key_hash)`,
+
 	// Linked providers for multi-provider authentication
 	`CREATE TABLE IF NOT EXISTS linked_providers (
 		user_id   TEXT NOT NULL,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -69,6 +69,16 @@ type Store interface {
 	ReconcileWorkerTasks(ctx context.Context, workerID string, running []string, minAge time.Duration) ([]string, error)
 	CancelledTasksForWorker(ctx context.Context, taskIDs []string) ([]string, error)
 
+	// Worker key operations (per-worker authentication, hashed at rest)
+	CreateWorkerKey(ctx context.Context, k *model.WorkerKey) error
+	GetWorkerKeyByID(ctx context.Context, id string) (*model.WorkerKey, error)
+	GetWorkerKeyByHash(ctx context.Context, hash string) (*model.WorkerKey, error)
+	ListWorkerKeys(ctx context.Context) ([]*model.WorkerKey, error)
+	UpdateWorkerKey(ctx context.Context, k *model.WorkerKey) error
+	DeleteWorkerKey(ctx context.Context, id string) error
+	CountWorkerKeys(ctx context.Context) (int, error)
+	TouchWorkerKey(ctx context.Context, id string, when time.Time) error
+
 	// User operations
 	GetUser(ctx context.Context, username string) (*model.User, error)
 	GetOrCreateUser(ctx context.Context, username string, provider model.AuthProvider) (*model.User, error)

--- a/internal/store/worker_keys.go
+++ b/internal/store/worker_keys.go
@@ -1,0 +1,207 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/me/gowe/pkg/model"
+)
+
+// nullableTime formats t for a nullable TEXT column: NULL when t is nil.
+func nullableTime(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return t.Format(time.RFC3339Nano)
+}
+
+// scanNullableTime parses a nullable RFC3339Nano timestamp column.
+func scanNullableTime(ns sql.NullString) (*time.Time, error) {
+	if !ns.Valid || ns.String == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, ns.String)
+	if err != nil {
+		return nil, fmt.Errorf("corrupt timestamp %q: %w", ns.String, err)
+	}
+	return &t, nil
+}
+
+// CreateWorkerKey inserts a new worker key. Only k.KeyHash (not the raw secret)
+// is persisted.
+func (s *SQLiteStore) CreateWorkerKey(ctx context.Context, k *model.WorkerKey) error {
+	s.logger.Debug("sql", "op", "insert", "table", "worker_keys", "id", k.ID)
+
+	groupsJSON, err := json.Marshal(k.Groups)
+	if err != nil {
+		return fmt.Errorf("marshal groups: %w", err)
+	}
+
+	disabled := 0
+	if k.Disabled {
+		disabled = 1
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO worker_keys (id, label, key_hash, key_prefix, groups, description, disabled, created_by, created_at, expires_at, last_used_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		k.ID, k.Label, k.KeyHash, k.KeyPrefix, string(groupsJSON), k.Description,
+		disabled, k.CreatedBy, k.CreatedAt.Format(time.RFC3339Nano),
+		nullableTime(k.ExpiresAt), nullableTime(k.LastUsedAt),
+	)
+	return err
+}
+
+// scanWorkerKey scans a single worker_keys row into a model.WorkerKey.
+func scanWorkerKey(row interface {
+	Scan(dest ...any) error
+}) (*model.WorkerKey, error) {
+	var k model.WorkerKey
+	var groupsJSON, createdAt string
+	var disabled int
+	var expiresAt, lastUsedAt sql.NullString
+
+	if err := row.Scan(&k.ID, &k.Label, &k.KeyHash, &k.KeyPrefix, &groupsJSON,
+		&k.Description, &disabled, &k.CreatedBy, &createdAt, &expiresAt, &lastUsedAt); err != nil {
+		return nil, err
+	}
+
+	k.Disabled = disabled != 0
+	if err := unmarshalJSON(groupsJSON, &k.Groups, "groups"); err != nil {
+		return nil, err
+	}
+	var err error
+	if k.CreatedAt, err = parseTimeOrZero(createdAt); err != nil {
+		return nil, err
+	}
+	if k.ExpiresAt, err = scanNullableTime(expiresAt); err != nil {
+		return nil, err
+	}
+	if k.LastUsedAt, err = scanNullableTime(lastUsedAt); err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
+const workerKeyColumns = `id, label, key_hash, key_prefix, groups, description, disabled, created_by, created_at, expires_at, last_used_at`
+
+// GetWorkerKeyByID returns the worker key with the given id, or nil if not found.
+func (s *SQLiteStore) GetWorkerKeyByID(ctx context.Context, id string) (*model.WorkerKey, error) {
+	s.logger.Debug("sql", "op", "select", "table", "worker_keys", "id", id)
+
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+workerKeyColumns+` FROM worker_keys WHERE id = ?`, id)
+	k, err := scanWorkerKey(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+// GetWorkerKeyByHash returns the worker key with the given SHA-256 hash, or nil
+// if not found. This is the lookup used during worker authentication.
+func (s *SQLiteStore) GetWorkerKeyByHash(ctx context.Context, hash string) (*model.WorkerKey, error) {
+	s.logger.Debug("sql", "op", "select", "table", "worker_keys", "by", "hash")
+
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+workerKeyColumns+` FROM worker_keys WHERE key_hash = ?`, hash)
+	k, err := scanWorkerKey(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+// ListWorkerKeys returns all worker keys ordered by creation time (newest first).
+func (s *SQLiteStore) ListWorkerKeys(ctx context.Context) ([]*model.WorkerKey, error) {
+	s.logger.Debug("sql", "op", "list", "table", "worker_keys")
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+workerKeyColumns+` FROM worker_keys ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var keys []*model.WorkerKey
+	for rows.Next() {
+		k, err := scanWorkerKey(rows)
+		if err != nil {
+			s.logger.Error("skipping corrupt worker_key row", "error", err)
+			continue
+		}
+		keys = append(keys, k)
+	}
+	return keys, rows.Err()
+}
+
+// UpdateWorkerKey updates the mutable fields of a worker key (label, groups,
+// description, disabled, expiry). The key hash is immutable.
+func (s *SQLiteStore) UpdateWorkerKey(ctx context.Context, k *model.WorkerKey) error {
+	s.logger.Debug("sql", "op", "update", "table", "worker_keys", "id", k.ID)
+
+	groupsJSON, err := json.Marshal(k.Groups)
+	if err != nil {
+		return fmt.Errorf("marshal groups: %w", err)
+	}
+
+	disabled := 0
+	if k.Disabled {
+		disabled = 1
+	}
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE worker_keys SET label=?, groups=?, description=?, disabled=?, expires_at=?, last_used_at=? WHERE id=?`,
+		k.Label, string(groupsJSON), k.Description, disabled,
+		nullableTime(k.ExpiresAt), nullableTime(k.LastUsedAt), k.ID,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("worker key %s not found", k.ID)
+	}
+	return nil
+}
+
+// DeleteWorkerKey permanently removes (revokes) a worker key.
+func (s *SQLiteStore) DeleteWorkerKey(ctx context.Context, id string) error {
+	s.logger.Debug("sql", "op", "delete", "table", "worker_keys", "id", id)
+
+	result, err := s.db.ExecContext(ctx, `DELETE FROM worker_keys WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("worker key %s not found", id)
+	}
+	return nil
+}
+
+// CountWorkerKeys returns the number of configured worker keys. Used to decide
+// whether DB-backed worker-key enforcement is active.
+func (s *SQLiteStore) CountWorkerKeys(ctx context.Context) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM worker_keys`).Scan(&n)
+	return n, err
+}
+
+// TouchWorkerKey records that a key was used at the given time. Best-effort: a
+// missing key is not treated as an error.
+func (s *SQLiteStore) TouchWorkerKey(ctx context.Context, id string, when time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE worker_keys SET last_used_at=? WHERE id=?`,
+		when.Format(time.RFC3339Nano), id)
+	return err
+}

--- a/internal/store/worker_keys_test.go
+++ b/internal/store/worker_keys_test.go
@@ -1,0 +1,159 @@
+package store
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/me/gowe/pkg/model"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	st, err := NewSQLiteStore(":memory:", logger)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := st.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+func sampleWorkerKey(id, raw string) *model.WorkerKey {
+	return &model.WorkerKey{
+		ID:          id,
+		Label:       "esmfold-node-1",
+		KeyHash:     model.HashWorkerKey(raw),
+		KeyPrefix:   model.WorkerKeyDisplayPrefix(raw),
+		Groups:      []string{"esmfold", "default"},
+		Description: "test key",
+		CreatedBy:   "admin",
+		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+	}
+}
+
+func TestWorkerKeyCRUD(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	raw := "gwk_rawsecret123"
+	key := sampleWorkerKey("wk_1", raw)
+
+	if err := st.CreateWorkerKey(ctx, key); err != nil {
+		t.Fatalf("CreateWorkerKey: %v", err)
+	}
+
+	// Count reflects the new key.
+	if n, err := st.CountWorkerKeys(ctx); err != nil || n != 1 {
+		t.Fatalf("CountWorkerKeys = %d, %v; want 1, nil", n, err)
+	}
+
+	// Lookup by hash (the auth path).
+	got, err := st.GetWorkerKeyByHash(ctx, model.HashWorkerKey(raw))
+	if err != nil {
+		t.Fatalf("GetWorkerKeyByHash: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetWorkerKeyByHash returned nil for existing key")
+	}
+	if got.ID != "wk_1" || got.KeyPrefix != model.WorkerKeyDisplayPrefix(raw) {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+	if len(got.Groups) != 2 || got.Groups[0] != "esmfold" {
+		t.Errorf("groups roundtrip mismatch: %v", got.Groups)
+	}
+
+	// The raw secret must never be stored — only its hash.
+	if got.KeyHash != model.HashWorkerKey(raw) {
+		t.Errorf("stored hash mismatch")
+	}
+
+	// Lookup by ID.
+	byID, err := st.GetWorkerKeyByID(ctx, "wk_1")
+	if err != nil || byID == nil {
+		t.Fatalf("GetWorkerKeyByID: %v, %v", byID, err)
+	}
+
+	// Unknown hash returns nil, not error.
+	if k, err := st.GetWorkerKeyByHash(ctx, "deadbeef"); err != nil || k != nil {
+		t.Errorf("unknown hash: got %v, %v; want nil, nil", k, err)
+	}
+}
+
+func TestWorkerKeyUpdateAndTouch(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	raw := "gwk_updateme"
+	key := sampleWorkerKey("wk_upd", raw)
+	if err := st.CreateWorkerKey(ctx, key); err != nil {
+		t.Fatalf("CreateWorkerKey: %v", err)
+	}
+
+	// Disable + change expiry.
+	exp := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	key.Disabled = true
+	key.ExpiresAt = &exp
+	key.Groups = []string{"only-this"}
+	if err := st.UpdateWorkerKey(ctx, key); err != nil {
+		t.Fatalf("UpdateWorkerKey: %v", err)
+	}
+
+	got, _ := st.GetWorkerKeyByID(ctx, "wk_upd")
+	if !got.Disabled {
+		t.Errorf("Disabled not persisted")
+	}
+	if got.ExpiresAt == nil || !got.ExpiresAt.Equal(exp) {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, exp)
+	}
+	if len(got.Groups) != 1 || got.Groups[0] != "only-this" {
+		t.Errorf("Groups update not persisted: %v", got.Groups)
+	}
+
+	// Touch records last-used.
+	when := time.Now().UTC().Truncate(time.Second)
+	if err := st.TouchWorkerKey(ctx, "wk_upd", when); err != nil {
+		t.Fatalf("TouchWorkerKey: %v", err)
+	}
+	got, _ = st.GetWorkerKeyByID(ctx, "wk_upd")
+	if got.LastUsedAt == nil || !got.LastUsedAt.Equal(when) {
+		t.Errorf("LastUsedAt = %v, want %v", got.LastUsedAt, when)
+	}
+}
+
+func TestWorkerKeyDeleteAndList(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	if err := st.CreateWorkerKey(ctx, sampleWorkerKey("wk_a", "gwk_a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CreateWorkerKey(ctx, sampleWorkerKey("wk_b", "gwk_b")); err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err := st.ListWorkerKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkerKeys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("ListWorkerKeys len = %d, want 2", len(keys))
+	}
+
+	if err := st.DeleteWorkerKey(ctx, "wk_a"); err != nil {
+		t.Fatalf("DeleteWorkerKey: %v", err)
+	}
+	if n, _ := st.CountWorkerKeys(ctx); n != 1 {
+		t.Errorf("after delete count = %d, want 1", n)
+	}
+
+	// Deleting a missing key is an error (surfaces as 404 in the handler).
+	if err := st.DeleteWorkerKey(ctx, "wk_missing"); err == nil {
+		t.Errorf("DeleteWorkerKey(missing) = nil, want error")
+	}
+}

--- a/pkg/model/worker_key.go
+++ b/pkg/model/worker_key.go
@@ -1,0 +1,86 @@
+package model
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// WorkerKey is a per-worker authentication credential.
+//
+// Unlike the legacy shared worker key, each WorkerKey is individually
+// attributable (via ID/Label), independently revocable (Disabled or deleted),
+// and MAY carry an expiry. The raw secret is shown to the operator exactly once
+// at issuance; only its SHA-256 hash (KeyHash) is persisted, so the datastore
+// never holds the raw credential ("hashed at rest").
+type WorkerKey struct {
+	ID          string     `json:"id"`
+	Label       string     `json:"label"`
+	KeyHash     string     `json:"-"`          // sha256 hex of the raw key; never serialized
+	KeyPrefix   string     `json:"key_prefix"` // non-secret leading fragment, for attribution
+	Groups      []string   `json:"groups"`
+	Description string     `json:"description,omitempty"`
+	Disabled    bool       `json:"disabled"`
+	CreatedBy   string     `json:"created_by,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	LastUsedAt  *time.Time `json:"last_used_at,omitempty"`
+}
+
+// workerKeyRawPrefix marks raw worker-key secrets minted by GoWe ("GoWe Worker Key").
+const workerKeyRawPrefix = "gwk_"
+
+// workerKeyPrefixLen is how many leading characters of a raw key are retained as
+// the non-secret display prefix. The raw key carries 256 bits of entropy, so a
+// short prefix is safe to store and show for attribution.
+const workerKeyPrefixLen = 12
+
+// HashWorkerKey returns the hex-encoded SHA-256 of a raw worker key. This is the
+// canonical at-rest representation; raw keys themselves are never stored.
+func HashWorkerKey(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// WorkerKeyDisplayPrefix returns a short, non-secret leading fragment of a raw
+// key, suitable for display and log attribution.
+func WorkerKeyDisplayPrefix(raw string) string {
+	if len(raw) <= workerKeyPrefixLen {
+		return raw
+	}
+	return raw[:workerKeyPrefixLen]
+}
+
+// GenerateWorkerKey mints a new random worker key. It returns the raw secret
+// (to be shown to the operator exactly once) together with its SHA-256 hash and
+// display prefix. Callers persist only the hash and prefix.
+func GenerateWorkerKey() (raw, hash, prefix string, err error) {
+	buf := make([]byte, 32)
+	if _, err = rand.Read(buf); err != nil {
+		return "", "", "", fmt.Errorf("generate worker key: %w", err)
+	}
+	raw = workerKeyRawPrefix + base64.RawURLEncoding.EncodeToString(buf)
+	return raw, HashWorkerKey(raw), WorkerKeyDisplayPrefix(raw), nil
+}
+
+// MatchesRaw reports whether raw hashes to this key's stored hash, using a
+// constant-time comparison to avoid leaking information via timing.
+func (k *WorkerKey) MatchesRaw(raw string) bool {
+	return subtle.ConstantTimeCompare([]byte(k.KeyHash), []byte(HashWorkerKey(raw))) == 1
+}
+
+// IsActive reports whether the key may authenticate at time now: it must not be
+// disabled and must not be past its expiry (if one is set).
+func (k *WorkerKey) IsActive(now time.Time) bool {
+	if k.Disabled {
+		return false
+	}
+	if k.ExpiresAt != nil && !now.Before(*k.ExpiresAt) {
+		return false
+	}
+	return true
+}

--- a/pkg/model/worker_key_test.go
+++ b/pkg/model/worker_key_test.go
@@ -1,0 +1,83 @@
+package model
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateWorkerKey(t *testing.T) {
+	raw1, hash1, prefix1, err := GenerateWorkerKey()
+	if err != nil {
+		t.Fatalf("GenerateWorkerKey: %v", err)
+	}
+	if !strings.HasPrefix(raw1, "gwk_") {
+		t.Errorf("raw key %q missing gwk_ prefix", raw1)
+	}
+	if hash1 != HashWorkerKey(raw1) {
+		t.Errorf("returned hash does not match HashWorkerKey(raw)")
+	}
+	if prefix1 != raw1[:workerKeyPrefixLen] {
+		t.Errorf("prefix %q not a leading fragment of raw", prefix1)
+	}
+	if len(hash1) != 64 {
+		t.Errorf("hash length = %d, want 64 hex chars", len(hash1))
+	}
+
+	// Keys must be unique across calls.
+	raw2, _, _, err := GenerateWorkerKey()
+	if err != nil {
+		t.Fatalf("GenerateWorkerKey: %v", err)
+	}
+	if raw1 == raw2 {
+		t.Errorf("two generated keys collided: %q", raw1)
+	}
+}
+
+func TestHashWorkerKeyDeterministic(t *testing.T) {
+	h1 := HashWorkerKey("some-secret")
+	h2 := HashWorkerKey("some-secret")
+	if h1 != h2 {
+		t.Errorf("hash not deterministic: %q vs %q", h1, h2)
+	}
+	if HashWorkerKey("a") == HashWorkerKey("b") {
+		t.Errorf("distinct inputs produced same hash")
+	}
+}
+
+func TestWorkerKeyMatchesRaw(t *testing.T) {
+	raw, hash, _, _ := GenerateWorkerKey()
+	k := &WorkerKey{KeyHash: hash}
+	if !k.MatchesRaw(raw) {
+		t.Errorf("MatchesRaw(correct key) = false, want true")
+	}
+	if k.MatchesRaw(raw + "x") {
+		t.Errorf("MatchesRaw(wrong key) = true, want false")
+	}
+}
+
+func TestWorkerKeyIsActive(t *testing.T) {
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Hour)
+
+	tests := []struct {
+		name string
+		key  WorkerKey
+		want bool
+	}{
+		{"enabled no expiry", WorkerKey{}, true},
+		{"disabled", WorkerKey{Disabled: true}, false},
+		{"not yet expired", WorkerKey{ExpiresAt: &future}, true},
+		{"expired", WorkerKey{ExpiresAt: &past}, false},
+		{"expires exactly now", WorkerKey{ExpiresAt: &now}, false},
+		{"disabled and unexpired", WorkerKey{Disabled: true, ExpiresAt: &future}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.key.IsActive(now); got != tt.want {
+				t.Errorf("IsActive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the single **shared** worker key with **per-worker keys** that can be issued and revoked independently, closing the hardening item documented in `SPECIFICATION.md` §13.7 and [ADR-0009](docs/adr/0009-delegated-identity-and-optional-worker-keys.md). A leaked worker's key can now be rotated without disrupting the fleet, and keys are **hashed at rest** so the datastore never holds the raw secret.

> Targets `docs/architecture-spec-adrs` (PR #135), which introduced the spec/ADR baseline this builds on. Rebase onto `main` once #135 merges.

## What's included

- **`model.WorkerKey`** — crypto-random `gwk_…` keys, SHA-256 hashing, constant-time compare, and disabled/expiry lifecycle (`pkg/model/worker_key.go`).
- **Store** — a `worker_keys` table persisting **only the hash** (plus a non-secret prefix + stable id for attribution), with CRUD, `CountWorkerKeys`, and last-used tracking (`internal/store/worker_keys.go`, `migrations.go`).
- **`WorkerKeyAuthenticator`** — validates the `X-Worker-Key` header against **both** static config (file/env) and DB-backed keys, enforces disabled/expiry, records usage, and **fails closed** on a store error so a DB blip can't silently open the fleet (`internal/server/worker_auth.go`).
- **Static keys hardened too** — `WorkerKeyEntry` gains `id`/`disabled`/`expires_at`, plus a `sha256:<hex>` sentinel so static entries can also be stored hashed rather than plaintext.
- **Admin API** — `POST/GET/PATCH/DELETE /api/v1/admin/worker-keys` behind `requireAdmin`. Minting returns the raw key **exactly once**; list/responses never expose the hash (`internal/server/handler_worker_keys.go`).
- **Backward compatible** — existing `--worker-key`, `--worker-keys` file, and `GOWE_WORKER_KEYS` env all still work; **no keys configured = open access** is preserved for local/dev.

## Lifecycle

```
admin POST /admin/worker-keys  ->  raw key (shown once) + metadata
worker --worker-key gwk_...     ->  X-Worker-Key header
admin PATCH {disabled:true}     ->  reversible revoke
admin DELETE /{id}              ->  permanent revoke (other keys unaffected)
```

## Tests

- `pkg/model` — generation/uniqueness, deterministic hashing, `IsActive` (disabled/expired boundaries).
- `internal/store` — CRUD roundtrip, hash-only persistence, update/touch, delete/list.
- `internal/server` — authenticator (static + DB, disabled/expired/revoked in isolation, `sha256:` sentinel), middleware 401/open-access, and the full admin mint → list → disable → re-enable → revoke HTTP flow, asserting the hash is never serialized.

## Docs

- `SPECIFICATION.md` §13.3/§13.5 (normative auth + hashed-at-rest rules), §13.7 (shared-key caveat updated to mitigated), version bumped to draft-4.
- `docs/tools/worker.md` — Worker keys section (per-worker vs static, issue/manage/revoke).
- `docs/tools/server.md` — config + admin endpoint reference.
- `docs/adr/0009` — Decision/Consequences updated.

## Verification

- `GOOS=linux go build ./...` succeeds for all packages.
- Full test suite passes (the only local failure is the pre-existing macOS-only `syscall.Sysinfo` build issue in `internal/worker`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)