### PR TITLE
ci: add Security changelog section and document PAT token option

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,17 @@ jobs:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: rp
         with:
+          # Uses the default GITHUB_TOKEN. This requires the repo setting
+          # "Allow GitHub Actions to create and approve pull requests" to be ON
+          # (Settings → Actions → General → Workflow permissions), otherwise
+          # release-please cannot open its release PR.
+          #
+          # Caveat: a tag/Release created with GITHUB_TOKEN does NOT trigger
+          # other tag/release-listening workflows — which is why GoReleaser runs
+          # in the goreleaser job below rather than on a tag trigger. If you add
+          # downstream workflows that must fire on the release, swap this for a
+          # PAT or GitHub App token (e.g. token: ${{ secrets.RELEASE_PLEASE_PAT }})
+          # so the resulting events cascade.
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,21 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "security", "section": "Security" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
The first automated release PR (#144, v0.12.1) dropped `security:`-typed commits from the changelog because release-please only maps `feat`/`fix` by default. Notably #138 (provider-token encryption at rest) was missing from the release notes.

- Add an explicit `changelog-sections` mapping so `security:` renders under a **Security** heading (plus `perf`/`revert`), keeping `docs`/`chore`/`ci`/etc. hidden as before.
- Document at the `token:` input why the default `GITHUB_TOKEN` needs the "Allow Actions to create PRs" repo setting, and when to switch to a PAT/App token (downstream workflows that must fire on the release tag).

After merge, re-running release-please regenerates #144 with #138 under Security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)