### PR TITLE
fix(store,scheduler): CAS submission finalize/activate + bounded list pagination

### DIFF
--- a/internal/scheduler/finalize_cas_test.go
+++ b/internal/scheduler/finalize_cas_test.go
@@ -1,0 +1,179 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/me/gowe/internal/store"
+	"github.com/me/gowe/pkg/model"
+)
+
+// createFinalizeFixture creates a workflow, a PENDING submission, and a single
+// StepInstance in the given state. Unlike createPipeline it lets the caller
+// choose the step state so finalizeSubmissions can be exercised directly.
+// It returns the submission ID.
+func createFinalizeFixture(t *testing.T, st store.Store, stepState model.StepInstanceState) string {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	wfID := "wf_" + uuid.New().String()
+	subID := "sub_" + uuid.New().String()
+
+	wf := &model.Workflow{
+		ID:         wfID,
+		Name:       "finalize-test-workflow",
+		CWLVersion: "v1.2",
+		Steps: []model.Step{
+			{
+				ID: "s1",
+				ToolInline: &model.Tool{
+					ID:          "echo_tool",
+					Class:       "CommandLineTool",
+					BaseCommand: []string{"echo", "hello"},
+				},
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+
+	sub := &model.Submission{
+		ID:           subID,
+		WorkflowID:   wfID,
+		WorkflowName: wf.Name,
+		State:        model.SubmissionStatePending,
+		Inputs:       map[string]any{},
+		Outputs:      map[string]any{},
+		Labels:       map[string]string{},
+		CreatedAt:    now,
+	}
+	if err := st.CreateSubmission(ctx, sub); err != nil {
+		t.Fatalf("CreateSubmission: %v", err)
+	}
+
+	si := &model.StepInstance{
+		ID:           "si_" + uuid.New().String(),
+		SubmissionID: subID,
+		StepID:       "s1",
+		State:        stepState,
+		Outputs:      map[string]any{},
+		CreatedAt:    now,
+	}
+	if err := st.CreateStepInstance(ctx, si); err != nil {
+		t.Fatalf("CreateStepInstance: %v", err)
+	}
+
+	return subID
+}
+
+// TestFinalize_CancelledMidTick_NotResurrected is the scheduler-level
+// regression test for the defect-3b clobber class: finalizeSubmissions holds a
+// snapshot of the submission taken earlier in the tick; if a cancel lands
+// between that read and the terminal write, the blind UpdateSubmission used to
+// resurrect the CANCELLED submission to COMPLETED (or RUNNING via activation).
+// The CAS variants must lose that race and leave CANCELLED in place.
+func TestFinalize_CancelledMidTick_NotResurrected(t *testing.T) {
+	tests := []struct {
+		name string
+		// stepState drives which finalize branch fires: a terminal step makes
+		// finalizeSubmissions attempt the terminal CAS write; an active step
+		// makes it attempt the PENDING→RUNNING activation.
+		stepState model.StepInstanceState
+	}{
+		{"terminal finalize loses to cancel", model.StepStateCompleted},
+		{"pending activation loses to cancel", model.StepStateRunning},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched, st := testSetup(t)
+			ctx := context.Background()
+
+			subID := createFinalizeFixture(t, st, tt.stepState)
+
+			// Materialize the mid-tick race: prime the tick cache with the
+			// still-PENDING submission (the snapshot phase 6 would hold), ...
+			sched.cache = newTickCache()
+			cached, err := sched.cache.getSubmission(ctx, st, subID)
+			if err != nil {
+				t.Fatalf("prime cache: %v", err)
+			}
+			if cached.State != model.SubmissionStatePending {
+				t.Fatalf("cached state = %q, want PENDING", cached.State)
+			}
+
+			// ... then cancel the submission behind the scheduler's back.
+			cancelled, err := st.GetSubmission(ctx, subID)
+			if err != nil {
+				t.Fatalf("GetSubmission: %v", err)
+			}
+			cancelled.State = model.SubmissionStateCancelled
+			if err := st.UpdateSubmission(ctx, cancelled); err != nil {
+				t.Fatalf("UpdateSubmission(cancel): %v", err)
+			}
+
+			// Run phase 6 against the stale snapshot.
+			if err := sched.finalizeSubmissions(ctx, map[string]bool{subID: true}); err != nil {
+				t.Fatalf("finalizeSubmissions: %v", err)
+			}
+
+			got, err := st.GetSubmission(ctx, subID)
+			if err != nil {
+				t.Fatalf("GetSubmission: %v", err)
+			}
+			if got.State != model.SubmissionStateCancelled {
+				t.Fatalf("after finalizeSubmissions: state = %q, want CANCELLED (resurrected)", got.State)
+			}
+
+			// A subsequent full tick must not touch the cancelled submission either.
+			if err := sched.Tick(ctx); err != nil {
+				t.Fatalf("Tick: %v", err)
+			}
+			got, err = st.GetSubmission(ctx, subID)
+			if err != nil {
+				t.Fatalf("GetSubmission: %v", err)
+			}
+			if got.State != model.SubmissionStateCancelled {
+				t.Errorf("after Tick: state = %q, want CANCELLED", got.State)
+			}
+		})
+	}
+}
+
+// TestFinalize_PaginationBeyond100 verifies that finalizeSubmissions visits
+// every candidate submission, not just the first Limit-100 page: 120 PENDING
+// submissions with terminal steps must all finalize in a single tick.
+func TestFinalize_PaginationBeyond100(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	const n = 120 // > model.MaxListLimit, forcing a second page
+	subIDs := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		subIDs = append(subIDs, createFinalizeFixture(t, st, model.StepStateCompleted))
+	}
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+
+	var notFinalized int
+	for _, subID := range subIDs {
+		sub, err := st.GetSubmission(ctx, subID)
+		if err != nil {
+			t.Fatalf("GetSubmission(%s): %v", subID, err)
+		}
+		if sub.State != model.SubmissionStateCompleted {
+			notFinalized++
+		}
+	}
+	if notFinalized > 0 {
+		t.Errorf("%d of %d submissions not finalized (Limit-100 page starvation)", notFinalized, n)
+	}
+}

