### PR TITLE
fix(release): build gowe-worker for linux only

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,11 +25,13 @@ builds:
     goarch: [amd64, arm64]
     flags: [-trimpath]
     ldflags: ["-s -w -X main.Version={{ .Version }}"]
+  # Linux only: the worker daemon uses syscall.Sysinfo (Linux-only) for host
+  # memory, so it cannot cross-compile to darwin. Workers run on Linux/HPC.
   - id: gowe-worker
     main: ./cmd/worker
     binary: gowe-worker
     env: [CGO_ENABLED=0]
-    goos: [linux, darwin]
+    goos: [linux]
     goarch: [amd64, arm64]
     flags: [-trimpath]
     ldflags: ["-s -w -X main.Version={{ .Version }}"]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,3 +61,6 @@ changelog:
 
 release:
   prerelease: auto
+  # release-please creates the GitHub Release first; append assets to it
+  # rather than failing on an existing release.
+  mode: append


### PR DESCRIPTION
## What failed

The `release-please` run on the **release 0.13.0 (#144)** merge created the tag and Release, but the **GoReleaser build failed**:

```
internal/worker/worker.go:148: undefined: syscall.Sysinfo_t
internal/worker/worker.go:149: undefined: syscall.Sysinfo   (target=darwin_amd64)
```

`syscall.Sysinfo` / `Sysinfo_t` are **Linux-only**. The worker daemon uses them for host memory, so `cmd/worker` can't cross-compile to darwin. `gowe`, `gowe-server`, and `cwl-runner` build fine on darwin — only `gowe-worker` breaks.

## Fix

Restrict the `gowe-worker` build to **linux (amd64, arm64)**. Workers run on Linux/HPC; macOS worker binaries aren't a real use case. The other three binaries still build for linux + darwin.

## Merge order

1. **Merge this PR** → `main` has the corrected `.goreleaser.yaml`.
2. **Merge the release PR #149 (`release 0.13.1`)** → release-please tags `v0.13.1` and GoReleaser builds successfully, attaching binaries. That becomes the first good binary release.

## Note on v0.13.0

The `v0.13.0` tag + GitHub Release exist but have **no binaries** (the build failed). Simplest is to let `v0.13.1` be the first release with assets. If you want `v0.13.0` to carry binaries too, I can build + upload them once this is merged (or we delete the empty `v0.13.0` Release). Your call.

### Follow-up option
Longer term, `internal/worker` could be made cross-platform with build tags (`Sysinfo` behind `//go:build linux`, a stub elsewhere) if a macOS worker is ever wanted — but that's app-code owned by the worker sessions, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)