### PR TITLE
security(worker-keys): stop PATCH clobbering last_used_at; test admin gate

### DIFF
--- a/internal/server/worker_key_auth_test.go
+++ b/internal/server/worker_key_auth_test.go
@@ -395,3 +395,81 @@ func TestUpdateWorkerKey_RejectsEmptyGroups(t *testing.T) {
 		t.Errorf("PATCH groups=[]: status=%d, want 400", rec.Code)
 	}
 }
+
+// guardedWorkerKeyRouter mounts the worker-key admin routes behind the REAL
+// requireAdmin middleware, injecting the given principal (nil = unauthenticated).
+// Unlike adminRouter, this exercises the authorization gate itself.
+func guardedWorkerKeyRouter(s *Server, principal *UserContext) http.Handler {
+	r := chi.NewRouter()
+	r.Use(requestIDMiddleware)
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if principal != nil {
+				req = req.WithContext(context.WithValue(req.Context(), ctxKeyUserAuth, principal))
+			}
+			next.ServeHTTP(w, req)
+		})
+	})
+	r.Route("/api/v1/admin/worker-keys", func(r chi.Router) {
+		r.Use(requireAdmin(discardLogger()))
+		r.Get("/", s.handleListWorkerKeys)
+		r.Post("/", s.handleCreateWorkerKey)
+	})
+	return r
+}
+
+// TestWorkerKeyAdminOnly verifies the admin gate: only an admin principal may
+// mint/list worker keys; a standard user is 403, anonymous is 403, and an
+// unauthenticated caller is 401 (GH #143 F3 — was untested).
+func TestWorkerKeyAdminOnly(t *testing.T) {
+	srv := testServer()
+	cases := []struct {
+		name      string
+		principal *UserContext
+		want      int
+	}{
+		{"admin allowed", &UserContext{User: &model.User{Username: "admin", Role: model.RoleAdmin}}, http.StatusCreated},
+		{"standard user forbidden", &UserContext{User: &model.User{Username: "bob", Role: model.RoleUser}}, http.StatusForbidden},
+		{"anonymous forbidden", &UserContext{User: model.AnonymousUser}, http.StatusForbidden},
+		{"unauthenticated", nil, http.StatusUnauthorized},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			router := guardedWorkerKeyRouter(srv, tt.principal)
+			rec, _ := doAdmin(t, router, "POST", "/api/v1/admin/worker-keys", `{"label":"x","groups":["g"]}`)
+			if rec.Code != tt.want {
+				t.Errorf("POST worker-keys: status=%d, want %d", rec.Code, tt.want)
+			}
+			// List is also gated.
+			rec, _ = doAdmin(t, router, "GET", "/api/v1/admin/worker-keys", "")
+			wantList := tt.want
+			if wantList == http.StatusCreated {
+				wantList = http.StatusOK
+			}
+			if rec.Code != wantList {
+				t.Errorf("GET worker-keys: status=%d, want %d", rec.Code, wantList)
+			}
+		})
+	}
+}
+
+// TestAuthenticator_DBKeyExpiry verifies a DB-backed key past its ExpiresAt is
+// rejected by Authenticate (GH #143 F3 — only static expiry was covered).
+func TestAuthenticator_DBKeyExpiry(t *testing.T) {
+	st := testAuthStore(t)
+	auth := NewWorkerKeyAuthenticator(nil, st, discardLogger())
+	ctx := context.Background()
+
+	past := time.Now().Add(-time.Hour)
+	raw, hash, prefix, _ := model.GenerateWorkerKey()
+	key := &model.WorkerKey{
+		ID: "wk_exp", Label: "expired", KeyHash: hash, KeyPrefix: prefix,
+		Groups: []string{"g"}, CreatedAt: time.Now().UTC(), ExpiresAt: &past,
+	}
+	if err := st.CreateWorkerKey(ctx, key); err != nil {
+		t.Fatalf("CreateWorkerKey: %v", err)
+	}
+	if auth.Authenticate(ctx, raw) != nil {
+		t.Error("expired DB key authenticated through Authenticate")
+	}
+}

--- a/internal/store/worker_keys.go
+++ b/internal/store/worker_keys.go
@@ -159,10 +159,13 @@ func (s *SQLiteStore) UpdateWorkerKey(ctx context.Context, k *model.WorkerKey) e
 		disabled = 1
 	}
 
+	// Note: last_used_at is deliberately NOT written here. It is owned solely by
+	// TouchWorkerKey (updated on each successful auth); writing it from a PATCH's
+	// round-tripped struct could clobber a concurrent Touch with a stale value.
 	result, err := s.db.ExecContext(ctx,
-		`UPDATE worker_keys SET label=?, groups=?, description=?, disabled=?, expires_at=?, last_used_at=? WHERE id=?`,
+		`UPDATE worker_keys SET label=?, groups=?, description=?, disabled=?, expires_at=? WHERE id=?`,
 		k.Label, string(groupsJSON), k.Description, disabled,
-		nullableTime(k.ExpiresAt), nullableTime(k.LastUsedAt), k.ID,
+		nullableTime(k.ExpiresAt), k.ID,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes #143. Low-severity follow-ups from the #139 auth red-team.

- **F4** — `UpdateWorkerKey` no longer writes `last_used_at`; that column is owned solely by `TouchWorkerKey` (bumped per successful auth). Writing it from a PATCH's round-tripped struct could clobber a concurrent Touch with a stale value.
- **F3 test gaps** — `TestWorkerKeyAdminOnly` mounts the mint/list routes behind the *real* `requireAdmin` middleware and asserts admin=201/200, standard-user=403, anonymous=403, unauthenticated=401 (the prior test router bypassed `requireAdmin`, so the gate was unverified). `TestAuthenticator_DBKeyExpiry` covers a past-expiry **DB** key rejected through `Authenticate` (only static-key expiry was covered before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)