--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -192,6 +192,76 @@ func (l *Loop) updateSubmission(ctx context.Context, sub *model.Submission) erro
 	return err
 }
 
+// finalizeSubmissionCAS persists a terminal submission update via
+// compare-and-set (skipped when the submission is already terminal, e.g. a
+// concurrent cancel won) and invalidates the tick cache. Returns whether the
+// write was applied.
+func (l *Loop) finalizeSubmissionCAS(ctx context.Context, sub *model.Submission) (bool, error) {
+	applied, err := l.store.FinalizeSubmission(ctx, sub)
+	if err == nil && l.cache != nil {
+		l.cache.invalidateSubmission(sub.ID)
+	}
+	return applied, err
+}
+
+// activateSubmissionCAS moves a submission PENDING→RUNNING via compare-and-set
+// (skipped when it is no longer PENDING) and invalidates the tick cache.
+// Returns whether the write was applied.
+func (l *Loop) activateSubmissionCAS(ctx context.Context, id string) (bool, error) {
+	applied, err := l.store.ActivateSubmission(ctx, id)
+	if err == nil && l.cache != nil {
+		l.cache.invalidateSubmission(id)
+	}
+	return applied, err
+}
+
+// maxSubmissionListPages caps the pagination walk in listSubmissionsByState
+// (10,000 submissions per state per tick) so a store bug that keeps returning
+// full pages cannot spin the scheduler forever.
+const maxSubmissionListPages = 100
+
+// listSubmissionsByState collects every submission in the given state by
+// paging through the store before any processing. A single Limit-100 page
+// starves older rows: the default created_at DESC ordering returns the newest
+// rows first, so anything beyond the first page would never be visited.
+// Callers process the collected list only after the walk completes, because
+// processing mutates submission states and would shift subsequent pages.
+func (l *Loop) listSubmissionsByState(ctx context.Context, state string) ([]*model.Submission, error) {
+	var all []*model.Submission
+	seen := make(map[string]bool)
+	for page := 0; ; page++ {
+		if page >= maxSubmissionListPages {
+			l.logger.Warn("submission list pagination cap reached; processing partial list",
+				"state", state, "pages", maxSubmissionListPages, "collected", len(all))
+			return all, nil
+		}
+		offset := page * model.MaxListLimit
+		// created_at ASC keeps the page walk stable under concurrent inserts
+		// (new rows land after the current position); the seen-map dedupes the
+		// residual boundary shifts from concurrent removals.
+		subs, total, err := l.store.ListSubmissions(ctx, model.ListOptions{
+			State: state, Limit: model.MaxListLimit, Offset: offset,
+			SortBy: "created_at", SortDir: "asc",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list %s submissions (offset %d): %w", state, offset, err)
+		}
+		for _, sub := range subs {
+			if seen[sub.ID] {
+				continue
+			}
+			seen[sub.ID] = true
+			all = append(all, sub)
+		}
+		// Drive the walk by the row count, not the page length: the store
+		// skips corrupt/undecryptable rows AFTER the SQL LIMIT, so a short
+		// page does not mean the end of the result set.
+		if offset+model.MaxListLimit >= total {
+			return all, nil
+		}
+	}
+}
+
 // Tick runs a single scheduling iteration using the 3-level state architecture:
 // Submissions → StepInstances → Tasks.
 func (l *Loop) Tick(ctx context.Context) error {
@@ -1491,6 +1561,20 @@ func (l *Loop) pollInFlight(ctx context.Context, affected map[string]bool) error
 				task.Stderr = stderr
 				scrubTaskToken(task)
 				l.logger.Info("task completed (poll)", "task_id", task.ID, "state", newState)
+
+				// CAS write: a concurrent cancel may have already terminalized
+				// this task (SKIPPED); the poll result must not overwrite it.
+				applied, err := l.store.TerminalizeTask(ctx, task)
+				if err != nil {
+					l.logger.Error("terminalize polled task", "task_id", task.ID, "error", err)
+					continue
+				}
+				if !applied {
+					l.logger.Info("task reached a terminal state concurrently, leaving as-is",
+						"task_id", task.ID, "polled_state", newState)
+				}
+				affected[task.SubmissionID] = true
+				continue
 			}
 
 			if err := l.store.UpdateTask(ctx, task); err != nil {
@@ -1812,7 +1896,7 @@ func (l *Loop) advanceSteps(ctx context.Context, affected map[string]bool) error
 func (l *Loop) finalizeSubmissions(ctx context.Context, affected map[string]bool) error {
 	// Check RUNNING and PENDING submissions.
 	for _, state := range []string{"RUNNING", "PENDING"} {
-		subs, _, err := l.store.ListSubmissions(ctx, model.ListOptions{State: state, Limit: 100})
+		subs, err := l.listSubmissionsByState(ctx, state)
 		if err != nil {
 			l.logger.Error("list submissions for finalize", "state", state, "error", err)
 			continue
@@ -1889,16 +1973,19 @@ func (l *Loop) finalizeSubmissions(ctx context.Context, affected map[string]bool
 			}
 			now := time.Now().UTC()
 			sub.CompletedAt = &now
-			if err := l.updateSubmission(ctx, sub); err != nil {
+			if applied, err := l.finalizeSubmissionCAS(ctx, sub); err != nil {
 				l.logger.Error("finalize submission", "submission_id", subID, "error", err)
+			} else if !applied {
+				// Lost the race to a concurrent terminal write (e.g. a
+				// cancel): leave the winning state alone.
+				l.logger.Info("finalize skipped: submission already terminal", "submission_id", subID)
 			} else {
 				l.logger.Info("submission finalized", "submission_id", subID, "state", sub.State)
 			}
 		} else if (anyActive || anyFailed) && sub.State == model.SubmissionStatePending {
-			sub.State = model.SubmissionStateRunning
-			if err := l.updateSubmission(ctx, sub); err != nil {
+			if applied, err := l.activateSubmissionCAS(ctx, sub.ID); err != nil {
 				l.logger.Error("activate submission", "submission_id", subID, "error", err)
-			} else {
+			} else if applied {
 				l.logger.Info("submission running", "submission_id", subID)
 			}
 		}

--- a/internal/scheduler/loop_test.go
+++ b/internal/scheduler/loop_test.go
@@ -1220,7 +1220,7 @@ func TestGroupAutoInjectsToken(t *testing.T) {
 		{"bvbrc", true},
 		{"esmfold", true},
 		{"default", false},
-		{"", false},      // empty group resolves to "default"
+		{"", false}, // empty group resolves to "default"
 		{"random", false},
 	}
 	for _, c := range cases {

--- a/internal/scheduler/workspace.go
+++ b/internal/scheduler/workspace.go
@@ -30,7 +30,7 @@ func (l *Loop) SetWorkspaceStager(ws wsStagerInterface) {
 // rewrites them to file:// locations, and updates the submission in the store.
 func (l *Loop) prestageWorkspaceInputs(ctx context.Context, affected map[string]bool) error {
 	// Find PENDING submissions that may have ws:// inputs.
-	subs, _, err := l.store.ListSubmissions(ctx, model.ListOptions{State: "PENDING", Limit: 100})
+	subs, err := l.listSubmissionsByState(ctx, "PENDING")
 	if err != nil {
 		return fmt.Errorf("list pending submissions: %w", err)
 	}
@@ -104,10 +104,12 @@ func (l *Loop) prestageWorkspaceInputs(ctx context.Context, affected map[string]
 // poststageWorkspaceOutputs uploads outputs for completed submissions that have
 // an OutputDestination, updates output locations to ws:// URIs, and marks delivery.
 func (l *Loop) poststageWorkspaceOutputs(ctx context.Context, affected map[string]bool) error {
-	// Find COMPLETED submissions with output_destination that haven't been uploaded yet.
-	subs, _, err := l.store.ListSubmissions(ctx, model.ListOptions{State: "COMPLETED", Limit: 100})
+	// SQL-filtered: COMPLETED + destination set + no delivery outcome yet, so
+	// the per-tick cost is bounded by pending deliveries rather than every
+	// COMPLETED submission in the database.
+	subs, err := l.store.ListSubmissionsAwaitingOutputStaging(ctx)
 	if err != nil {
-		return fmt.Errorf("list completed submissions: %w", err)
+		return fmt.Errorf("list submissions awaiting output staging: %w", err)
 	}
 
 	for _, sub := range subs {

--- a/internal/server/resolve_refs_test.go
+++ b/internal/server/resolve_refs_test.go
@@ -43,7 +43,11 @@ func (m *mockStore) ListSubmissions(context.Context, model.ListOptions) ([]*mode
 	return nil, 0, nil
 }
 func (m *mockStore) UpdateSubmission(context.Context, *model.Submission) error { return nil }
-func (m *mockStore) DeleteSubmission(context.Context, string) error            { return nil }
+func (m *mockStore) FinalizeSubmission(context.Context, *model.Submission) (bool, error) {
+	return true, nil
+}
+func (m *mockStore) ActivateSubmission(context.Context, string) (bool, error) { return true, nil }
+func (m *mockStore) DeleteSubmission(context.Context, string) error           { return nil }
 func (m *mockStore) UpdateSubmissionInputs(context.Context, string, map[string]any) error {
 	return nil
 }
@@ -83,7 +87,11 @@ func (m *mockStore) ListTasksBySubmissionPaged(context.Context, string, model.Li
 func (m *mockStore) ListTasksByStepInstance(context.Context, string) ([]*model.Task, error) {
 	return nil, nil
 }
-func (m *mockStore) UpdateTask(context.Context, *model.Task) error { return nil }
+func (m *mockStore) UpdateTask(context.Context, *model.Task) error              { return nil }
+func (m *mockStore) TerminalizeTask(context.Context, *model.Task) (bool, error) { return true, nil }
+func (m *mockStore) ListSubmissionsAwaitingOutputStaging(context.Context) ([]*model.Submission, error) {
+	return nil, nil
+}
 func (m *mockStore) GetTasksByState(context.Context, model.TaskState) ([]*model.Task, error) {
 	return nil, nil
 }

--- a/internal/store/cas_test.go
+++ b/internal/store/cas_test.go
@@ -1,0 +1,231 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/me/gowe/pkg/model"
+)
+
+// --- Compare-and-set write tests ---
+
+func TestFinalizeSubmission(t *testing.T) {
+	tests := []struct {
+		name        string
+		initial     model.SubmissionState
+		wantApplied bool
+		wantState   model.SubmissionState
+	}{
+		{"applies over RUNNING", model.SubmissionStateRunning, true, model.SubmissionStateCompleted},
+		{"refuses to overwrite CANCELLED", model.SubmissionStateCancelled, false, model.SubmissionStateCancelled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := testStore(t)
+			ctx := context.Background()
+
+			wf := sampleWorkflow()
+			if err := st.CreateWorkflow(ctx, wf); err != nil {
+				t.Fatalf("create workflow: %v", err)
+			}
+			sub := sampleSubmission(wf.ID)
+			sub.State = tt.initial
+			if err := st.CreateSubmission(ctx, sub); err != nil {
+				t.Fatalf("create submission: %v", err)
+			}
+
+			now := time.Now().UTC().Truncate(time.Millisecond)
+			sub.State = model.SubmissionStateCompleted
+			sub.CompletedAt = &now
+			sub.Outputs = map[string]any{"genome": "annotated.gb"}
+
+			applied, err := st.FinalizeSubmission(ctx, sub)
+			if err != nil {
+				t.Fatalf("finalize: %v", err)
+			}
+			if applied != tt.wantApplied {
+				t.Errorf("applied = %v, want %v", applied, tt.wantApplied)
+			}
+
+			got, err := st.GetSubmission(ctx, sub.ID)
+			if err != nil {
+				t.Fatalf("get submission: %v", err)
+			}
+			if got.State != tt.wantState {
+				t.Errorf("state = %q, want %q", got.State, tt.wantState)
+			}
+			if tt.wantApplied {
+				if got.CompletedAt == nil {
+					t.Error("expected completed_at to be set")
+				}
+				if got.Outputs["genome"] != "annotated.gb" {
+					t.Errorf("outputs = %v, want genome=annotated.gb", got.Outputs)
+				}
+			} else {
+				if got.CompletedAt != nil {
+					t.Error("expected completed_at to stay unset")
+				}
+				if len(got.Outputs) != 0 {
+					t.Errorf("outputs = %v, want empty", got.Outputs)
+				}
+			}
+		})
+	}
+}
+
+func TestActivateSubmission(t *testing.T) {
+	tests := []struct {
+		name        string
+		initial     model.SubmissionState
+		wantApplied bool
+		wantState   model.SubmissionState
+	}{
+		{"applies from PENDING", model.SubmissionStatePending, true, model.SubmissionStateRunning},
+		{"refuses from CANCELLED", model.SubmissionStateCancelled, false, model.SubmissionStateCancelled},
+		{"refuses from RUNNING", model.SubmissionStateRunning, false, model.SubmissionStateRunning},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := testStore(t)
+			ctx := context.Background()
+
+			wf := sampleWorkflow()
+			if err := st.CreateWorkflow(ctx, wf); err != nil {
+				t.Fatalf("create workflow: %v", err)
+			}
+			sub := sampleSubmission(wf.ID)
+			sub.State = tt.initial
+			if err := st.CreateSubmission(ctx, sub); err != nil {
+				t.Fatalf("create submission: %v", err)
+			}
+
+			applied, err := st.ActivateSubmission(ctx, sub.ID)
+			if err != nil {
+				t.Fatalf("activate: %v", err)
+			}
+			if applied != tt.wantApplied {
+				t.Errorf("applied = %v, want %v", applied, tt.wantApplied)
+			}
+
+			got, err := st.GetSubmission(ctx, sub.ID)
+			if err != nil {
+				t.Fatalf("get submission: %v", err)
+			}
+			if got.State != tt.wantState {
+				t.Errorf("state = %q, want %q", got.State, tt.wantState)
+			}
+		})
+	}
+}
+
+func TestTerminalizeTask(t *testing.T) {
+	tests := []struct {
+		name        string
+		initial     model.TaskState
+		wantApplied bool
+		wantState   model.TaskState
+	}{
+		{"applies over RUNNING", model.TaskStateRunning, true, model.TaskStateSuccess},
+		// SKIPPED simulates a concurrent cancel that already terminalized the task.
+		{"refuses to overwrite SKIPPED", model.TaskStateSkipped, false, model.TaskStateSkipped},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := testStore(t)
+			ctx := context.Background()
+
+			wf := sampleWorkflow()
+			if err := st.CreateWorkflow(ctx, wf); err != nil {
+				t.Fatalf("create workflow: %v", err)
+			}
+			sub := sampleSubmission(wf.ID)
+			if err := st.CreateSubmission(ctx, sub); err != nil {
+				t.Fatalf("create submission: %v", err)
+			}
+			task := sampleTask(sub.ID)
+			task.State = tt.initial
+			if err := st.CreateTask(ctx, task); err != nil {
+				t.Fatalf("create task: %v", err)
+			}
+
+			now := time.Now().UTC().Truncate(time.Millisecond)
+			task.State = model.TaskStateSuccess
+			task.CompletedAt = &now
+			task.Outputs = map[string]any{"contigs": "contigs.fasta"}
+
+			applied, err := st.TerminalizeTask(ctx, task)
+			if err != nil {
+				t.Fatalf("terminalize: %v", err)
+			}
+			if applied != tt.wantApplied {
+				t.Errorf("applied = %v, want %v", applied, tt.wantApplied)
+			}
+
+			got, err := st.GetTask(ctx, task.ID)
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.State != tt.wantState {
+				t.Errorf("state = %q, want %q", got.State, tt.wantState)
+			}
+			if tt.wantApplied {
+				if got.CompletedAt == nil {
+					t.Error("expected completed_at to be set")
+				}
+				if got.Outputs["contigs"] != "contigs.fasta" {
+					t.Errorf("outputs = %v, want contigs=contigs.fasta", got.Outputs)
+				}
+			} else {
+				if got.CompletedAt != nil {
+					t.Error("expected completed_at to stay unset")
+				}
+				if len(got.Outputs) != 0 {
+					t.Errorf("outputs = %v, want empty", got.Outputs)
+				}
+			}
+		})
+	}
+}
+
+func TestListSubmissionsAwaitingOutputStaging(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+
+	seq := 0
+	mk := func(state model.SubmissionState, dest, outputState string) *model.Submission {
+		seq++
+		sub := sampleSubmission(wf.ID)
+		sub.ID = fmt.Sprintf("sub_staging-%d", seq)
+		sub.State = state
+		sub.OutputDestination = dest
+		sub.OutputState = outputState
+		if err := st.CreateSubmission(ctx, sub); err != nil {
+			t.Fatalf("create submission: %v", err)
+		}
+		return sub
+	}
+
+	eligible := mk(model.SubmissionStateCompleted, "ws:///user@bvbrc/home/out/", "")
+	mk(model.SubmissionStateCompleted, "", "")                                    // no destination
+	mk(model.SubmissionStateCompleted, "ws:///user@bvbrc/home/out/", "delivered") // already delivered
+	mk(model.SubmissionStateRunning, "ws:///user@bvbrc/home/out/", "")            // not completed
+	mk(model.SubmissionStateFailed, "ws:///user@bvbrc/home/out/", "")             // terminal but not completed
+
+	got, err := st.ListSubmissionsAwaitingOutputStaging(ctx)
+	if err != nil {
+		t.Fatalf("list awaiting output staging: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d submissions, want 1", len(got))
+	}
+	if got[0].ID != eligible.ID {
+		t.Errorf("got %s, want %s", got[0].ID, eligible.ID)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -591,7 +591,7 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 	}, "created_at DESC")
 
 	// List query with pagination.
-	listQuery := `SELECT id, workflow_id, workflow_name, state, inputs, outputs, labels, submitted_by, created_at, completed_at, user_token, token_expiry, auth_provider, output_destination, output_state
+	listQuery := `SELECT ` + submissionListColumns + `
 		FROM submissions` + whereSQL + ` ORDER BY ` + orderSQL + ` LIMIT ? OFFSET ?`
 	listArgs := append(countArgs, opts.Limit, opts.Offset)
 
@@ -601,6 +601,17 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 	}
 	defer rows.Close()
 
+	subs, err := s.scanSubmissionRows(rows)
+	return subs, total, err
+}
+
+// submissionListColumns is the column set scanned by scanSubmissionRows.
+const submissionListColumns = `id, workflow_id, workflow_name, state, inputs, outputs, labels, submitted_by, created_at, completed_at, user_token, token_expiry, auth_provider, output_destination, output_state`
+
+// scanSubmissionRows scans submissionListColumns rows, skipping (with an error
+// log) rows that fail token decryption or JSON/timestamp parsing so one corrupt
+// row cannot hide the rest of the result set.
+func (s *SQLiteStore) scanSubmissionRows(rows *sql.Rows) ([]*model.Submission, error) {
 	var subs []*model.Submission
 	for rows.Next() {
 		var sub model.Submission
@@ -614,10 +625,11 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 			&sub.SubmittedBy, &createdAt, &completedAt,
 			&sub.UserToken, &tokenExpiry, &sub.AuthProvider,
 			&sub.OutputDestination, &sub.OutputState); err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 
 		sub.State = model.SubmissionState(state)
+		var err error
 		if sub.UserToken, err = s.decryptToken(sub.UserToken, submissionTokenAAD(sub.ID)); err != nil {
 			slog.Error("skipping submission row with undecryptable token", "id", sub.ID, "error", err)
 			continue
@@ -652,7 +664,28 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 
 		subs = append(subs, &sub)
 	}
-	return subs, total, rows.Err()
+	return subs, rows.Err()
+}
+
+// ListSubmissionsAwaitingOutputStaging returns COMPLETED submissions that have
+// an output destination and no recorded delivery outcome — the exact set the
+// scheduler's post-stage phase must process. Filtering in SQL keeps the
+// per-tick cost bounded by pending deliveries instead of every COMPLETED
+// submission in the database.
+func (s *SQLiteStore) ListSubmissionsAwaitingOutputStaging(ctx context.Context) ([]*model.Submission, error) {
+	s.logger.Debug("sql", "op", "list_awaiting_output_staging", "table", "submissions")
+
+	query := `SELECT ` + submissionListColumns + `
+		FROM submissions
+		WHERE state = 'COMPLETED' AND output_destination != '' AND (output_state = '' OR output_state IS NULL)
+		ORDER BY created_at ASC`
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return s.scanSubmissionRows(rows)
 }
 
 func (s *SQLiteStore) CountSubmissionsByState(ctx context.Context, since time.Time, submittedBy string) (map[string]int, error) {
@@ -692,16 +725,18 @@ func (s *SQLiteStore) CountSubmissionsByState(ctx context.Context, since time.Ti
 	return counts, rows.Err()
 }
 
-func (s *SQLiteStore) UpdateSubmission(ctx context.Context, sub *model.Submission) error {
-	s.logger.Debug("sql", "op", "update", "table", "submissions", "id", sub.ID)
-
+// execSubmissionUpdate marshals the mutable submission columns and runs the
+// shared UPDATE with the given WHERE clause, returning the number of rows
+// affected. It is the single write path behind UpdateSubmission and
+// FinalizeSubmission so both persist the same field set.
+func (s *SQLiteStore) execSubmissionUpdate(ctx context.Context, sub *model.Submission, where string, whereArgs ...any) (int64, error) {
 	outputsJSON, err := json.Marshal(sub.Outputs)
 	if err != nil {
-		return fmt.Errorf("marshal outputs: %w", err)
+		return 0, fmt.Errorf("marshal outputs: %w", err)
 	}
 	labelsJSON, err := json.Marshal(sub.Labels)
 	if err != nil {
-		return fmt.Errorf("marshal labels: %w", err)
+		return 0, fmt.Errorf("marshal labels: %w", err)
 	}
 
 	errorJSON := ""
@@ -713,22 +748,70 @@ func (s *SQLiteStore) UpdateSubmission(ctx context.Context, sub *model.Submissio
 
 	var completedAt *string
 	if sub.CompletedAt != nil {
-		s := sub.CompletedAt.Format(time.RFC3339Nano)
-		completedAt = &s
+		v := sub.CompletedAt.Format(time.RFC3339Nano)
+		completedAt = &v
 	}
 
+	args := append([]any{
+		string(sub.State), string(outputsJSON), string(labelsJSON), errorJSON,
+		completedAt, sub.OutputDestination, sub.OutputState,
+	}, whereArgs...)
 	result, err := s.db.ExecContext(ctx,
-		`UPDATE submissions SET state=?, outputs=?, labels=?, error=?, completed_at=?, output_destination=?, output_state=? WHERE id=?`,
-		string(sub.State), string(outputsJSON), string(labelsJSON), errorJSON, completedAt, sub.OutputDestination, sub.OutputState, sub.ID,
+		`UPDATE submissions SET state=?, outputs=?, labels=?, error=?, completed_at=?, output_destination=?, output_state=?`+where,
+		args...,
 	)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := result.RowsAffected()
+	return n, nil
+}
+
+func (s *SQLiteStore) UpdateSubmission(ctx context.Context, sub *model.Submission) error {
+	s.logger.Debug("sql", "op", "update", "table", "submissions", "id", sub.ID)
+
+	n, err := s.execSubmissionUpdate(ctx, sub, ` WHERE id=?`, sub.ID)
 	if err != nil {
 		return err
 	}
-	n, _ := result.RowsAffected()
 	if n == 0 {
 		return fmt.Errorf("submission %s not found", sub.ID)
 	}
 	return nil
+}
+
+// FinalizeSubmission writes the same field set as UpdateSubmission, but only
+// while the submission is still active (compare-and-set): a row already in a
+// terminal state (CANCELLED, COMPLETED, FAILED) is left untouched. Returns
+// applied=false (no error) when the guard rejected the write, so callers can
+// re-read and observe the winning state.
+func (s *SQLiteStore) FinalizeSubmission(ctx context.Context, sub *model.Submission) (bool, error) {
+	s.logger.Debug("sql", "op", "finalize", "table", "submissions", "id", sub.ID)
+
+	n, err := s.execSubmissionUpdate(ctx, sub, ` WHERE id=? AND state NOT IN (?, ?, ?)`,
+		sub.ID,
+		string(model.SubmissionStateCancelled), string(model.SubmissionStateCompleted), string(model.SubmissionStateFailed))
+	if err != nil {
+		return false, fmt.Errorf("finalize submission %s: %w", sub.ID, err)
+	}
+	return n > 0, nil
+}
+
+// ActivateSubmission moves a submission from PENDING to RUNNING
+// (compare-and-set). Returns applied=false (no error) when the submission is
+// no longer PENDING — e.g. it was cancelled mid-tick — so the activation
+// cannot resurrect a terminal submission.
+func (s *SQLiteStore) ActivateSubmission(ctx context.Context, id string) (bool, error) {
+	s.logger.Debug("sql", "op", "activate", "table", "submissions", "id", id)
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE submissions SET state=? WHERE id=? AND state=?`,
+		string(model.SubmissionStateRunning), id, string(model.SubmissionStatePending))
+	if err != nil {
+		return false, fmt.Errorf("activate submission %s: %w", id, err)
+	}
+	n, _ := result.RowsAffected()
+	return n > 0, nil
 }
 
 func (s *SQLiteStore) DeleteSubmission(ctx context.Context, id string) error {
@@ -1239,9 +1322,12 @@ func (s *SQLiteStore) ListTasksByStepInstance(ctx context.Context, stepInstanceI
 	return s.scanTasks(rows)
 }
 
-func (s *SQLiteStore) UpdateTask(ctx context.Context, task *model.Task) error {
-	s.logger.Debug("sql", "op", "update", "table", "tasks", "id", task.ID)
-
+// execTaskUpdate marshals the mutable task columns (encrypting any embedded
+// HTTP bearer token via marshalRuntimeHints) and runs the shared UPDATE with
+// the given WHERE clause, returning the number of rows affected. It is the
+// single write path behind UpdateTask and TerminalizeTask so both persist the
+// same field set.
+func (s *SQLiteStore) execTaskUpdate(ctx context.Context, task *model.Task, where string, whereArgs ...any) (int64, error) {
 	// Sanitize NaN/Inf values before marshaling (Go's encoding/json rejects them).
 	sanitizeFloats(task.Outputs)
 	sanitizeFloats(task.Tool)
@@ -1249,19 +1335,19 @@ func (s *SQLiteStore) UpdateTask(ctx context.Context, task *model.Task) error {
 
 	outputsJSON, err := json.Marshal(task.Outputs)
 	if err != nil {
-		return fmt.Errorf("marshal outputs: %w", err)
+		return 0, fmt.Errorf("marshal outputs: %w", err)
 	}
 	toolJSON, err := json.Marshal(task.Tool)
 	if err != nil {
-		return fmt.Errorf("marshal tool: %w", err)
+		return 0, fmt.Errorf("marshal tool: %w", err)
 	}
 	jobJSON, err := json.Marshal(task.Job)
 	if err != nil {
-		return fmt.Errorf("marshal job: %w", err)
+		return 0, fmt.Errorf("marshal job: %w", err)
 	}
 	runtimeHintsJSON, err := s.marshalRuntimeHints(task.RuntimeHints, taskHintsAAD(task.ID))
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	var startedAt, completedAt *string
@@ -1274,27 +1360,56 @@ func (s *SQLiteStore) UpdateTask(ctx context.Context, task *model.Task) error {
 		completedAt = &v
 	}
 
-	result, err := s.db.ExecContext(ctx,
-		`UPDATE tasks SET state=?, executor_type=?, external_id=?,
-		 outputs=?, priority=?, retry_count=?, max_retries=?, stdout=?, stderr=?, exit_code=?,
-		 started_at=?, completed_at=?, tool=?, job=?, runtime_hints=?,
-		 step_instance_id=?, scatter_index=? WHERE id=?`,
+	args := append([]any{
 		string(task.State), string(task.ExecutorType), task.ExternalID,
 		string(outputsJSON), task.Priority, task.RetryCount, task.MaxRetries,
 		task.Stdout, task.Stderr, task.ExitCode,
 		startedAt, completedAt,
 		string(toolJSON), string(jobJSON), string(runtimeHintsJSON),
 		task.StepInstanceID, task.ScatterIndex,
-		task.ID,
+	}, whereArgs...)
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE tasks SET state=?, executor_type=?, external_id=?,
+		 outputs=?, priority=?, retry_count=?, max_retries=?, stdout=?, stderr=?, exit_code=?,
+		 started_at=?, completed_at=?, tool=?, job=?, runtime_hints=?,
+		 step_instance_id=?, scatter_index=?`+where,
+		args...,
 	)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := result.RowsAffected()
+	return n, nil
+}
+
+func (s *SQLiteStore) UpdateTask(ctx context.Context, task *model.Task) error {
+	s.logger.Debug("sql", "op", "update", "table", "tasks", "id", task.ID)
+
+	n, err := s.execTaskUpdate(ctx, task, ` WHERE id=?`, task.ID)
 	if err != nil {
 		return err
 	}
-	n, _ := result.RowsAffected()
 	if n == 0 {
 		return fmt.Errorf("task %s not found", task.ID)
 	}
 	return nil
+}
+
+// TerminalizeTask writes the same field set as UpdateTask, but only while the
+// task is not already terminal (SUCCESS, FAILED, SKIPPED) — compare-and-set,
+// so a concurrent terminal write (e.g. a cancel that SKIPPED the task) is
+// never overwritten. Returns applied=false (no error) when the guard rejected
+// the write, so callers can re-read and observe the winning state.
+func (s *SQLiteStore) TerminalizeTask(ctx context.Context, task *model.Task) (bool, error) {
+	s.logger.Debug("sql", "op", "terminalize", "table", "tasks", "id", task.ID)
+
+	n, err := s.execTaskUpdate(ctx, task, ` WHERE id=? AND state NOT IN (?, ?, ?)`,
+		task.ID,
+		string(model.TaskStateSuccess), string(model.TaskStateFailed), string(model.TaskStateSkipped))
+	if err != nil {
+		return false, fmt.Errorf("terminalize task %s: %w", task.ID, err)
+	}
+	return n > 0, nil
 }
 
 func (s *SQLiteStore) GetTasksByState(ctx context.Context, state model.TaskState) ([]*model.Task, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,6 +23,17 @@ type Store interface {
 	GetSubmission(ctx context.Context, id string) (*model.Submission, error)
 	ListSubmissions(ctx context.Context, opts model.ListOptions) ([]*model.Submission, int, error)
 	UpdateSubmission(ctx context.Context, sub *model.Submission) error
+	// FinalizeSubmission is UpdateSubmission guarded by a compare-and-set:
+	// the write is skipped (applied=false, no error) when the submission is
+	// already terminal.
+	FinalizeSubmission(ctx context.Context, sub *model.Submission) (bool, error)
+	// ActivateSubmission moves a submission PENDING→RUNNING; applied=false
+	// (no error) when it is no longer PENDING.
+	ActivateSubmission(ctx context.Context, id string) (bool, error)
+	// ListSubmissionsAwaitingOutputStaging returns COMPLETED submissions with
+	// an output destination and no recorded delivery outcome (SQL-filtered so
+	// the post-stage phase's cost is bounded by pending deliveries).
+	ListSubmissionsAwaitingOutputStaging(ctx context.Context) ([]*model.Submission, error)
 	DeleteSubmission(ctx context.Context, id string) error
 	UpdateSubmissionInputs(ctx context.Context, id string, inputs map[string]any) error
 	GetChildSubmissions(ctx context.Context, parentTaskID string) ([]*model.Submission, error)
@@ -44,6 +55,9 @@ type Store interface {
 	ListTasksBySubmissionPaged(ctx context.Context, submissionID string, opts model.ListOptions) ([]*model.Task, int, error)
 	ListTasksByStepInstance(ctx context.Context, stepInstanceID string) ([]*model.Task, error)
 	UpdateTask(ctx context.Context, task *model.Task) error
+	// TerminalizeTask is UpdateTask guarded by a compare-and-set: the write is
+	// skipped (applied=false, no error) when the task is already terminal.
+	TerminalizeTask(ctx context.Context, task *model.Task) (bool, error)
 	GetTasksByState(ctx context.Context, state model.TaskState) ([]*model.Task, error)
 	GetActiveTasks(ctx context.Context) ([]*model.Task, error)
 	GetTaskSummaries(ctx context.Context, submissionIDs []string) (map[string]model.TaskSummary, error)


### PR DESCRIPTION
## Summary

**PR 1 of 5** for the #164 implementation plan ([spec on the issue](https://github.com/wilke/GoWe/issues/164#issuecomment-5235047430)). Standalone fix for two defect classes the plan's review isolated — landing it first de-risks the core scatter-over-subworkflow rewrite (PR 2).

### Defects fixed

1. **Uncancellable-run clobber (#164 defect 3b class):** the tick loop's submission writes were unconditional last-writer-wins. A concurrently cancelled submission could be overwritten back to COMPLETED by finalization, or resurrected PENDING→RUNNING mid-tick from the tickCache's stale snapshot — then finalized COMPLETED next tick. Same class at task level: a poll result could overwrite a cancel's SKIPPED.
2. **Limit-100 starvation:** finalize, workspace prestage, and workspace poststage each did a single `Limit: 100` list per state, `created_at DESC` — anything past the newest 100 was never visited. (The upcoming child-submission work multiplies row counts, making this acute.)

### Changes

- **Store:** `FinalizeSubmission` / `ActivateSubmission` / `TerminalizeTask` — compare-and-set variants sharing exact field sets and token-encryption/AAD paths with their unconditional counterparts; `applied=false` (no error) on guard refusal.
- **Scheduler:** CAS methods used via tickCache-invalidating wrappers; refused writes leave the winning state. `pollInFlight` terminal writes go through `TerminalizeTask`.
- **Pagination:** total-count-driven page walk (short pages ≠ end — the store drops corrupt rows *after* the SQL LIMIT), `created_at ASC` for insert-stability, ID-dedupe, 100-page cap. Poststage instead gets an SQL-filtered `ListSubmissionsAwaitingOutputStaging` so per-tick cost is bounded by pending deliveries, not all COMPLETED rows ever.

### Testing

- Store CAS tests re-read DB state after refused writes (not just the bool)
- `TestFinalize_CancelledMidTick_NotResurrected` reproduces the race deterministically by priming the tickCache with the pre-cancel snapshot — **mutation-verified**: reverting to blind `UpdateSubmission` fails it with "state = COMPLETED, want CANCELLED"
- `TestFinalize_PaginationBeyond100` (120 submissions) — mutation-verified against single-page collapse
- Poststage query filter test; full suite + gofmt/vet green

### Built & verified with a 5-agent workflow

Store/scheduler implementation agents + 3 adversarial review lenses (CAS-vs-plan, regression hunt, test adequacy). Review findings fixed in this PR: total-driven pagination (short-page bug), SQL-filtered poststage (unbounded walk), `TerminalizeTask` wired rather than shipped dead, ASC+dedupe walk stability.

**Known follow-up (PR 2):** `markRetries`' FAILED→RETRYING write is still unconditional — will be guarded alongside the proxy-task pollInFlight branch.

Part of #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg