### PR TITLE
feat(worker): task-dir cleanup after success, with per-submission debug mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ Trunk-based (GitHub Flow). Full guide: [`CONTRIBUTING.md`](CONTRIBUTING.md).
 | `--secret-file` | Load secrets from file (`NAME=value` per line) |
 | `--image-dir` | Base directory for resolving relative `.sif` image paths |
 | `--gpu` / `--gpu-id` | GPU passthrough |
+| `--keep-task-dirs` | Keep task dirs after success (failed tasks always kept; `gowe submit --debug` keeps a single job's) |
 
 ## Running the Server
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -33,6 +33,7 @@ func main() {
 	flag.StringVar(&cfg.WorkDir, "workdir", "", "Local working directory (default: $TMPDIR/gowe-worker)")
 	flag.StringVar(&cfg.StageOut, "stage-out", "local", "Output staging mode (local, file:///path, http://..., s3://bucket, shock://host)")
 	flag.DurationVar(&cfg.Poll, "poll", 5*time.Second, "Poll interval")
+	flag.BoolVar(&cfg.KeepTaskDirs, "keep-task-dirs", false, "Retain task working directories after successful completion (failed tasks are always kept)")
 
 	// Staging mode flags.
 	var stageMode string

--- a/docs/tools/worker.md
+++ b/docs/tools/worker.md
@@ -39,6 +39,7 @@ gowe-worker [flags]
 | `--stage-out` | `local` | Output staging mode (local, file://, http://, https://) |
 | `--poll` | `5s` | Poll interval for checking new tasks |
 | `--stage-mode` | `copy` | File staging mode (`copy`, `symlink`, `reference`) |
+| `--keep-task-dirs` | `false` | Retain task working directories after successful completion (failed tasks are always kept) |
 | `--docker-host-path-map` | `""` | Path mapping for DinD (env: `DOCKER_HOST_PATH_MAP`) |
 | `--docker-volume` | `""` | Named Docker volume shared with tool containers (env: `DOCKER_VOLUME`) |
 | `--input-path-map` | `""` | Input path mapping (env: `INPUT_PATH_MAP`) |
@@ -556,6 +557,11 @@ gowe-worker --runtime none,apptainer
 
 Outputs remain in the worker's work directory. The server can retrieve them via API.
 
+Because the task directory itself holds the outputs in this mode, it is never
+auto-deleted (see [Work directory full](#work-directory-full)); with a copying
+stage-out destination (`file:///path`, HTTP, S3, Shock, `ws://`) the directory
+is removed automatically after successful completion.
+
 ```bash
 gowe-worker --stage-out local
 ```
@@ -916,7 +922,17 @@ apptainer pull docker://ubuntu:22.04
 
 ### Work directory full
 
-Clean up old task directories:
+Workers automatically delete a task's working directory (and its `_tmp`
+sibling) once the server accepts the task's SUCCESS result. Directories are
+retained when:
+
+- the task **failed** or was cancelled (kept for debugging)
+- the submission was run with `gowe submit --debug`
+- the worker runs with `--keep-task-dirs`
+- outputs are staged in place (`--stage-out local`), where downstream tasks
+  read directly from the task directory
+
+Clean up retained directories manually:
 ```bash
 # Remove tasks older than 7 days
 find /var/lib/gowe/work -maxdepth 1 -type d -mtime +7 -exec rm -rf {} \;

--- a/internal/cli/submit.go
+++ b/internal/cli/submit.go
@@ -22,6 +22,7 @@ func newSubmitCmd() *cobra.Command {
 	var workspaceUpload bool
 	var workerGroup string
 	var outputDest string
+	var debug bool
 	var workflowRef string
 
 	cmd := &cobra.Command{
@@ -141,6 +142,9 @@ Alternatively, use --workflow to reference an already-registered workflow by ID 
 			if workerGroup != "" {
 				labels["worker_group"] = workerGroup
 			}
+			if debug {
+				labels["debug"] = "true"
+			}
 			subReq := map[string]any{
 				"workflow_id": workflowID,
 				"inputs":      inputs,
@@ -184,6 +188,7 @@ Alternatively, use --workflow to reference an already-registered workflow by ID 
 	cmd.Flags().BoolVar(&noUpload, "no-upload", false, "Disable file upload; assume files are accessible on workers")
 	cmd.Flags().BoolVar(&workspaceUpload, "workspace-upload", false, "Upload input files to BV-BRC workspace instead of server (for bvbrc executor)")
 	cmd.Flags().StringVar(&workerGroup, "group", "", "Target worker group for task scheduling")
+	cmd.Flags().BoolVar(&debug, "debug", false, "Debug mode: workers keep all task working data for this submission (no cleanup)")
 	cmd.Flags().StringVar(&outputDest, "output-destination", "", "Target URI for uploading outputs (e.g., ws:///user@bvbrc/home/results/)")
 	cmd.Flags().StringVar(&workflowRef, "workflow", "", "Submit using an already-registered workflow (by ID or name)")
 	return cmd

--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -1028,6 +1028,13 @@ func (l *Loop) createTaskFromStep(si *model.StepInstance, tmpTask *model.Task, s
 				task.RuntimeHints.WorkerGroup = wg
 			}
 		}
+		// Debug submissions: workers keep all task working data for inspection.
+		if sub.Labels["debug"] == "true" {
+			if task.RuntimeHints == nil {
+				task.RuntimeHints = &model.RuntimeHints{}
+			}
+			task.RuntimeHints.Debug = true
+		}
 	}
 
 	return task

--- a/internal/stepinput/resolve.go
+++ b/internal/stepinput/resolve.go
@@ -225,30 +225,35 @@ func ApplyLoadContents(value any, cwlDir string) any {
 	case map[string]any:
 		// Check if this is a File object.
 		if class, ok := v["class"].(string); ok && class == "File" {
-			// Get the file path.
-			path := ""
-			if p, ok := v["path"].(string); ok {
-				path = p
-			} else if p, ok := v["location"].(string); ok {
-				path = p
+			// Candidate paths: "path" first, then "location" as fallback —
+			// a worker task's local path may be gone (task-dir cleanup)
+			// while the staged location is still readable.
+			var candidates []string
+			if p, ok := v["path"].(string); ok && p != "" {
+				candidates = append(candidates, p)
 			}
-			if path == "" {
+			if p, ok := v["location"].(string); ok && p != "" {
+				candidates = append(candidates, p)
+			}
+			if len(candidates) == 0 {
 				return value
 			}
 
-			// Handle file:// URLs.
-			if strings.HasPrefix(path, "file://") {
-				path = strings.TrimPrefix(path, "file://")
-			}
-
-			// Make path absolute if needed.
-			if !filepath.IsAbs(path) && cwlDir != "" {
-				path = filepath.Join(cwlDir, path)
-			}
-
-			// Read up to 64 KiB of the file.
+			// Read up to 64 KiB of the first readable candidate.
 			const maxSize = 64 * 1024
-			data, err := os.ReadFile(path)
+			var data []byte
+			var err error
+			for _, path := range candidates {
+				// Handle file:// URLs.
+				path = strings.TrimPrefix(path, "file://")
+				// Make path absolute if needed.
+				if !filepath.IsAbs(path) && cwlDir != "" {
+					path = filepath.Join(cwlDir, path)
+				}
+				if data, err = os.ReadFile(path); err == nil {
+					break
+				}
+			}
 			if err != nil {
 				return value // Return unchanged if we can't read.
 			}

--- a/internal/worker/cleanup_test.go
+++ b/internal/worker/cleanup_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/me/gowe/pkg/model"
+	"github.com/me/gowe/pkg/staging"
 )
 
 func TestOutputsReferenceDir(t *testing.T) {
@@ -157,7 +159,7 @@ func TestCleanupTaskDir(t *testing.T) {
 		t.Helper()
 		taskDir := filepath.Join(workDir, taskID)
 		tmpDir := taskDir + "_tmp"
-		for _, d := range []string{taskDir, tmpDir} {
+		for _, d := range []string{taskDir, tmpDir, taskDir + "_staging"} {
 			if err := os.MkdirAll(d, 0o755); err != nil {
 				t.Fatal(err)
 			}
@@ -168,7 +170,7 @@ func TestCleanupTaskDir(t *testing.T) {
 		return taskDir, tmpDir
 	}
 
-	t.Run("removes task dir and tmp sibling after staged outputs", func(t *testing.T) {
+	t.Run("removes task dir and its siblings after staged outputs", func(t *testing.T) {
 		workDir := t.TempDir()
 		taskDir, tmpDir := mkTaskDirs(t, workDir, "task_1")
 		w := newWorker(workDir, false)
@@ -177,7 +179,7 @@ func TestCleanupTaskDir(t *testing.T) {
 			"out": map[string]any{"class": "File", "location": "file:///shared/task_1/out.txt"},
 		})
 
-		for _, d := range []string{taskDir, tmpDir} {
+		for _, d := range []string{taskDir, tmpDir, taskDir + "_staging"} {
 			if _, err := os.Stat(d); !os.IsNotExist(err) {
 				t.Errorf("%s still exists after cleanup", d)
 			}
@@ -322,6 +324,103 @@ func TestExecuteTaskCleanupWiring(t *testing.T) {
 		}
 		if _, err := os.Stat(filepath.Join(workDir, "task_fail")); err != nil {
 			t.Errorf("failed task's dir was deleted: %v", err)
+		}
+	})
+}
+
+// failingStager errors on every StageOut, simulating an unreachable staging
+// destination.
+type failingStager struct{}
+
+func (failingStager) StageIn(context.Context, string, string, staging.StageOptions) error {
+	return errors.New("stager down")
+}
+func (failingStager) StageOut(context.Context, string, string, staging.StageOptions) (string, error) {
+	return "", errors.New("stager down")
+}
+func (failingStager) Supports(string) bool { return true }
+
+// fixedStager reports every file staged to a fixed remote location.
+type fixedStager struct{ loc string }
+
+func (fixedStager) StageIn(context.Context, string, string, staging.StageOptions) error { return nil }
+func (s fixedStager) StageOut(context.Context, string, string, staging.StageOptions) (string, error) {
+	return s.loc, nil
+}
+func (fixedStager) Supports(string) bool { return true }
+
+// TestLegacyStageOutFailureKeepsData: when stage-out fails on the legacy path,
+// the local location must be reported (so the guard retains the only copy)
+// rather than the output being silently dropped and the dir deleted.
+func TestLegacyStageOutFailureKeepsData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	workDir := t.TempDir()
+	w := &Worker{
+		client:  NewClient(srv.URL, nil),
+		runtime: NewBareRuntime(),
+		stager:  failingStager{},
+		workDir: workDir,
+		active:  newActiveTaskSet(),
+		logger:  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+
+	task := &model.Task{ID: "task_so", Inputs: map[string]any{
+		"_base_command": []any{"sh", "-c", "echo data > out.txt"},
+		"_output_globs": map[string]any{"out": "out.txt"},
+	}}
+	if err := w.executeTask(context.Background(), task); err != nil {
+		t.Fatalf("executeTask: %v", err)
+	}
+
+	outFile := filepath.Join(workDir, "task_so", "out.txt")
+	if _, err := os.Stat(outFile); err != nil {
+		t.Fatalf("only copy of output was deleted after failed stage-out: %v", err)
+	}
+}
+
+// TestStageOutputValueStripsStalePath: once an output is staged to a different
+// location, the stale local path/dirname must be dropped so server-side
+// consumers resolve via the staged location; in-place stage-out keeps them.
+func TestStageOutputValueStripsStalePath(t *testing.T) {
+	w := &Worker{
+		logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+	task := &model.Task{ID: "task_sp"}
+
+	t.Run("moved output loses stale path", func(t *testing.T) {
+		val := map[string]any{
+			"class":   "File",
+			"path":    "/work/task_sp/out.txt",
+			"dirname": "/work/task_sp",
+		}
+		got := w.stageOutputValue(context.Background(), val, task,
+			fixedStager{loc: "file:///shared/task_sp/out.txt"}, "").(map[string]any)
+
+		if got["location"] != "file:///shared/task_sp/out.txt" {
+			t.Errorf("location = %v", got["location"])
+		}
+		if _, ok := got["path"]; ok {
+			t.Error("stale path survived staging to a different location")
+		}
+		if _, ok := got["dirname"]; ok {
+			t.Error("stale dirname survived staging to a different location")
+		}
+	})
+
+	t.Run("in-place output keeps path", func(t *testing.T) {
+		val := map[string]any{
+			"class": "File",
+			"path":  "/work/task_sp/out.txt",
+		}
+		got := w.stageOutputValue(context.Background(), val, task,
+			fixedStager{loc: "file:///work/task_sp/out.txt"}, "").(map[string]any)
+
+		if got["path"] != "/work/task_sp/out.txt" {
+			t.Errorf("in-place path was stripped: %v", got["path"])
 		}
 	})
 }

--- a/internal/worker/cleanup_test.go
+++ b/internal/worker/cleanup_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/me/gowe/pkg/model"
 )
 
 func TestOutputsReferenceDir(t *testing.T) {
@@ -168,7 +170,7 @@ func TestCleanupTaskDir(t *testing.T) {
 		taskDir, tmpDir := mkTaskDirs(t, workDir, "task_1")
 		w := newWorker(workDir, false)
 
-		w.cleanupTaskDir("task_1", map[string]any{
+		w.cleanupTaskDir(&model.Task{ID: "task_1"}, map[string]any{
 			"out": map[string]any{"class": "File", "location": "file:///shared/task_1/out.txt"},
 		})
 
@@ -184,7 +186,7 @@ func TestCleanupTaskDir(t *testing.T) {
 		taskDir, _ := mkTaskDirs(t, workDir, "task_2")
 		w := newWorker(workDir, false)
 
-		w.cleanupTaskDir("task_2", map[string]any{
+		w.cleanupTaskDir(&model.Task{ID: "task_2"}, map[string]any{
 			"out": map[string]any{"class": "File", "location": "file://" + filepath.Join(taskDir, "out.txt")},
 		})
 
@@ -198,12 +200,29 @@ func TestCleanupTaskDir(t *testing.T) {
 		taskDir, _ := mkTaskDirs(t, workDir, "task_3")
 		w := newWorker(workDir, true)
 
-		w.cleanupTaskDir("task_3", map[string]any{
+		w.cleanupTaskDir(&model.Task{ID: "task_3"}, map[string]any{
 			"out": map[string]any{"class": "File", "location": "file:///shared/task_3/out.txt"},
 		})
 
 		if _, err := os.Stat(taskDir); err != nil {
 			t.Errorf("task dir was deleted despite keep-task-dirs: %v", err)
+		}
+	})
+
+	t.Run("keeps dir for debug submission", func(t *testing.T) {
+		workDir := t.TempDir()
+		taskDir, _ := mkTaskDirs(t, workDir, "task_5")
+		w := newWorker(workDir, false)
+
+		w.cleanupTaskDir(&model.Task{
+			ID:           "task_5",
+			RuntimeHints: &model.RuntimeHints{Debug: true},
+		}, map[string]any{
+			"out": map[string]any{"class": "File", "location": "file:///shared/task_5/out.txt"},
+		})
+
+		if _, err := os.Stat(taskDir); err != nil {
+			t.Errorf("task dir was deleted despite debug submission: %v", err)
 		}
 	})
 
@@ -221,7 +240,7 @@ func TestCleanupTaskDir(t *testing.T) {
 		}
 
 		w := newWorker(workDir, false)
-		w.cleanupTaskDir("task_4", map[string]any{
+		w.cleanupTaskDir(&model.Task{ID: "task_4"}, map[string]any{
 			"out": map[string]any{"class": "File", "location": "file:///shared/task_4/out.txt"},
 		})
 

--- a/internal/worker/cleanup_test.go
+++ b/internal/worker/cleanup_test.go
@@ -1,7 +1,10 @@
 package worker
 
 import (
+	"context"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -249,6 +252,76 @@ func TestCleanupTaskDir(t *testing.T) {
 		}
 		if _, err := os.Stat(target); err != nil {
 			t.Errorf("symlink target was deleted: %v", err)
+		}
+	})
+}
+
+// TestExecuteTaskCleanupWiring exercises the legacy execute path end-to-end
+// against a stub server, verifying cleanup fires only when the SUCCESS result
+// was actually accepted.
+func TestExecuteTaskCleanupWiring(t *testing.T) {
+	newTestWorker := func(t *testing.T, serverURL string) (*Worker, string) {
+		t.Helper()
+		workDir := t.TempDir()
+		return &Worker{
+			client:  NewClient(serverURL, nil),
+			runtime: NewBareRuntime(),
+			workDir: workDir,
+			active:  newActiveTaskSet(),
+			logger:  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		}, workDir
+	}
+
+	legacyTask := func(id string, cmd ...string) *model.Task {
+		args := make([]any, len(cmd))
+		for i, c := range cmd {
+			args[i] = c
+		}
+		return &model.Task{ID: id, Inputs: map[string]any{"_base_command": args}}
+	}
+
+	t.Run("success accepted by server removes dir", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		w, workDir := newTestWorker(t, srv.URL)
+
+		if err := w.executeTask(context.Background(), legacyTask("task_ok", "true")); err != nil {
+			t.Fatalf("executeTask: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(workDir, "task_ok")); !os.IsNotExist(err) {
+			t.Error("task dir still exists after accepted SUCCESS report")
+		}
+	})
+
+	t.Run("rejected report keeps dir", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		w, workDir := newTestWorker(t, srv.URL)
+
+		if err := w.executeTask(context.Background(), legacyTask("task_rej", "true")); err == nil {
+			t.Fatal("expected error from rejected report")
+		}
+		if _, err := os.Stat(filepath.Join(workDir, "task_rej")); err != nil {
+			t.Errorf("task dir was deleted despite rejected report: %v", err)
+		}
+	})
+
+	t.Run("failed task keeps dir", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		w, workDir := newTestWorker(t, srv.URL)
+
+		if err := w.executeTask(context.Background(), legacyTask("task_fail", "false")); err != nil {
+			t.Fatalf("executeTask: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(workDir, "task_fail")); err != nil {
+			t.Errorf("failed task's dir was deleted: %v", err)
 		}
 	})
 }

--- a/internal/worker/cleanup_test.go
+++ b/internal/worker/cleanup_test.go
@@ -1,0 +1,235 @@
+package worker
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOutputsReferenceDir(t *testing.T) {
+	dir := "/work/task_abc"
+
+	tests := []struct {
+		name    string
+		outputs map[string]any
+		want    bool
+	}{
+		{
+			name: "staged file elsewhere",
+			outputs: map[string]any{
+				"out": map[string]any{
+					"class":    "File",
+					"path":     "/work/task_abc/result.txt", // stale local path is ignored
+					"location": "file:///shared/task_abc/result.txt",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "in-place stage-out location",
+			outputs: map[string]any{
+				"out": map[string]any{
+					"class":    "File",
+					"location": "file:///work/task_abc/result.txt",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "failed stage-out leaves bare path",
+			outputs: map[string]any{
+				"out": map[string]any{
+					"class": "File",
+					"path":  "/work/task_abc/result.txt",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "shock location",
+			outputs: map[string]any{
+				"out": map[string]any{
+					"class":    "File",
+					"location": "shock://shock.example.org/node/123",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "secondary file in place",
+			outputs: map[string]any{
+				"out": map[string]any{
+					"class":    "File",
+					"location": "file:///shared/task_abc/result.bam",
+					"secondaryFiles": []any{
+						map[string]any{
+							"class":    "File",
+							"location": "file:///work/task_abc/result.bam.bai",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "directory listing staged elsewhere",
+			outputs: map[string]any{
+				"out": map[string]any{
+					"class":    "Directory",
+					"location": "file:///shared/task_abc/outdir",
+					"listing": []any{
+						map[string]any{
+							"class":    "File",
+							"path":     "/work/task_abc/outdir/a.txt",
+							"location": "file:///shared/task_abc/outdir/a.txt",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "legacy string location in dir",
+			outputs: map[string]any{
+				"out": "file:///work/task_abc/result.txt",
+			},
+			want: true,
+		},
+		{
+			name: "legacy string slice staged elsewhere",
+			outputs: map[string]any{
+				"out": []string{"file:///shared/task_abc/a", "file:///shared/task_abc/b"},
+			},
+			want: false,
+		},
+		{
+			name: "prefix must be a path boundary",
+			outputs: map[string]any{
+				"out": map[string]any{
+					"class":    "File",
+					"location": "file:///work/task_abc_output/result.txt",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "array of files one in place",
+			outputs: map[string]any{
+				"out": []any{
+					map[string]any{"class": "File", "location": "file:///shared/x"},
+					map[string]any{"class": "File", "location": "file:///work/task_abc/y"},
+				},
+			},
+			want: true,
+		},
+		{
+			name:    "nil and scalars",
+			outputs: map[string]any{"count": 3, "flag": true, "none": nil},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := outputsReferenceDir(tt.outputs, dir); got != tt.want {
+				t.Errorf("outputsReferenceDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanupTaskDir(t *testing.T) {
+	newWorker := func(workDir string, keep bool) *Worker {
+		return &Worker{
+			workDir:      workDir,
+			keepTaskDirs: keep,
+			logger:       slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		}
+	}
+
+	mkTaskDirs := func(t *testing.T, workDir, taskID string) (string, string) {
+		t.Helper()
+		taskDir := filepath.Join(workDir, taskID)
+		tmpDir := taskDir + "_tmp"
+		for _, d := range []string{taskDir, tmpDir} {
+			if err := os.MkdirAll(d, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(taskDir, "out.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return taskDir, tmpDir
+	}
+
+	t.Run("removes task dir and tmp sibling after staged outputs", func(t *testing.T) {
+		workDir := t.TempDir()
+		taskDir, tmpDir := mkTaskDirs(t, workDir, "task_1")
+		w := newWorker(workDir, false)
+
+		w.cleanupTaskDir("task_1", map[string]any{
+			"out": map[string]any{"class": "File", "location": "file:///shared/task_1/out.txt"},
+		})
+
+		for _, d := range []string{taskDir, tmpDir} {
+			if _, err := os.Stat(d); !os.IsNotExist(err) {
+				t.Errorf("%s still exists after cleanup", d)
+			}
+		}
+	})
+
+	t.Run("keeps dir when outputs are in place", func(t *testing.T) {
+		workDir := t.TempDir()
+		taskDir, _ := mkTaskDirs(t, workDir, "task_2")
+		w := newWorker(workDir, false)
+
+		w.cleanupTaskDir("task_2", map[string]any{
+			"out": map[string]any{"class": "File", "location": "file://" + filepath.Join(taskDir, "out.txt")},
+		})
+
+		if _, err := os.Stat(filepath.Join(taskDir, "out.txt")); err != nil {
+			t.Errorf("in-place output was deleted: %v", err)
+		}
+	})
+
+	t.Run("keeps dir with keep-task-dirs", func(t *testing.T) {
+		workDir := t.TempDir()
+		taskDir, _ := mkTaskDirs(t, workDir, "task_3")
+		w := newWorker(workDir, true)
+
+		w.cleanupTaskDir("task_3", map[string]any{
+			"out": map[string]any{"class": "File", "location": "file:///shared/task_3/out.txt"},
+		})
+
+		if _, err := os.Stat(taskDir); err != nil {
+			t.Errorf("task dir was deleted despite keep-task-dirs: %v", err)
+		}
+	})
+
+	t.Run("symlink targets survive cleanup", func(t *testing.T) {
+		workDir := t.TempDir()
+		shared := t.TempDir()
+		taskDir, _ := mkTaskDirs(t, workDir, "task_4")
+
+		target := filepath.Join(shared, "input.dat")
+		if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, filepath.Join(taskDir, "input.dat")); err != nil {
+			t.Fatal(err)
+		}
+
+		w := newWorker(workDir, false)
+		w.cleanupTaskDir("task_4", map[string]any{
+			"out": map[string]any{"class": "File", "location": "file:///shared/task_4/out.txt"},
+		})
+
+		if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
+			t.Errorf("task dir still exists after cleanup")
+		}
+		if _, err := os.Stat(target); err != nil {
+			t.Errorf("symlink target was deleted: %v", err)
+		}
+	})
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -509,15 +509,21 @@ func (w *Worker) executeTask(ctx context.Context, task *model.Task) error {
 
 // cleanupTaskDir removes a completed task's working directories (the task dir
 // and its cwltool "_tmp" sibling). Called only after a SUCCESS result was
-// accepted by the server. The directories are kept when --keep-task-dirs is set,
-// and when any reported output still resolves into the task dir — which happens
-// with in-place stage-out (e.g. FileStager "local" mode) or when a StageOut
-// failed and left the local path; deleting the dir then would destroy outputs
-// that downstream tasks reference.
-func (w *Worker) cleanupTaskDir(taskID string, outputs map[string]any) {
+// accepted by the server. The directories are kept when --keep-task-dirs is
+// set, when the task belongs to a debug submission (RuntimeHints.Debug, from
+// `gowe submit --debug`), and when any reported output still resolves into the
+// task dir — which happens with in-place stage-out (e.g. FileStager "local"
+// mode) or when a StageOut failed and left the local path; deleting the dir
+// then would destroy outputs that downstream tasks reference.
+func (w *Worker) cleanupTaskDir(task *model.Task, outputs map[string]any) {
 	if w.keepTaskDirs {
 		return
 	}
+	if task.RuntimeHints != nil && task.RuntimeHints.Debug {
+		w.logger.Debug("keeping task dir: debug submission", "task_id", task.ID)
+		return
+	}
+	taskID := task.ID
 	taskDir := filepath.Join(w.workDir, taskID)
 	if abs, err := filepath.Abs(taskDir); err == nil {
 		taskDir = abs
@@ -775,7 +781,7 @@ func (w *Worker) executeWithCWLTool(ctx context.Context, task *model.Task, taskD
 	}); err != nil {
 		return err
 	}
-	w.cleanupTaskDir(task.ID, stagedOutputs)
+	w.cleanupTaskDir(task, stagedOutputs)
 	return nil
 }
 
@@ -876,7 +882,7 @@ func (w *Worker) executeLegacy(ctx context.Context, task *model.Task, taskDir st
 		return err
 	}
 	if state == model.TaskStateSuccess {
-		w.cleanupTaskDir(task.ID, outputs)
+		w.cleanupTaskDir(task, outputs)
 	}
 	return nil
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -509,12 +509,14 @@ func (w *Worker) executeTask(ctx context.Context, task *model.Task) error {
 
 // cleanupTaskDir removes a completed task's working directories (the task dir
 // and its cwltool "_tmp" sibling). Called only after a SUCCESS result was
-// accepted by the server. The directories are kept when --keep-task-dirs is
-// set, when the task belongs to a debug submission (RuntimeHints.Debug, from
-// `gowe submit --debug`), and when any reported output still resolves into the
-// task dir — which happens with in-place stage-out (e.g. FileStager "local"
-// mode) or when a StageOut failed and left the local path; deleting the dir
-// then would destroy outputs that downstream tasks reference.
+// accepted by the server — FAILED and SKIPPED (cancelled) tasks deliberately
+// never reach it, so their directories stay around for debugging. The
+// directories are also kept when --keep-task-dirs is set, when the task
+// belongs to a debug submission (RuntimeHints.Debug, from `gowe submit
+// --debug`), and when any reported output still resolves into the task dir —
+// which happens with in-place stage-out (e.g. FileStager "local" mode) or
+// when a StageOut failed and left the local path; deleting the dir then would
+// destroy outputs that downstream tasks reference.
 func (w *Worker) cleanupTaskDir(task *model.Task, outputs map[string]any) {
 	if w.keepTaskDirs {
 		return
@@ -532,12 +534,16 @@ func (w *Worker) cleanupTaskDir(task *model.Task, outputs map[string]any) {
 		w.logger.Debug("keeping task dir: outputs are referenced in place", "task_id", taskID)
 		return
 	}
+	removed := true
 	for _, d := range []string{taskDir, taskDir + "_tmp"} {
 		if err := os.RemoveAll(d); err != nil {
 			w.logger.Warn("cleanup task dir", "dir", d, "error", err)
+			removed = false
 		}
 	}
-	w.logger.Debug("task dir removed", "task_id", taskID)
+	if removed {
+		w.logger.Debug("task dir removed", "task_id", taskID)
+	}
 }
 
 // outputsReferenceDir reports whether any output location resolves into dir.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -45,6 +45,7 @@ type Worker struct {
 	envVars           map[string]string        // Non-secret env vars injected into containers
 	wsStager          *staging.WorkspaceStager // Workspace stager for ws:// URIs (nil if disabled)
 	active            *activeTaskSet           // In-flight tasks → per-task cancel funcs
+	keepTaskDirs      bool                     // Retain task working dirs after successful completion
 	logger            *slog.Logger
 }
 
@@ -104,6 +105,11 @@ type Config struct {
 
 	// Version is the build version (git commit hash), sent during registration.
 	Version string
+
+	// KeepTaskDirs retains task working directories after successful
+	// completion instead of deleting them (debugging aid). Directories of
+	// FAILED tasks are always kept regardless of this setting.
+	KeepTaskDirs bool
 
 	// WorkspaceStager enables the ws:// workspace stager for BV-BRC.
 	WorkspaceStager bool
@@ -360,6 +366,7 @@ func New(cfg Config, logger *slog.Logger) (*Worker, error) {
 		datasets:          datasets,
 		secrets:           cfg.Secrets,
 		envVars:           cfg.EnvVars,
+		keepTaskDirs:      cfg.KeepTaskDirs,
 		active:            newActiveTaskSet(),
 		logger:            logger.With("component", "worker"),
 	}, nil
@@ -498,6 +505,88 @@ func (w *Worker) executeTask(ctx context.Context, task *model.Task) error {
 
 	// Legacy path: use _base_command from task.Inputs.
 	return w.executeLegacy(runCtx, task, taskDir)
+}
+
+// cleanupTaskDir removes a completed task's working directories (the task dir
+// and its cwltool "_tmp" sibling). Called only after a SUCCESS result was
+// accepted by the server. The directories are kept when --keep-task-dirs is set,
+// and when any reported output still resolves into the task dir — which happens
+// with in-place stage-out (e.g. FileStager "local" mode) or when a StageOut
+// failed and left the local path; deleting the dir then would destroy outputs
+// that downstream tasks reference.
+func (w *Worker) cleanupTaskDir(taskID string, outputs map[string]any) {
+	if w.keepTaskDirs {
+		return
+	}
+	taskDir := filepath.Join(w.workDir, taskID)
+	if abs, err := filepath.Abs(taskDir); err == nil {
+		taskDir = abs
+	}
+	if outputsReferenceDir(outputs, taskDir) {
+		w.logger.Debug("keeping task dir: outputs are referenced in place", "task_id", taskID)
+		return
+	}
+	for _, d := range []string{taskDir, taskDir + "_tmp"} {
+		if err := os.RemoveAll(d); err != nil {
+			w.logger.Warn("cleanup task dir", "dir", d, "error", err)
+		}
+	}
+	w.logger.Debug("task dir removed", "task_id", taskID)
+}
+
+// outputsReferenceDir reports whether any output location resolves into dir.
+// File/Directory objects are judged by their effective location ("location" if
+// staged, else the local "path"); bare strings (legacy staged locations) are
+// checked directly. The stale "path" left behind on a File whose "location"
+// was staged elsewhere is deliberately ignored.
+func outputsReferenceDir(v any, dir string) bool {
+	underDir := func(loc string) bool {
+		p := strings.TrimPrefix(loc, "file://")
+		return p == dir || strings.HasPrefix(p, dir+string(filepath.Separator))
+	}
+	var walk func(any) bool
+	walk = func(v any) bool {
+		switch val := v.(type) {
+		case string:
+			return underDir(val)
+		case map[string]any:
+			if class, _ := val["class"].(string); class == "File" || class == "Directory" {
+				loc, _ := val["location"].(string)
+				if loc == "" {
+					loc, _ = val["path"].(string)
+				}
+				if underDir(loc) {
+					return true
+				}
+				return walk(val["secondaryFiles"]) || walk(val["listing"])
+			}
+			for _, item := range val {
+				if walk(item) {
+					return true
+				}
+			}
+		case []any:
+			for _, item := range val {
+				if walk(item) {
+					return true
+				}
+			}
+		case []map[string]any:
+			for _, item := range val {
+				if walk(item) {
+					return true
+				}
+			}
+		case []string:
+			for _, item := range val {
+				if underDir(item) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return walk(v)
 }
 
 // redactSecrets replaces every non-trivial secret value in s with a placeholder,
@@ -677,13 +766,17 @@ func (w *Worker) executeWithCWLTool(ctx context.Context, task *model.Task, taskD
 		stagedOutputs[outputID] = w.stageOutputValue(ctx, output, task, outStager, "")
 	}
 
-	return w.reportComplete(ctx, task.ID, TaskResult{
+	if err := w.reportComplete(ctx, task.ID, TaskResult{
 		State:    model.TaskStateSuccess,
 		ExitCode: &result.ExitCode,
 		Stdout:   result.Stdout,
 		Stderr:   result.Stderr,
 		Outputs:  stagedOutputs,
-	})
+	}); err != nil {
+		return err
+	}
+	w.cleanupTaskDir(task.ID, stagedOutputs)
+	return nil
 }
 
 // executeLegacy executes a task using the legacy _base_command approach.
@@ -773,13 +866,19 @@ func (w *Worker) executeLegacy(ctx context.Context, task *model.Task, taskDir st
 		state = model.TaskStateFailed
 	}
 
-	return w.reportComplete(ctx, task.ID, TaskResult{
+	if err := w.reportComplete(ctx, task.ID, TaskResult{
 		State:    state,
 		ExitCode: &result.ExitCode,
 		Stdout:   result.Stdout,
 		Stderr:   result.Stderr,
 		Outputs:  outputs,
-	})
+	}); err != nil {
+		return err
+	}
+	if state == model.TaskStateSuccess {
+		w.cleanupTaskDir(task.ID, outputs)
+	}
+	return nil
 }
 
 // stageOutputValue recursively stages File objects in output values.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -508,7 +508,7 @@ func (w *Worker) executeTask(ctx context.Context, task *model.Task) error {
 }
 
 // cleanupTaskDir removes a completed task's working directories (the task dir
-// and its cwltool "_tmp" sibling). Called only after a SUCCESS result was
+// and its "_tmp" / "_staging" siblings). Called only after a SUCCESS result was
 // accepted by the server — FAILED and SKIPPED (cancelled) tasks deliberately
 // never reach it, so their directories stay around for debugging. The
 // directories are also kept when --keep-task-dirs is set, when the task
@@ -535,7 +535,7 @@ func (w *Worker) cleanupTaskDir(task *model.Task, outputs map[string]any) {
 		return
 	}
 	removed := true
-	for _, d := range []string{taskDir, taskDir + "_tmp"} {
+	for _, d := range []string{taskDir, taskDir + "_tmp", taskDir + "_staging"} {
 		if err := os.RemoveAll(d); err != nil {
 			w.logger.Warn("cleanup task dir", "dir", d, "error", err)
 			removed = false
@@ -856,11 +856,17 @@ func (w *Worker) executeLegacy(ctx context.Context, task *model.Task, taskDir st
 		// Stage-out matched files.
 		var staged []string
 		for _, m := range matches {
+			if abs, err := filepath.Abs(m); err == nil {
+				m = abs
+			}
 			opts := execution.StageOptions{}
 			loc, err := w.stager.StageOut(ctx, m, task.ID, opts)
 			if err != nil {
-				w.logger.Warn("stage-out failed", "file", m, "error", err)
-				continue
+				// Report the local location instead of dropping the output:
+				// the file in the task dir is the only copy, and referencing
+				// it keeps cleanupTaskDir from deleting it.
+				w.logger.Warn("stage-out failed, reporting local location", "file", m, "error", err)
+				loc = cwl.BuildLocation(cwl.SchemeFile, m)
 			}
 			staged = append(staged, loc)
 		}
@@ -917,6 +923,15 @@ func (w *Worker) stageOutputValue(ctx context.Context, v any, task *model.Task, 
 				if err == nil {
 					w.logger.Debug("staged file", "file", filepath.Base(path), "location", loc)
 					val["location"] = loc
+					// If the output actually moved (not an in-place file://
+					// URI), drop the stale local path/dirname so server-side
+					// consumers (loadContents, local-executor steps) resolve
+					// via the staged location instead of a path inside a task
+					// dir that cleanupTaskDir may delete.
+					if loc != cwl.BuildLocation(cwl.SchemeFile, path) {
+						delete(val, "path")
+						delete(val, "dirname")
+					}
 				} else {
 					w.logger.Warn("stage-out failed", "path", path, "error", err)
 				}

--- a/pkg/model/task.go
+++ b/pkg/model/task.go
@@ -105,6 +105,11 @@ type RuntimeHints struct {
 	// OutputDestination is the target URI for uploading task outputs
 	// (e.g., "ws:///user@bvbrc/home/results/"). Propagated from Submission.
 	OutputDestination string `json:"output_destination,omitempty"`
+
+	// Debug marks this task as part of a debug submission: workers keep all
+	// task working data (no cleanup) so it can be inspected afterwards.
+	// Propagated from the submission's "debug" label.
+	Debug bool `json:"debug,omitempty"`
 }
 
 // StagerOverrides allows per-task stager customization.


### PR DESCRIPTION
## Summary

Fixes #157 — workers never removed `<workdir>/<task-id>` (and the cwltool `_tmp` sibling), leaving every task's staged inputs, scratch, and output originals on disk forever. Production workers on coconut have accumulated 16–18 GB each; a full JATS/OA ingest (~330 MB of embeddings per shard) would fill the filesystem mid-run.

## Behavior

After a **SUCCESS** result is accepted by the server, the worker removes the task dir and its `_tmp` sibling. Deletion is skipped when:

- the task belongs to a **debug submission** (`gowe submit --debug` → `labels["debug"]` → `RuntimeHints.Debug`) — per-job retention for troubleshooting
- `--keep-task-dirs` is set on the worker (new flag; keeps everything that lands on that worker)
- the task **FAILED** — always kept for debugging
- **any reported output location still resolves into the task dir** — the correctness guard for in-place stage-out configurations (`FileStager` "local" mode, shared-FS stager without a stage-out dir) and for `StageOut` failures that fall back to the local path. In those cases the task dir *is* the store downstream tasks read from, so it must survive.

With a copying/uploading stage-out (`file:///shared`, Shock, S3, HTTP, `ws://`), the staged copy is the inter-task handoff — downstream tasks stage-in from the store, never from the worker's dir — so immediate deletion after the report is safe regardless of downstream task state.

## Debug mode plumbing

`internal/cli/submit.go` (`--debug` flag) → submission label `debug=true` (labels already persist; no migration) → `internal/scheduler/loop.go` `createTaskFromStep` (same path as `worker_group`) → `pkg/model` `RuntimeHints.Debug` → worker `cleanupTaskDir` skips.

## Out of scope (follow-up in #159)

Retention of the **staged intermediates** themselves (stage-out dir contents, Shock nodes) after a submission completes — that requires submission-level lifecycle knowledge the server owns — now tracked in #159.

## Testing

- `outputsReferenceDir`: 11 table-driven cases — staged-elsewhere vs in-place locations, stale `path` on staged Files ignored, bare-path fallback after failed stage-out, secondaryFiles/listing recursion, legacy string/[]string outputs, path-boundary prefix check
- `cleanupTaskDir`: removal of dir + `_tmp`, in-place keep, `--keep-task-dirs` keep, debug-submission keep, symlink targets survive `RemoveAll`
- `go build ./... && go test ./...` green; `go vet` and `gofmt` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg