### PR TITLE
fix(worker): make total-memory detection cross-compile (unbreak release binaries)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,13 @@ jobs:
         run: go vet ./...
       - name: Build
         run: go build ./...
+      - name: Cross-compile (release targets)
+        # Catch platform-specific breakage (e.g. Linux-only syscalls) before it
+        # fails the GoReleaser build at release time. Mirrors .goreleaser.yaml.
+        run: |
+          for target in darwin/amd64 darwin/arm64 linux/arm64; do
+            echo "building $target"
+            GOOS=${target%/*} GOARCH=${target#*/} CGO_ENABLED=0 go build ./...
+          done
       - name: Test
         run: go test ./...

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/me/gowe/internal/cwltool"
@@ -143,12 +142,11 @@ func New(cfg Config, logger *slog.Logger) (*Worker, error) {
 		cfg.Poll = 5 * time.Second
 	}
 
-	// Auto-detect system resources if not explicitly set.
+	// Auto-detect system resources if not explicitly set. Total-memory detection
+	// is platform-specific (see worker_meminfo_*.go); it returns 0 where the OS
+	// isn't supported, leaving MaxMemMB unset (no limit) — the prior behavior.
 	if cfg.Resources.MaxMemMB == 0 {
-		var si syscall.Sysinfo_t
-		if err := syscall.Sysinfo(&si); err == nil {
-			cfg.Resources.MaxMemMB = (int64(si.Totalram) * int64(si.Unit)) / (1024 * 1024)
-		}
+		cfg.Resources.MaxMemMB = sysTotalMemMB()
 	}
 	if cfg.Resources.MaxCPUs == 0 {
 		cfg.Resources.MaxCPUs = runtime.NumCPU()

--- a/internal/worker/worker_meminfo_linux.go
+++ b/internal/worker/worker_meminfo_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package worker
+
+import "syscall"
+
+// sysTotalMemMB returns total physical memory in MiB via the Linux sysinfo(2)
+// syscall, or 0 if it cannot be determined.
+func sysTotalMemMB() int64 {
+	var si syscall.Sysinfo_t
+	if err := syscall.Sysinfo(&si); err != nil {
+		return 0
+	}
+	return (int64(si.Totalram) * int64(si.Unit)) / (1024 * 1024)
+}

--- a/internal/worker/worker_meminfo_other.go
+++ b/internal/worker/worker_meminfo_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package worker
+
+// sysTotalMemMB returns 0 on platforms without a supported total-memory probe;
+// the worker then leaves MaxMemMB unset (no limit). Workers run on Linux in
+// production — this stub exists so the module cross-compiles (e.g. for the
+// macOS release binaries GoReleaser builds).
+func sysTotalMemMB() int64 { return 0 }


### PR DESCRIPTION
## Problem
The v0.13.0 GitHub release has **no binary assets**. The GoReleaser job failed because `internal/worker/worker.go` used the **Linux-only** `syscall.Sysinfo`/`Sysinfo_t` unconditionally, so the darwin cross-compile errored:
```
internal/worker/worker.go:148:18: undefined: syscall.Sysinfo_t
internal/worker/worker.go:149:21: undefined: syscall.Sysinfo
```
CI never caught it because it only builds `linux/amd64`.

## Fix
- Move total-memory detection behind build tags: `worker_meminfo_linux.go` (the sysinfo(2) probe, unchanged on Linux) and `worker_meminfo_other.go` (returns 0 → no limit) so all release targets compile. Workers run on Linux in production; this only affects the cross-built release binaries.
- Add a **CI cross-compile step** (darwin/amd64, darwin/arm64, linux/arm64 — mirroring `.goreleaser.yaml`) so this class of break fails the PR, not the release.

Verified: `GOOS=darwin GOARCH={amd64,arm64} go build ./...` now succeed; linux build + worker tests pass.

Note: v0.13.0 stays asset-less (its tagged code lacks this fix); the pending release PR (#149 → 0.13.1) will be the first with working binaries once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)