### PR TITLE
ci: bump minor (not patch) for features while pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
release-please proposed `0.12.1` (a patch) for release PR #144, but this release carries **31 `feat` commits** since `v0.12.0` (native TLS #136, token encryption #138, per-worker keys #139, scoped token injection #132, …) with no breaking changes — semantically a **minor** bump. A `v0.13.0-alpha` pre-release already exists, so `0.12.1` would sort *below* it.

Removing `bump-patch-for-minor-pre-major` (keeping `bump-minor-pre-major`) makes features bump the minor digit pre-1.0. After merge, release-please regenerates #144 as **`0.13.0`**, cleanly superseding the alpha; future feature releases bump minor too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)