### PR TITLE
fix(release): per-binary archives so the release produces assets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,8 +25,8 @@ builds:
     goarch: [amd64, arm64]
     flags: [-trimpath]
     ldflags: ["-s -w -X main.Version={{ .Version }}"]
-  # Linux only: the worker daemon uses syscall.Sysinfo (Linux-only) for host
-  # memory, so it cannot cross-compile to darwin. Workers run on Linux/HPC.
+  # Linux only: workers run container/Apptainer workloads on Linux/HPC, so a
+  # macOS worker binary isn't a useful artifact. (The code cross-compiles fine.)
   - id: gowe-worker
     main: ./cmd/worker
     binary: gowe-worker
@@ -44,10 +44,23 @@ builds:
     flags: [-trimpath]
     ldflags: ["-s -w -X main.Version={{ .Version }}"]
 
-# One archive per OS/arch containing all four binaries.
+# One archive per binary (per OS/arch). Per-binary rather than a single bundle so
+# the Linux-only worker doesn't produce archives with different binary counts
+# across platforms (which GoReleaser rejects), and so users can grab just the
+# tool they need.
 archives:
   - id: gowe
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    ids: [gowe]
+    name_template: "gowe_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: gowe-server
+    ids: [gowe-server]
+    name_template: "gowe-server_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: gowe-worker
+    ids: [gowe-worker]
+    name_template: "gowe-worker_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: cwl-runner
+    ids: [cwl-runner]
+    name_template: "cwl-runner_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Problem
v0.13.0 **and** v0.13.1 both published with **zero binary assets**. Two distinct GoReleaser failures:
1. v0.13.0 — worker used a Linux-only syscall, darwin build failed (fixed in #151).
2. v0.13.1 — after the worker went Linux-only (#150), the single bundled archive had 4 binaries on Linux vs 3 on darwin → `archive has different count of binaries for each platform`.

## Fix
Split into **one archive per binary** (each filtered by build `id`), so platforms don't need matching binary counts and users can grab just the tool they need. `gowe`/`gowe-server`/`cwl-runner` for linux+darwin × amd64/arm64; `gowe-worker` linux-only.

Validated locally with `goreleaser release --snapshot --clean`: **14 archives**, worker linux-only, `release succeeded`, no mismatch. Also corrects #150's stale comment.

Next: merging this + the resulting release PR cuts **v0.13.2** — the first release with working binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)