### PR TITLE
security(tokencrypt): bind at-rest token ciphertext to its row (enc:v2 AAD)

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -450,7 +450,7 @@ func (s *SQLiteStore) CreateSubmission(ctx context.Context, sub *model.Submissio
 
 	// Encrypt the submitter's provider token before it touches disk. The
 	// in-memory sub.UserToken stays plaintext for the delegation path.
-	storedToken, err := s.encryptToken(sub.UserToken)
+	storedToken, err := s.encryptToken(sub.UserToken, submissionTokenAAD(sub.ID))
 	if err != nil {
 		return err
 	}
@@ -493,7 +493,7 @@ func (s *SQLiteStore) GetSubmission(ctx context.Context, id string) (*model.Subm
 	}
 
 	sub.State = model.SubmissionState(state)
-	if sub.UserToken, err = s.decryptToken(sub.UserToken); err != nil {
+	if sub.UserToken, err = s.decryptToken(sub.UserToken, submissionTokenAAD(sub.ID)); err != nil {
 		return nil, fmt.Errorf("decrypt user token: %w", err)
 	}
 	if err := unmarshalJSON(inputsJSON, &sub.Inputs, "inputs"); err != nil {
@@ -618,7 +618,7 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 		}
 
 		sub.State = model.SubmissionState(state)
-		if sub.UserToken, err = s.decryptToken(sub.UserToken); err != nil {
+		if sub.UserToken, err = s.decryptToken(sub.UserToken, submissionTokenAAD(sub.ID)); err != nil {
 			slog.Error("skipping submission row with undecryptable token", "id", sub.ID, "error", err)
 			continue
 		}
@@ -1113,7 +1113,7 @@ func (s *SQLiteStore) CreateTask(ctx context.Context, task *model.Task) error {
 	if err != nil {
 		return fmt.Errorf("marshal job: %w", err)
 	}
-	runtimeHintsJSON, err := s.marshalRuntimeHints(task.RuntimeHints)
+	runtimeHintsJSON, err := s.marshalRuntimeHints(task.RuntimeHints, taskHintsAAD(task.ID))
 	if err != nil {
 		return err
 	}
@@ -1259,7 +1259,7 @@ func (s *SQLiteStore) UpdateTask(ctx context.Context, task *model.Task) error {
 	if err != nil {
 		return fmt.Errorf("marshal job: %w", err)
 	}
-	runtimeHintsJSON, err := s.marshalRuntimeHints(task.RuntimeHints)
+	runtimeHintsJSON, err := s.marshalRuntimeHints(task.RuntimeHints, taskHintsAAD(task.ID))
 	if err != nil {
 		return err
 	}
@@ -1488,7 +1488,7 @@ func (s *SQLiteStore) scanTask(row scanner) (*model.Task, error) {
 	if err := unmarshalJSON(runtimeHintsJSON, &task.RuntimeHints, "runtime_hints"); err != nil {
 		return nil, err
 	}
-	if err := s.revealRuntimeHints(task.RuntimeHints); err != nil {
+	if err := s.revealRuntimeHints(task.RuntimeHints, taskHintsAAD(task.ID)); err != nil {
 		return nil, fmt.Errorf("decrypt runtime_hints token: %w", err)
 	}
 	if task.CreatedAt, err = parseTimeOrZero(createdAt); err != nil {
@@ -1560,7 +1560,7 @@ func (s *SQLiteStore) scanTasks(rows *sql.Rows) ([]*model.Task, error) {
 			slog.Error("skipping corrupt task row", "id", task.ID, "error", err)
 			continue
 		}
-		if err := s.revealRuntimeHints(task.RuntimeHints); err != nil {
+		if err := s.revealRuntimeHints(task.RuntimeHints, taskHintsAAD(task.ID)); err != nil {
 			slog.Error("skipping task row with undecryptable token", "id", task.ID, "error", err)
 			continue
 		}
@@ -1936,7 +1936,7 @@ func (s *SQLiteStore) CheckoutTask(ctx context.Context, workerID string, workerG
 			slog.Error("skipping corrupt task row in checkout", "id", task.ID, "error", err)
 			continue
 		}
-		if err := s.revealRuntimeHints(task.RuntimeHints); err != nil {
+		if err := s.revealRuntimeHints(task.RuntimeHints, taskHintsAAD(task.ID)); err != nil {
 			slog.Error("skipping task row with undecryptable token in checkout", "id", task.ID, "error", err)
 			continue
 		}

--- a/internal/store/tokens.go
+++ b/internal/store/tokens.go
@@ -30,13 +30,21 @@ func (s *SQLiteStore) ConfigureTokenEncryption(cipher *tokencrypt.Cipher, refuse
 	s.refusePlaintextTokens = refusePlaintext
 }
 
-// encryptToken prepares a token for persistence per the configured policy.
-func (s *SQLiteStore) encryptToken(token string) (string, error) {
+// submissionTokenAAD and taskHintsAAD build the context strings that bind a
+// ciphertext to the row/column it is stored in (AES-GCM AAD, see tokencrypt).
+// They MUST be stable for a given row across encrypt and decrypt.
+func submissionTokenAAD(id string) string { return "submission.user_token:" + id }
+func taskHintsAAD(id string) string       { return "task.runtime_hints.http_credential:" + id }
+
+// encryptToken prepares a token for persistence per the configured policy,
+// binding aad as the storage context so the ciphertext cannot be relocated to
+// another row.
+func (s *SQLiteStore) encryptToken(token, aad string) (string, error) {
 	if token == "" {
 		return "", nil
 	}
 	if s.cipher != nil {
-		return s.cipher.Encrypt(token)
+		return s.cipher.Encrypt(token, aad)
 	}
 	if s.refusePlaintextTokens {
 		return "", fmt.Errorf("refusing to persist provider token in plaintext: no encryption key configured (set %s, or start the server with --allow-plaintext-tokens to override)", tokencrypt.EnvKeyVar)
@@ -51,12 +59,12 @@ func (s *SQLiteStore) encryptToken(token string) (string, error) {
 // Without a cipher, a plaintext value passes through, but a value that is
 // marked as encrypted is an error (the key is missing/misconfigured) rather
 // than something to hand downstream as if it were a real token.
-func (s *SQLiteStore) decryptToken(stored string) (string, error) {
+func (s *SQLiteStore) decryptToken(stored, aad string) (string, error) {
 	if stored == "" {
 		return "", nil
 	}
 	if s.cipher != nil {
-		return s.cipher.Decrypt(stored)
+		return s.cipher.Decrypt(stored, aad)
 	}
 	if tokencrypt.IsEncrypted(stored) {
 		return "", fmt.Errorf("stored token is encrypted but no key is configured (set %s)", tokencrypt.EnvKeyVar)
@@ -66,8 +74,8 @@ func (s *SQLiteStore) decryptToken(stored string) (string, error) {
 
 // marshalRuntimeHints marshals task runtime hints for persistence, encrypting an
 // embedded HTTP bearer token when required by policy.
-func (s *SQLiteStore) marshalRuntimeHints(h *model.RuntimeHints) (string, error) {
-	stored, err := s.runtimeHintsForStorage(h)
+func (s *SQLiteStore) marshalRuntimeHints(h *model.RuntimeHints, aad string) (string, error) {
+	stored, err := s.runtimeHintsForStorage(h, aad)
 	if err != nil {
 		return "", err
 	}
@@ -82,14 +90,14 @@ func (s *SQLiteStore) marshalRuntimeHints(h *model.RuntimeHints) (string, error)
 // HTTP bearer token encrypted for storage. The input is never mutated, so
 // callers keep operating on the live, plaintext token in memory. Returns h
 // unchanged when there is no token to protect.
-func (s *SQLiteStore) runtimeHintsForStorage(h *model.RuntimeHints) (*model.RuntimeHints, error) {
+func (s *SQLiteStore) runtimeHintsForStorage(h *model.RuntimeHints, aad string) (*model.RuntimeHints, error) {
 	if h == nil || h.StagerOverrides == nil || h.StagerOverrides.HTTPCredential == nil {
 		return h, nil
 	}
 	if h.StagerOverrides.HTTPCredential.Token == "" {
 		return h, nil
 	}
-	enc, err := s.encryptToken(h.StagerOverrides.HTTPCredential.Token)
+	enc, err := s.encryptToken(h.StagerOverrides.HTTPCredential.Token, aad)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +113,7 @@ func (s *SQLiteStore) runtimeHintsForStorage(h *model.RuntimeHints) (*model.Runt
 
 // revealRuntimeHints decrypts an embedded HTTP bearer token in freshly-scanned
 // task runtime hints, in place. Safe because each read produces a fresh object.
-func (s *SQLiteStore) revealRuntimeHints(h *model.RuntimeHints) error {
+func (s *SQLiteStore) revealRuntimeHints(h *model.RuntimeHints, aad string) error {
 	if h == nil || h.StagerOverrides == nil || h.StagerOverrides.HTTPCredential == nil {
 		return nil
 	}
@@ -113,7 +121,7 @@ func (s *SQLiteStore) revealRuntimeHints(h *model.RuntimeHints) error {
 	if cred.Token == "" {
 		return nil
 	}
-	pt, err := s.decryptToken(cred.Token)
+	pt, err := s.decryptToken(cred.Token, aad)
 	if err != nil {
 		return err
 	}
@@ -148,10 +156,19 @@ func (s *SQLiteStore) ReencryptPlaintextTokens(ctx context.Context) (subs int, t
 			rows.Close()
 			return subs, tasks, fmt.Errorf("scan submission token: %w", err)
 		}
-		if tokencrypt.IsEncrypted(tok) {
+		// Already in the current AAD-bound format: nothing to do.
+		if tokencrypt.IsEncrypted(tok) && !tokencrypt.NeedsAADUpgrade(tok) {
 			continue
 		}
-		enc, encErr := s.cipher.Encrypt(tok)
+		aad := submissionTokenAAD(id)
+		// Normalize plaintext or legacy v1 to v2. Decrypt passes plaintext
+		// through and decrypts v1 with no AAD; Encrypt re-binds it to this row.
+		pt, decErr := s.cipher.Decrypt(tok, aad)
+		if decErr != nil {
+			s.logger.Error("re-encrypt submission token", "id", id, "error", decErr)
+			continue
+		}
+		enc, encErr := s.cipher.Encrypt(pt, aad)
 		if encErr != nil {
 			s.logger.Error("re-encrypt submission token", "id", id, "error", encErr)
 			continue
@@ -190,10 +207,16 @@ func (s *SQLiteStore) ReencryptPlaintextTokens(ctx context.Context) (subs int, t
 			continue
 		}
 		tok := h.StagerOverrides.HTTPCredential.Token
-		if tok == "" || tokencrypt.IsEncrypted(tok) {
+		if tok == "" || (tokencrypt.IsEncrypted(tok) && !tokencrypt.NeedsAADUpgrade(tok)) {
 			continue
 		}
-		enc, encErr := s.cipher.Encrypt(tok)
+		aad := taskHintsAAD(id)
+		pt, decErr := s.cipher.Decrypt(tok, aad)
+		if decErr != nil {
+			s.logger.Error("re-encrypt task token", "id", id, "error", decErr)
+			continue
+		}
+		enc, encErr := s.cipher.Encrypt(pt, aad)
 		if encErr != nil {
 			s.logger.Error("re-encrypt task token", "id", id, "error", encErr)
 			continue

--- a/internal/store/tokens_test.go
+++ b/internal/store/tokens_test.go
@@ -159,8 +159,8 @@ func TestTaskRuntimeHintsTokenEncryptedAtRest(t *testing.T) {
 	if strings.Contains(raw, secret) {
 		t.Fatalf("stored runtime_hints leaks plaintext token: %q", raw)
 	}
-	if !strings.Contains(raw, "enc:v1:") {
-		t.Fatalf("stored runtime_hints token not encrypted: %q", raw)
+	if !strings.Contains(raw, "enc:v2:") {
+		t.Fatalf("stored runtime_hints token not encrypted (expected v2/AAD-bound): %q", raw)
 	}
 
 	got, err := st.GetTask(ctx, "task_enc")
@@ -216,5 +216,56 @@ func TestReencryptPlaintextTokens(t *testing.T) {
 	nSub2, nTask2, err := st.ReencryptPlaintextTokens(ctx)
 	if err != nil || nSub2 != 0 || nTask2 != 0 {
 		t.Fatalf("second migration not idempotent: (%d,%d) err=%v", nSub2, nTask2, err)
+	}
+}
+
+// TestSubmissionTokenAADRejectsRelocation proves the at-rest ciphertext is bound
+// to its row: a blob valid for one submission fails to decrypt when moved into
+// another submission's row (GH #142 — AAD/enc:v2).
+func TestSubmissionTokenAADRejectsRelocation(t *testing.T) {
+	st := testStore(t)
+	st.ConfigureTokenEncryption(testTokenCipher(t), true)
+	ctx := context.Background()
+
+	if err := st.CreateSubmission(ctx, tokenSubmission("sub_A", "token-A|sig=aaa")); err != nil {
+		t.Fatalf("create sub_A: %v", err)
+	}
+	if err := st.CreateSubmission(ctx, tokenSubmission("sub_B", "token-B|sig=bbb")); err != nil {
+		t.Fatalf("create sub_B: %v", err)
+	}
+
+	// Transplant sub_A's ciphertext into sub_B's row (simulating a DB-write
+	// attacker relocating a credential).
+	cipherA := rawSubmissionToken(t, st, "sub_A")
+	if _, err := st.db.ExecContext(ctx,
+		`UPDATE submissions SET user_token=? WHERE id=?`, cipherA, "sub_B"); err != nil {
+		t.Fatalf("transplant: %v", err)
+	}
+
+	// Reading sub_B must now fail: the AAD binds cipherA to sub_A, not sub_B.
+	if _, err := st.GetSubmission(ctx, "sub_B"); err == nil {
+		t.Fatal("GetSubmission(sub_B) with relocated ciphertext: expected decrypt error, got nil")
+	}
+	// sub_A itself still decrypts fine.
+	if got, err := st.GetSubmission(ctx, "sub_A"); err != nil || got.UserToken != "token-A|sig=aaa" {
+		t.Fatalf("sub_A still valid: got (%v, %v)", got.UserToken, err)
+	}
+}
+
+// TestReadFailsClosedWithoutKey verifies that once a token is stored encrypted,
+// reading it back with no cipher configured is a hard error rather than handing
+// the ciphertext downstream as if it were a token (GH #142 read-side fail-closed).
+func TestReadFailsClosedWithoutKey(t *testing.T) {
+	st := testStore(t)
+	st.ConfigureTokenEncryption(testTokenCipher(t), true)
+	ctx := context.Background()
+
+	if err := st.CreateSubmission(ctx, tokenSubmission("sub_fc", "secret|sig=xyz")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Simulate a restart with the key removed/misconfigured.
+	st.ConfigureTokenEncryption(nil, true)
+	if _, err := st.GetSubmission(ctx, "sub_fc"); err == nil {
+		t.Fatal("GetSubmission with encrypted token and no key: expected error, got nil")
 	}
 }

--- a/internal/tokencrypt/tokencrypt.go
+++ b/internal/tokencrypt/tokencrypt.go
@@ -5,12 +5,20 @@
 // Values are encrypted with AES-256-GCM under a single server-held key and
 // stored as a self-describing string:
 //
-//	enc:v1:<base64(nonce || ciphertext || tag)>
+//	enc:v2:<base64(nonce || ciphertext || tag)>   // current: AAD-bound
+//	enc:v1:<base64(nonce || ciphertext || tag)>   // legacy: no AAD
 //
-// The marker prefix lets readers distinguish ciphertext from legacy plaintext
-// rows written before encryption was enabled, so an operator can turn the key
-// on without a hard cutover: unmarked values pass through unchanged until they
-// are re-encrypted.
+// New writes use v2, which binds the ciphertext to a caller-supplied context
+// string (the row/column it lives in) as AES-GCM Additional Authenticated Data.
+// A v2 blob only decrypts under the same context, so an attacker with DB-write
+// access cannot relocate one row's ciphertext into another row and have it
+// decrypt as that row's token. v1 blobs (written before AAD binding) still
+// decrypt for backward compatibility, using no AAD.
+//
+// The marker prefix also lets readers distinguish ciphertext from legacy
+// plaintext rows written before encryption was enabled, so an operator can turn
+// the key on without a hard cutover: unmarked values pass through unchanged
+// until they are re-encrypted.
 package tokencrypt
 
 import (
@@ -30,9 +38,12 @@ import (
 // encoded as base64 (standard or raw) or hex and decoding to exactly 32 bytes.
 const EnvKeyVar = "GOWE_TOKEN_KEY"
 
-// marker prefixes an encrypted value. The version segment allows the on-disk
-// format to evolve without ambiguity.
-const marker = "enc:v1:"
+// Marker prefixes for the on-disk encrypted formats. The version segment lets
+// the format evolve without ambiguity. markerV2 binds AAD; markerV1 does not.
+const (
+	markerV1 = "enc:v1:"
+	markerV2 = "enc:v2:"
+)
 
 // keyLen is the AES-256 key length in bytes.
 const keyLen = 32
@@ -93,15 +104,24 @@ func FromEnv() (*Cipher, error) {
 	return New(key)
 }
 
-// IsEncrypted reports whether v was produced by Encrypt (has the marker prefix).
+// IsEncrypted reports whether v was produced by Encrypt (has a v1 or v2 marker).
 func IsEncrypted(v string) bool {
-	return strings.HasPrefix(v, marker)
+	return strings.HasPrefix(v, markerV2) || strings.HasPrefix(v, markerV1)
 }
 
-// Encrypt returns a marked, authenticated ciphertext for plaintext. Empty input
-// returns empty output (there is nothing to protect). Each call draws a fresh
-// random nonce, so encrypting the same token twice yields different ciphertexts.
-func (c *Cipher) Encrypt(plaintext string) (string, error) {
+// NeedsAADUpgrade reports whether v is an encrypted value not yet bound to a
+// context (a legacy v1 blob). The migration uses this to re-encrypt v1 rows into
+// the AAD-bound v2 format.
+func NeedsAADUpgrade(v string) bool {
+	return strings.HasPrefix(v, markerV1)
+}
+
+// Encrypt returns a v2 marked, authenticated ciphertext for plaintext, binding
+// aad as Additional Authenticated Data so the value only decrypts under the same
+// context. Empty input returns empty output (there is nothing to protect). Each
+// call draws a fresh random nonce, so encrypting the same token twice yields
+// different ciphertexts.
+func (c *Cipher) Encrypt(plaintext, aad string) (string, error) {
 	if plaintext == "" {
 		return "", nil
 	}
@@ -109,22 +129,33 @@ func (c *Cipher) Encrypt(plaintext string) (string, error) {
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return "", fmt.Errorf("tokencrypt: read nonce: %w", err)
 	}
-	sealed := c.aead.Seal(nonce, nonce, []byte(plaintext), nil)
-	return marker + base64.StdEncoding.EncodeToString(sealed), nil
+	sealed := c.aead.Seal(nonce, nonce, []byte(plaintext), aadBytes(aad))
+	return markerV2 + base64.StdEncoding.EncodeToString(sealed), nil
 }
 
-// Decrypt reverses Encrypt. A value without the marker is treated as legacy
-// plaintext and returned unchanged, so rows written before encryption was
-// enabled keep working until they are re-encrypted. Empty input returns empty.
-// A marked-but-corrupt or wrong-key value returns an error.
-func (c *Cipher) Decrypt(v string) (string, error) {
+// Decrypt reverses Encrypt. A v2 value is authenticated against aad; a legacy v1
+// value is decrypted with no AAD (aad is ignored). A value without a marker is
+// treated as legacy plaintext and returned unchanged, so rows written before
+// encryption was enabled keep working until they are re-encrypted. Empty input
+// returns empty. A marked-but-corrupt, wrong-key, or wrong-context value returns
+// an error.
+func (c *Cipher) Decrypt(v, aad string) (string, error) {
 	if v == "" {
 		return "", nil
 	}
-	if !IsEncrypted(v) {
+	switch {
+	case strings.HasPrefix(v, markerV2):
+		return c.open(strings.TrimPrefix(v, markerV2), aadBytes(aad))
+	case strings.HasPrefix(v, markerV1):
+		return c.open(strings.TrimPrefix(v, markerV1), nil)
+	default:
 		return v, nil // legacy plaintext passthrough
 	}
-	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(v, marker))
+}
+
+// open decodes and authenticates a base64 nonce||ciphertext||tag blob.
+func (c *Cipher) open(b64 string, aad []byte) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {
 		return "", fmt.Errorf("tokencrypt: decode ciphertext: %w", err)
 	}
@@ -133,9 +164,18 @@ func (c *Cipher) Decrypt(v string) (string, error) {
 		return "", errors.New("tokencrypt: ciphertext too short")
 	}
 	nonce, ct := raw[:ns], raw[ns:]
-	pt, err := c.aead.Open(nil, nonce, ct, nil)
+	pt, err := c.aead.Open(nil, nonce, ct, aad)
 	if err != nil {
 		return "", fmt.Errorf("tokencrypt: authenticate/decrypt: %w", err)
 	}
 	return string(pt), nil
+}
+
+// aadBytes converts a context string to AAD bytes; an empty context yields nil
+// so it is interchangeable with "no AAD".
+func aadBytes(aad string) []byte {
+	if aad == "" {
+		return nil
+	}
+	return []byte(aad)
 }

--- a/internal/tokencrypt/tokencrypt_test.go
+++ b/internal/tokencrypt/tokencrypt_test.go
@@ -30,13 +30,17 @@ func TestNewRejectsBadKeyLength(t *testing.T) {
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {
 	c := testCipher(t)
+	const aad = "submission.user_token:sub_123"
 	for _, pt := range []string{"a", "bvbrc|token|expiry=123|sig=abc", strings.Repeat("x", 4096)} {
-		enc, err := c.Encrypt(pt)
+		enc, err := c.Encrypt(pt, aad)
 		if err != nil {
 			t.Fatalf("Encrypt: %v", err)
 		}
 		if !IsEncrypted(enc) {
 			t.Fatalf("ciphertext missing marker: %q", enc)
+		}
+		if !strings.HasPrefix(enc, markerV2) {
+			t.Fatalf("new writes must use v2 format: %q", enc)
 		}
 		// The leak check is only meaningful for plaintexts long enough that a
 		// coincidental substring in the base64 ciphertext is negligible. A
@@ -45,7 +49,7 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 		if len(pt) >= 8 && strings.Contains(enc, pt) {
 			t.Fatalf("ciphertext leaks plaintext: %q", enc)
 		}
-		got, err := c.Decrypt(enc)
+		got, err := c.Decrypt(enc, aad)
 		if err != nil {
 			t.Fatalf("Decrypt: %v", err)
 		}
@@ -55,13 +59,60 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	}
 }
 
+// TestAADBindingRejectsWrongContext verifies a v2 ciphertext only decrypts under
+// the exact context it was sealed with — so a blob moved to another row (a
+// different AAD) fails authentication rather than decrypting as that row's token.
+func TestAADBindingRejectsWrongContext(t *testing.T) {
+	c := testCipher(t)
+	enc, err := c.Encrypt("secret-token", "submission.user_token:sub_A")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Same context: succeeds.
+	if got, err := c.Decrypt(enc, "submission.user_token:sub_A"); err != nil || got != "secret-token" {
+		t.Fatalf("Decrypt with matching AAD: got (%q, %v)", got, err)
+	}
+	// Different row's context: must fail.
+	if _, err := c.Decrypt(enc, "submission.user_token:sub_B"); err == nil {
+		t.Fatal("Decrypt with wrong AAD context: expected error, got nil (ciphertext relocatable)")
+	}
+	// Empty context (as a v1 reader would use): must also fail for a v2 blob.
+	if _, err := c.Decrypt(enc, ""); err == nil {
+		t.Fatal("Decrypt of v2 blob with empty AAD: expected error, got nil")
+	}
+}
+
+// TestDecryptLegacyV1NoAAD verifies that ciphertext written in the pre-AAD v1
+// format still decrypts (using no AAD), so existing rows keep working.
+func TestDecryptLegacyV1NoAAD(t *testing.T) {
+	c := testCipher(t)
+	// Build a v1 blob directly (the old format: nonce||ct||tag, no AAD).
+	nonce := make([]byte, c.aead.NonceSize())
+	sealed := c.aead.Seal(nonce, nonce, []byte("legacy-secret"), nil)
+	v1 := markerV1 + base64.StdEncoding.EncodeToString(sealed)
+
+	if !NeedsAADUpgrade(v1) {
+		t.Error("NeedsAADUpgrade(v1) = false, want true")
+	}
+	// Decrypts regardless of the aad argument (v1 ignores it).
+	for _, aad := range []string{"", "some.context:id"} {
+		got, err := c.Decrypt(v1, aad)
+		if err != nil {
+			t.Fatalf("Decrypt(v1, %q): %v", aad, err)
+		}
+		if got != "legacy-secret" {
+			t.Fatalf("v1 round-trip mismatch: got %q", got)
+		}
+	}
+}
+
 func TestEmptyIsNoop(t *testing.T) {
 	c := testCipher(t)
-	enc, err := c.Encrypt("")
+	enc, err := c.Encrypt("", "ctx")
 	if err != nil || enc != "" {
 		t.Fatalf("Encrypt(\"\") = %q, %v; want \"\", nil", enc, err)
 	}
-	dec, err := c.Decrypt("")
+	dec, err := c.Decrypt("", "ctx")
 	if err != nil || dec != "" {
 		t.Fatalf("Decrypt(\"\") = %q, %v; want \"\", nil", dec, err)
 	}
@@ -69,8 +120,8 @@ func TestEmptyIsNoop(t *testing.T) {
 
 func TestNonceIsRandomised(t *testing.T) {
 	c := testCipher(t)
-	a, _ := c.Encrypt("same-secret")
-	b, _ := c.Encrypt("same-secret")
+	a, _ := c.Encrypt("same-secret", "ctx")
+	b, _ := c.Encrypt("same-secret", "ctx")
 	if a == b {
 		t.Fatalf("expected distinct ciphertexts for repeated Encrypt, got identical: %q", a)
 	}
@@ -78,36 +129,39 @@ func TestNonceIsRandomised(t *testing.T) {
 
 func TestDecryptLegacyPlaintextPassthrough(t *testing.T) {
 	c := testCipher(t)
-	// A value without the marker is a pre-encryption row; return it unchanged.
-	got, err := c.Decrypt("legacy-plain-token")
+	// A value without a marker is a pre-encryption row; return it unchanged.
+	got, err := c.Decrypt("legacy-plain-token", "ctx")
 	if err != nil {
 		t.Fatalf("Decrypt(plaintext): %v", err)
 	}
 	if got != "legacy-plain-token" {
 		t.Fatalf("passthrough mismatch: got %q", got)
 	}
+	if IsEncrypted("legacy-plain-token") {
+		t.Error("IsEncrypted(plaintext) = true")
+	}
 }
 
 func TestDecryptWrongKeyFails(t *testing.T) {
 	c := testCipher(t)
-	enc, _ := c.Encrypt("secret")
+	enc, _ := c.Encrypt("secret", "ctx")
 
 	other, err := New([]byte("0123456789abcdef0123456789abcdef")) // 32 bytes, different key
 	if err != nil {
 		t.Fatalf("New other: %v", err)
 	}
-	if _, err := other.Decrypt(enc); err == nil {
+	if _, err := other.Decrypt(enc, "ctx"); err == nil {
 		t.Fatal("Decrypt with wrong key: expected error, got nil")
 	}
 }
 
 func TestDecryptTamperedFails(t *testing.T) {
 	c := testCipher(t)
-	enc, _ := c.Encrypt("secret")
-	raw, _ := base64.StdEncoding.DecodeString(strings.TrimPrefix(enc, marker))
+	enc, _ := c.Encrypt("secret", "ctx")
+	raw, _ := base64.StdEncoding.DecodeString(strings.TrimPrefix(enc, markerV2))
 	raw[len(raw)-1] ^= 0xFF // flip a tag bit
-	tampered := marker + base64.StdEncoding.EncodeToString(raw)
-	if _, err := c.Decrypt(tampered); err == nil {
+	tampered := markerV2 + base64.StdEncoding.EncodeToString(raw)
+	if _, err := c.Decrypt(tampered, "ctx"); err == nil {
 		t.Fatal("Decrypt of tampered ciphertext: expected error, got nil")
 	}
 }


### PR DESCRIPTION
Closes #142.

Hardens the #138 at-rest token encryption per the crypto red-team's F1 (plus F2/F3).

## Problem
AES-256-GCM sealed with no AAD, so a DB-write attacker could transplant one row's ciphertext into another row and it would decrypt as that row's token — a confused-deputy on the delegated-identity path.

## Fix
- **`enc:v2` format** binds each ciphertext to a stable context string (`submission.user_token:<id>` / `task.runtime_hints.http_credential:<id>`) as GCM AAD; a v2 blob only decrypts under the same context. **Legacy `enc:v1` still decrypts** (no AAD) for backward compatibility.
- Context threaded through `encryptToken`/`decryptToken`, `marshal`/`revealRuntimeHints`, and all submission/task read+write call sites.
- `ReencryptPlaintextTokens` upgrades **v1 → v2** (re-binding AAD) as well as plaintext → encrypted, so existing rows gain binding on next startup.
- F2: `IsEncrypted` handles v1+v2; `NeedsAADUpgrade` flags v1. F3: list-path decrypt failures already log-and-skip while single-row reads hard-error (consistent split, left as-is).

## Tests
AAD cross-context/relocation rejection (crypto-level **and** end-to-end store), v1 backward-compat decrypt, read-side fail-closed when the key is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)