### PR TITLE
feat(scheduler): non-blocking scatter-over-subworkflow via proxy tasks

### DIFF
--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -852,7 +852,12 @@ func (l *Loop) dispatchScatterStep(ctx context.Context, si *model.StepInstance, 
 	return l.updateStepInstance(ctx, si)
 }
 
-// dispatchSubWorkflowStep handles a non-scatter sub-workflow step.
+// dispatchSubWorkflowStep handles a non-scatter sub-workflow step without
+// blocking the tick loop: it persists a single proxy task (ExecutorType
+// "subworkflow", RUNNING from birth) paired 1:1 with a child submission that
+// flows through the normal tick machinery. pollInFlight advances the proxy
+// from the child's state, and fan-in is the ordinary single-task path in
+// advanceSteps.
 func (l *Loop) dispatchSubWorkflowStep(ctx context.Context, si *model.StepInstance, tmpTask *model.Task,
 	step *model.Step, wf *model.Workflow, sub *model.Submission,
 	mergedInputs map[string]any, tasksByStep map[string]*model.Task,
@@ -870,45 +875,35 @@ func (l *Loop) dispatchSubWorkflowStep(ctx context.Context, si *model.StepInstan
 		return fmt.Errorf("sub-workflow %q not found", step.ToolRef)
 	}
 
-	// Create a temporary task for the child submission linkage.
-	parentTask := &model.Task{
-		ID:             "task_" + uuid.New().String(),
-		SubmissionID:   si.SubmissionID,
-		StepID:         si.StepID,
-		StepInstanceID: si.ID,
-		Tool:           tmpTask.Tool,
-		Job:            tmpTask.Job,
-		RuntimeHints:   tmpTask.RuntimeHints,
-	}
+	task := l.createSubworkflowProxyTask(si, tmpTask, step, sub, tmpTask.Job, -1)
 
-	childSub, err := l.createChildSubmission(ctx, parentTask, subGraph, tmpTask.Job, sub, wf)
+	// Persist the proxy and the DISPATCHED step in ONE transaction: a crash
+	// can never leave a DISPATCHED step without its task (or vice versa) —
+	// either both land, or the step stays READY and is re-dispatched. [F4]
+	si.State = model.StepStateDispatched
+	if err := l.store.CreateTasksAndDispatchStep(ctx, []*model.Task{task}, si); err != nil {
+		return fmt.Errorf("persist sub-workflow dispatch: %w", err)
+	}
+	l.cache.invalidateSteps(si.SubmissionID)
+
+	childSub, err := l.createChildSubmission(ctx, task, subGraph, task.Job, sub, wf)
 	if err != nil {
-		now := time.Now().UTC()
-		si.State = model.StepStateFailed
-		si.CompletedAt = &now
-		return l.updateStepInstance(ctx, si)
+		// Child creation is not retryable (e.g. plaintext-token refusal):
+		// surface the error on the proxy and fail the step outright. [F11]
+		l.failSubworkflowProxy(ctx, task, si, fmt.Sprintf("create child submission: %v", err))
+		return nil
 	}
 
-	if err := l.executeChildSubmission(ctx, childSub); err != nil {
-		now := time.Now().UTC()
-		si.State = model.StepStateFailed
-		si.CompletedAt = &now
-		return l.updateStepInstance(ctx, si)
-	}
-
-	now := time.Now().UTC()
-	if childSub.State == model.SubmissionStateCompleted {
-		si.State = model.StepStateCompleted
-		si.Outputs = childSub.Outputs
-	} else {
-		si.State = model.StepStateFailed
-	}
-	si.CompletedAt = &now
-
-	return l.updateStepInstance(ctx, si)
+	l.reconcileDispatchWithCancel(ctx, sub.ID, si.ID, []*model.Task{task}, []*model.Submission{childSub})
+	return nil
 }
 
-// dispatchScatterSubWorkflow handles scatter over a sub-workflow.
+// dispatchScatterSubWorkflow handles scatter over a sub-workflow without
+// blocking the tick loop: every scatter combination gets one persisted proxy
+// task (RUNNING, Job=combo, MaxRetries=0) paired 1:1 with a child submission
+// that flows through the normal tick machinery. The step fans in through the
+// ordinary ScatterIndex merge in advanceSteps once pollInFlight has advanced
+// every proxy from its child's state.
 func (l *Loop) dispatchScatterSubWorkflow(ctx context.Context, si *model.StepInstance, tmpTask *model.Task,
 	step *model.Step, wf *model.Workflow, sub *model.Submission,
 	mergedInputs map[string]any, tasksByStep map[string]*model.Task,
@@ -971,61 +966,230 @@ func (l *Loop) dispatchScatterSubWorkflow(ctx context.Context, si *model.StepIns
 		}
 	}
 
-	parentTask := &model.Task{
-		ID:             "task_" + uuid.New().String(),
-		SubmissionID:   si.SubmissionID,
-		StepID:         si.StepID,
-		StepInstanceID: si.ID,
+	// Empty scatter completes inline with empty merged outputs: advanceSteps
+	// skips zero-task steps, so a DISPATCHED empty scatter would hang
+	// forever. [M1]
+	if len(combinations) == 0 {
+		si.Outputs = l.mergeScatterOutputs(nil, step, method, scatterArrays)
+		now := time.Now().UTC()
+		si.State = model.StepStateCompleted
+		si.CompletedAt = &now
+		l.logger.Info("scatter sub-workflow completed (empty scatter)", "si_id", si.ID)
+		return l.updateStepInstance(ctx, si)
 	}
 
-	var results []map[string]any
+	// Build all proxy tasks up front. When-skipped combinations become
+	// terminal SUCCESS tasks with null outputs — exactly like plain scatter —
+	// so the ScatterIndex fan-in still sees a full index set.
+	tasks := make([]*model.Task, 0, len(combinations))
+	childless := make(map[string]bool) // task IDs of when-skipped combos: no child
 	for i, combo := range combinations {
 		if step.When != "" {
 			shouldRun, err := l.evaluateWhenForScatterIterationFromSteps(step, combo, mergedInputs, stepOutputs)
 			if err != nil {
-				l.logger.Warn("scatter when eval failed", "si_id", si.ID, "iter", i, "error", err)
+				// CWL spec: non-boolean 'when' expressions must fail the step.
+				now := time.Now().UTC()
+				si.State = model.StepStateFailed
+				si.CompletedAt = &now
+				l.logger.Error("scatter when eval failed", "si_id", si.ID, "iter", i, "error", err)
+				return l.updateStepInstance(ctx, si)
 			} else if !shouldRun {
 				nullOutputs := make(map[string]any)
 				for _, outID := range step.Out {
 					nullOutputs[outID] = nil
 				}
-				results = append(results, nullOutputs)
+				now := time.Now().UTC()
+				task := l.createTaskFromStep(si, tmpTask, step, sub, model.ExecutorTypeSubworkflow, i)
+				task.Outputs = nullOutputs
+				task.State = model.TaskStateSuccess
+				task.CompletedAt = &now
+				task.Job = combo
+				task.Inputs = combo
+				task.MaxRetries = 0
+				tasks = append(tasks, task)
+				childless[task.ID] = true
 				continue
 			}
 		}
-
-		childSub, err := l.createChildSubmission(ctx, parentTask, subGraph, combo, sub, wf)
-		if err != nil {
-			now := time.Now().UTC()
-			si.State = model.StepStateFailed
-			si.CompletedAt = &now
-			return l.updateStepInstance(ctx, si)
-		}
-
-		if err := l.executeChildSubmission(ctx, childSub); err != nil {
-			now := time.Now().UTC()
-			si.State = model.StepStateFailed
-			si.CompletedAt = &now
-			return l.updateStepInstance(ctx, si)
-		}
-
-		if childSub.State != model.SubmissionStateCompleted {
-			now := time.Now().UTC()
-			si.State = model.StepStateFailed
-			si.CompletedAt = &now
-			return l.updateStepInstance(ctx, si)
-		}
-
-		results = append(results, childSub.Outputs)
+		tasks = append(tasks, l.createSubworkflowProxyTask(si, tmpTask, step, sub, combo, i))
 	}
 
-	si.Outputs = l.mergeScatterOutputs(results, step, method, scatterArrays)
-	now := time.Now().UTC()
-	si.State = model.StepStateCompleted
-	si.CompletedAt = &now
-	l.logger.Info("scatter sub-workflow completed", "si_id", si.ID, "iterations", len(combinations))
+	// Persist all proxies and the DISPATCHED step in ONE transaction — a
+	// crash mid-dispatch leaves the step READY with zero tasks, so the next
+	// tick re-dispatches cleanly with no duplicates. [F4]
+	si.State = model.StepStateDispatched
+	si.ScatterCount = len(combinations)
+	si.ScatterMethod = method
+	if method == "nested_crossproduct" && len(step.Scatter) > 1 {
+		si.ScatterDims = make([]int, len(step.Scatter))
+		for i, name := range step.Scatter {
+			si.ScatterDims[i] = len(scatterArrays[name])
+		}
+	}
+	if err := l.store.CreateTasksAndDispatchStep(ctx, tasks, si); err != nil {
+		return fmt.Errorf("persist scatter sub-workflow dispatch: %w", err)
+	}
+	l.cache.invalidateSteps(si.SubmissionID)
 
-	return l.updateStepInstance(ctx, si)
+	// Create the child submissions outside the transaction (idempotent per
+	// proxy: a crash between the transaction and any child creation is
+	// repaired by pollInFlight from the persisted task.Job).
+	children := make([]*model.Submission, 0, len(tasks))
+	for _, task := range tasks {
+		if childless[task.ID] {
+			continue
+		}
+		childSub, err := l.createChildSubmission(ctx, task, subGraph, task.Job, sub, wf)
+		if err != nil {
+			// Not retryable (e.g. plaintext-token refusal): fail the step
+			// outright. Already-created siblings keep running until
+			// pollInFlight's reconciliation cancels them against the
+			// now-terminal step. [F11]
+			l.failSubworkflowProxy(ctx, task, si, fmt.Sprintf("create child submission: %v", err))
+			return nil
+		}
+		children = append(children, childSub)
+	}
+
+	l.reconcileDispatchWithCancel(ctx, sub.ID, si.ID, tasks, children)
+
+	l.logger.Info("scatter sub-workflow dispatched",
+		"si_id", si.ID, "iterations", len(combinations), "children", len(children))
+	return nil
+}
+
+// createSubworkflowProxyTask builds the persisted proxy task that pairs 1:1
+// with a child submission. Proxies are RUNNING from birth — never QUEUED, so
+// CheckoutTask, the stuck detector, and requeue/reconcile (which all filter
+// on executor_type='worker') never see them — and carry the fully-resolved
+// child inputs in Job, so recovery can recreate the child without re-running
+// scatter combination or valueFrom/when JavaScript. MaxRetries is pinned to
+// 0: a FAILED proxy must never cycle through resubmitRetrying, which would
+// erase the child's error. [F8]
+func (l *Loop) createSubworkflowProxyTask(si *model.StepInstance, tmpTask *model.Task, step *model.Step,
+	sub *model.Submission, job map[string]any, scatterIndex int) *model.Task {
+
+	task := l.createTaskFromStep(si, tmpTask, step, sub, model.ExecutorTypeSubworkflow, scatterIndex)
+	now := time.Now().UTC()
+	task.State = model.TaskStateRunning
+	task.StartedAt = &now
+	task.Job = job
+	task.Inputs = job
+	task.MaxRetries = 0
+	// No addUserToken: the proxy never executes, so a token at rest on a
+	// long-lived RUNNING row is pure exposure, and propagating the parent's
+	// OutputDestination here would contradict the child-level drop. [F6]
+	return task
+}
+
+// failSubworkflowProxy records a non-retryable sub-workflow dispatch failure:
+// the proxy task goes FAILED with the reason in Stderr (so
+// buildSubmissionError surfaces it) and the step instance is failed. [F11]
+func (l *Loop) failSubworkflowProxy(ctx context.Context, task *model.Task, si *model.StepInstance, reason string) {
+	now := time.Now().UTC()
+	task.State = model.TaskStateFailed
+	task.Stderr = reason
+	task.CompletedAt = &now
+	if _, err := l.store.TerminalizeTask(ctx, task); err != nil {
+		l.logger.Error("fail subworkflow proxy", "task_id", task.ID, "error", err)
+	}
+	si.State = model.StepStateFailed
+	si.CompletedAt = &now
+	if err := l.updateStepInstance(ctx, si); err != nil {
+		l.logger.Error("fail subworkflow step", "si_id", si.ID, "error", err)
+	}
+	l.logger.Error("sub-workflow dispatch failed", "si_id", si.ID, "task_id", task.ID, "reason", reason)
+}
+
+// reconcileDispatchWithCancel closes the cancel-during-dispatch race: the
+// cancel handler's CancelNonTerminalSteps/Tasks fan-out may have run between
+// this step's READY read and the dispatch transaction, in which case the
+// transaction's DISPATCHED write clobbered the handler's SKIPPED and the
+// proxies/children were created after the handler's snapshot. Re-read the
+// parent; if it went terminal, cancel the created children, SKIP the proxy
+// tasks, and conditionally re-SKIP the step. pollInFlight's reconciliation is
+// the per-tick backstop for anything this misses. [F2,M2]
+func (l *Loop) reconcileDispatchWithCancel(ctx context.Context, subID, siID string,
+	tasks []*model.Task, children []*model.Submission) {
+
+	// Fresh read (not tickCache): the whole point is to observe a cancel that
+	// landed after this tick's snapshot.
+	fresh, err := l.store.GetSubmission(ctx, subID)
+	if err != nil || fresh == nil {
+		l.logger.Error("re-read submission after dispatch", "submission_id", subID, "error", err)
+		return
+	}
+	if !fresh.State.IsTerminal() {
+		return
+	}
+	l.logger.Info("submission went terminal during sub-workflow dispatch; undoing fan-out",
+		"submission_id", subID, "si_id", siID, "state", fresh.State)
+	for _, child := range children {
+		l.cancelChildSubmission(ctx, child)
+	}
+	now := time.Now().UTC()
+	for _, task := range tasks {
+		task.State = model.TaskStateSkipped
+		task.CompletedAt = &now
+		// CAS: when-skipped synthetic SUCCESS tasks are already terminal and
+		// stay as they are.
+		if _, err := l.store.TerminalizeTask(ctx, task); err != nil {
+			l.logger.Error("skip proxy task after cancel", "task_id", task.ID, "error", err)
+		}
+	}
+	l.skipStepInstanceIfActive(ctx, siID)
+}
+
+// cancelChildSubmission cancels an active child submission and skips its
+// steps and tasks, mirroring the server's cancel handler. The CAS finalize
+// leaves a concurrently-terminalized child alone; the step/task writes only
+// touch non-terminal rows either way, so a worker can never check out
+// orphaned child work.
+//
+// Nested sub-workflows cascade one level per tick with no explicit recursion:
+// CancelNonTerminalTasks excludes the child's own subworkflow proxies, so they
+// stay RUNNING here — next tick pollSubworkflowTask observes their (now
+// CANCELLED) submission, cancels the grandchildren, and SKIPs those proxies.
+func (l *Loop) cancelChildSubmission(ctx context.Context, child *model.Submission) {
+	now := time.Now().UTC()
+	child.State = model.SubmissionStateCancelled
+	child.CompletedAt = &now
+	if _, err := l.finalizeSubmissionCAS(ctx, child); err != nil {
+		l.logger.Error("cancel child submission", "child_id", child.ID, "error", err)
+		return
+	}
+	if _, err := l.store.CancelNonTerminalSteps(ctx, child.ID, now); err != nil {
+		l.logger.Error("cancel child steps", "child_id", child.ID, "error", err)
+	}
+	if _, err := l.store.CancelNonTerminalTasks(ctx, child.ID, now); err != nil {
+		l.logger.Error("cancel child tasks", "child_id", child.ID, "error", err)
+	}
+	l.logger.Info("child submission cancelled", "child_id", child.ID)
+}
+
+// skipStepInstanceIfActive re-reads a step instance and marks it SKIPPED
+// unless a concurrent writer already made it terminal. This is the
+// "conditionally re-SKIP" half of the cancel-during-dispatch defense: the
+// dispatch transaction may have clobbered the cancel handler's SKIPPED with
+// DISPATCHED, and the cancel handler may crash between its submission and
+// step writes. [F2,M2]
+func (l *Loop) skipStepInstanceIfActive(ctx context.Context, siID string) {
+	si, err := l.store.GetStepInstance(ctx, siID)
+	if err != nil || si == nil {
+		l.logger.Error("re-read step instance for skip", "si_id", siID, "error", err)
+		return
+	}
+	if si.State.IsTerminal() {
+		return
+	}
+	now := time.Now().UTC()
+	si.State = model.StepStateSkipped
+	si.CompletedAt = &now
+	if err := l.updateStepInstance(ctx, si); err != nil {
+		l.logger.Error("skip step instance", "si_id", siID, "error", err)
+		return
+	}
+	l.logger.Info("step instance skipped (cancel reconciliation)", "si_id", siID)
 }
 
 // createTaskFromStep creates a new Task linked to a StepInstance.
@@ -1346,6 +1510,9 @@ func scrubTaskToken(task *model.Task) {
 }
 
 // submitAndUpdateTask submits a task to its executor and updates its state.
+// The final persist is a guarded write: a concurrent HTTP cancel may have
+// already terminalized (SKIPPED) the task, and the submit outcome must not
+// resurrect it under a cancelled submission.
 func (l *Loop) submitAndUpdateTask(ctx context.Context, task *model.Task) {
 	exec, err := l.registry.Get(task.ExecutorType)
 	if err != nil {
@@ -1353,7 +1520,7 @@ func (l *Loop) submitAndUpdateTask(ctx context.Context, task *model.Task) {
 		task.State = model.TaskStateFailed
 		task.Stderr = err.Error()
 		task.CompletedAt = &now
-		l.store.UpdateTask(ctx, task)
+		l.persistSubmitOutcome(ctx, task)
 		return
 	}
 
@@ -1395,7 +1562,22 @@ func (l *Loop) submitAndUpdateTask(ctx context.Context, task *model.Task) {
 		}
 	}
 
-	l.store.UpdateTask(ctx, task)
+	l.persistSubmitOutcome(ctx, task)
+}
+
+// persistSubmitOutcome writes a submit result without overwriting a state a
+// concurrent cancel already made terminal (TerminalizeTask's guard fits both
+// the QUEUED and FAILED outcomes: write only while the row is non-terminal).
+func (l *Loop) persistSubmitOutcome(ctx context.Context, task *model.Task) {
+	applied, err := l.store.TerminalizeTask(ctx, task)
+	if err != nil {
+		l.logger.Error("persist submit outcome", "task_id", task.ID, "error", err)
+		return
+	}
+	if !applied {
+		l.logger.Info("task reached a terminal state concurrently, submit outcome discarded",
+			"task_id", task.ID, "outcome_state", task.State)
+	}
 }
 
 // mergeScatterOutputs merges scatter results into arrays with proper nesting.
@@ -1500,14 +1682,49 @@ func (l *Loop) evaluateWhenForScatterIterationFromSteps(step *model.Step, iterIn
 	return evaluator.EvaluateBool(step.When, evalCtx)
 }
 
-// resubmitRetrying re-submits RETRYING tasks to their executor.
+// resubmitRetrying re-submits RETRYING tasks to their executor. Each task is
+// first CLAIMED with a RETRYING→SCHEDULED CAS: a concurrent cancel may have
+// SKIPPED the task since the snapshot above was taken, and re-submitting it
+// would resurrect a terminal task; applied=false means someone else moved the
+// task and this loop must leave it alone.
 func (l *Loop) resubmitRetrying(ctx context.Context, affected map[string]bool) error {
+	// Reclaim stranded claims first: a crash between the RETRYING→SCHEDULED
+	// claim below and the submit persist leaves a SCHEDULED row that no other
+	// phase scans. The scheduler is single-goroutine, so any SCHEDULED task
+	// observed at the start of this phase is such a stranded claim — sweep it
+	// back to RETRYING so the normal path below reclaims it this tick.
+	stranded, err := l.store.GetTasksByState(ctx, model.TaskStateScheduled)
+	if err != nil {
+		return err
+	}
+	for _, task := range stranded {
+		applied, err := l.store.CASTaskState(ctx, task.ID, model.TaskStateScheduled, model.TaskStateRetrying)
+		if err != nil {
+			l.logger.Error("reclaim stranded scheduled task", "task_id", task.ID, "error", err)
+			continue
+		}
+		if applied {
+			l.logger.Warn("reclaimed stranded SCHEDULED task (crash mid-resubmit)", "task_id", task.ID)
+		}
+	}
+
 	retrying, err := l.store.GetTasksByState(ctx, model.TaskStateRetrying)
 	if err != nil {
 		return err
 	}
 
 	for _, task := range retrying {
+		applied, err := l.store.CASTaskState(ctx, task.ID, model.TaskStateRetrying, model.TaskStateScheduled)
+		if err != nil {
+			l.logger.Error("claim retrying task", "task_id", task.ID, "error", err)
+			continue
+		}
+		if !applied {
+			l.logger.Info("retry resubmit skipped: task no longer RETRYING", "task_id", task.ID)
+			continue
+		}
+
+		task.State = model.TaskStateScheduled
 		task.RetryCount++
 		task.ExitCode = nil
 		task.Stdout = ""
@@ -1532,6 +1749,13 @@ func (l *Loop) pollInFlight(ctx context.Context, affected map[string]bool) error
 		}
 
 		for _, task := range tasks {
+			// Sub-workflow proxy tasks pair 1:1 with child submissions and
+			// advance from the child's state, not from an executor backend —
+			// intercept them before the registry lookup. [F8]
+			if task.ExecutorType == model.ExecutorTypeSubworkflow {
+				l.pollSubworkflowTask(ctx, task, affected)
+				continue
+			}
 			exec, err := l.registry.Get(task.ExecutorType)
 			if err != nil {
 				l.logger.Error("get executor for poll", "task_id", task.ID, "error", err)
@@ -1586,6 +1810,178 @@ func (l *Loop) pollInFlight(ctx context.Context, affected map[string]bool) error
 	}
 
 	return nil
+}
+
+// pollSubworkflowTask advances an in-flight sub-workflow proxy task from its
+// child submission's state:
+//
+//	(a) reconciliation — the proxy's own submission or step instance is
+//	    already terminal: cancel the child, retire the proxy as SKIPPED, and
+//	    conditionally SKIP the step. This is the ONLY path that cancels a
+//	    proxy: CancelNonTerminalTasks deliberately excludes subworkflow
+//	    proxies so a parent cancel leaves them RUNNING (in this scan) until
+//	    the cascade has reached their children — nested sub-workflows thus
+//	    cancel one level per tick with no explicit recursion [F2,M2]
+//	(b) repair — no child exists (crash between the dispatch transaction and
+//	    child creation): recreate it deterministically from task.Job [F4]
+//	(c) advancement — child COMPLETED → proxy SUCCESS with the child's
+//	    outputs; child FAILED or CANCELLED → proxy FAILED with the child's
+//	    error in Stderr. CANCELLED maps to FAILED (not SKIPPED) because
+//	    advanceSteps sets anyFailed only for FAILED tasks — a SKIPPED proxy
+//	    would let the parent COMPLETE with a null hole in the gathered
+//	    array. [F1,F9]
+//
+// All child reads go through GetChildSubmissions, which is uncached — the
+// tickCache could hold a pre-cancel snapshot. [F11]
+func (l *Loop) pollSubworkflowTask(ctx context.Context, task *model.Task, affected map[string]bool) {
+	// Fresh reads (not tickCache): reconciliation exists to observe cancels
+	// that landed after this tick's cache was primed.
+	sub, err := l.store.GetSubmission(ctx, task.SubmissionID)
+	if err != nil {
+		l.logger.Error("get submission for subworkflow poll", "task_id", task.ID, "error", err)
+		return
+	}
+	si, err := l.store.GetStepInstance(ctx, task.StepInstanceID)
+	if err != nil {
+		l.logger.Error("get step instance for subworkflow poll", "task_id", task.ID, "error", err)
+		return
+	}
+
+	// (a) Reconciliation.
+	if sub == nil || sub.State.IsTerminal() || si == nil || si.State.IsTerminal() {
+		children, err := l.store.GetChildSubmissions(ctx, task.ID)
+		if err != nil {
+			// Strict scan: a corrupt child row surfaces as an error. Skip the
+			// task this tick (no terminalization) — the proxy stays RUNNING
+			// and is retried next tick.
+			l.logger.Error("list children for subworkflow reconcile", "task_id", task.ID, "error", err)
+			return
+		}
+		for _, child := range children {
+			if !child.State.IsTerminal() {
+				l.cancelChildSubmission(ctx, child)
+			}
+		}
+		now := time.Now().UTC()
+		task.State = model.TaskStateSkipped
+		task.CompletedAt = &now
+		if _, err := l.store.TerminalizeTask(ctx, task); err != nil {
+			l.logger.Error("skip orphaned subworkflow proxy", "task_id", task.ID, "error", err)
+			return
+		}
+		if si != nil && !si.State.IsTerminal() {
+			l.skipStepInstanceIfActive(ctx, si.ID)
+		}
+		l.logger.Info("subworkflow proxy reconciled (parent terminal)",
+			"task_id", task.ID, "submission_id", task.SubmissionID)
+		affected[task.SubmissionID] = true
+		return
+	}
+
+	children, err := l.store.GetChildSubmissions(ctx, task.ID)
+	if err != nil {
+		// Strict scan: "child exists but its row is corrupt" surfaces as an
+		// error, NOT as an empty list — running the repair below on it would
+		// create a duplicate child. Skip the task this tick.
+		l.logger.Error("list children for subworkflow poll", "task_id", task.ID, "error", err)
+		return
+	}
+
+	// (b) Repair.
+	if len(children) == 0 {
+		l.repairSubworkflowChild(ctx, task, sub, si, affected)
+		return
+	}
+
+	// (c) Advancement.
+	child := children[0]
+	switch child.State {
+	case model.SubmissionStateCompleted:
+		task.State = model.TaskStateSuccess
+		task.Outputs = child.Outputs
+	case model.SubmissionStateFailed:
+		task.State = model.TaskStateFailed
+		task.Stderr = formatChildError(child)
+	case model.SubmissionStateCancelled:
+		task.State = model.TaskStateFailed
+		task.Stderr = fmt.Sprintf("child submission %s cancelled", child.ID)
+	default:
+		return // Child still in flight — poll again next tick.
+	}
+	now := time.Now().UTC()
+	task.CompletedAt = &now
+	// CAS write: a concurrent cancel may have already terminalized this proxy
+	// (SKIPPED); the child's result must not overwrite it. [F3]
+	applied, err := l.store.TerminalizeTask(ctx, task)
+	if err != nil {
+		l.logger.Error("terminalize subworkflow proxy", "task_id", task.ID, "error", err)
+		return
+	}
+	if !applied {
+		l.logger.Info("subworkflow proxy reached a terminal state concurrently, leaving as-is",
+			"task_id", task.ID)
+	} else {
+		l.logger.Info("subworkflow proxy advanced",
+			"task_id", task.ID, "state", task.State, "child_id", child.ID)
+	}
+	affected[task.SubmissionID] = true
+}
+
+// repairSubworkflowChild recreates a missing child submission from its
+// persisted proxy: the dispatch crashed after the task transaction but before
+// child creation. task.Job already holds the fully-resolved combination, so
+// the repair re-parses the sub-workflow graph but never re-runs scatter
+// combination or valueFrom/when JavaScript (deterministic recovery). [F4]
+func (l *Loop) repairSubworkflowChild(ctx context.Context, task *model.Task,
+	sub *model.Submission, si *model.StepInstance, affected map[string]bool) {
+
+	fail := func(reason string) {
+		// Same policy as dispatch-time child-creation failure. [F11]
+		l.failSubworkflowProxy(ctx, task, si, reason)
+		affected[task.SubmissionID] = true
+	}
+
+	wf, err := l.cache.getWorkflow(ctx, l.store, sub.WorkflowID)
+	if err != nil || wf == nil {
+		l.logger.Error("get workflow for subworkflow repair", "task_id", task.ID, "error", err)
+		return
+	}
+	step := findStep(wf, task.StepID)
+	if step == nil {
+		fail(fmt.Sprintf("repair child submission: step %s not found in workflow %s", task.StepID, wf.ID))
+		return
+	}
+	graphDoc, err := parser.New(l.logger).ParseGraph([]byte(wf.RawCWL))
+	if err != nil {
+		fail(fmt.Sprintf("repair child submission: parse parent CWL: %v", err))
+		return
+	}
+	subGraph := graphDoc.SubWorkflows[step.ToolRef]
+	if subGraph == nil {
+		fail(fmt.Sprintf("repair child submission: sub-workflow %q not found", step.ToolRef))
+		return
+	}
+	child, err := l.createChildSubmission(ctx, task, subGraph, task.Job, sub, wf)
+	if err != nil {
+		fail(fmt.Sprintf("repair child submission: %v", err))
+		return
+	}
+	l.logger.Info("subworkflow child repaired", "task_id", task.ID, "child_id", child.ID)
+	affected[task.SubmissionID] = true
+}
+
+// formatChildError renders a failed child submission's error for the proxy
+// task's Stderr, so the parent's buildSubmissionError surfaces the child's
+// failure detail. [F9]
+func formatChildError(child *model.Submission) string {
+	if child.Error == nil {
+		return fmt.Sprintf("child submission %s failed", child.ID)
+	}
+	msg := fmt.Sprintf("child submission %s failed: %s: %s", child.ID, child.Error.Code, child.Error.Message)
+	if child.Error.Context != nil && child.Error.Context.Stderr != "" {
+		msg += "\n" + child.Error.Context.Stderr
+	}
+	return msg
 }
 
 // detectStuckTasks identifies classes of QUEUED worker tasks making zero progress.
@@ -1814,6 +2210,7 @@ func (l *Loop) advanceSteps(ctx context.Context, affected map[string]bool) error
 			allTerminal := true
 			anyFailed := false
 			anyRunning := false
+			anySkipped := false
 			for _, t := range tasks {
 				if t.State == model.TaskStateFailed && t.RetryCount < t.MaxRetries {
 					// Task will be retried — treat as non-terminal.
@@ -1828,6 +2225,29 @@ func (l *Loop) advanceSteps(ctx context.Context, affected map[string]bool) error
 				}
 				if t.State == model.TaskStateFailed {
 					anyFailed = true
+				}
+				if t.State == model.TaskStateSkipped {
+					anySkipped = true
+				}
+			}
+
+			if allTerminal && si.ScatterCount > 0 {
+				// Scatter fan-in requires the full index set: a crash during
+				// legacy serial task creation can leave fewer task rows than
+				// ScatterCount, and completing over the gap would emit an
+				// undersized output array. Duplicate rows (same index twice)
+				// are harmless — the results slice below is sized by
+				// ScatterCount, never len(tasks). [F5]
+				distinct := make(map[int]bool)
+				for _, t := range tasks {
+					if t.ScatterIndex >= 0 && t.ScatterIndex < si.ScatterCount {
+						distinct[t.ScatterIndex] = true
+					}
+				}
+				if len(distinct) < si.ScatterCount {
+					l.logger.Warn("scatter fan-in waiting: incomplete task index set",
+						"si_id", si.ID, "have", len(distinct), "want", si.ScatterCount)
+					continue
 				}
 			}
 
@@ -1847,6 +2267,15 @@ func (l *Loop) advanceSteps(ctx context.Context, affected map[string]bool) error
 			now := time.Now().UTC()
 			if anyFailed {
 				si.State = model.StepStateFailed
+			} else if anySkipped {
+				// SKIPPED tasks arise only from cancellation
+				// (CancelNonTerminalTasks or subworkflow reconciliation) —
+				// when-skip synthetics are terminal SUCCESS, never SKIPPED.
+				// Completing over a SKIPPED task would produce a COMPLETED
+				// step under a cancelled submission (with null holes, for
+				// scatter). Mirror the cancel and skip the step, scatter or
+				// not. [M2]
+				si.State = model.StepStateSkipped
 			} else {
 				si.State = model.StepStateCompleted
 
@@ -1860,7 +2289,7 @@ func (l *Loop) advanceSteps(ctx context.Context, affected map[string]bool) error
 						if wf != nil {
 							step := findStep(wf, si.StepID)
 							if step != nil {
-								results := make([]map[string]any, len(tasks))
+								results := make([]map[string]any, si.ScatterCount)
 								for _, t := range tasks {
 									if t.ScatterIndex >= 0 && t.ScatterIndex < len(results) {
 										results[t.ScatterIndex] = t.Outputs
@@ -2073,9 +2502,16 @@ func (l *Loop) markRetries(ctx context.Context, affected map[string]bool) error 
 		if task.RetryCount >= task.MaxRetries {
 			continue
 		}
-		task.State = model.TaskStateRetrying
-		if err := l.store.UpdateTask(ctx, task); err != nil {
+		// CAS write: only flip FAILED→RETRYING while the task is still FAILED
+		// — a concurrent cancel may have SKIPPED it since the list above was
+		// taken, and a retry must not resurrect a terminal task.
+		applied, err := l.store.CASTaskState(ctx, task.ID, model.TaskStateFailed, model.TaskStateRetrying)
+		if err != nil {
 			l.logger.Error("mark retrying", "task_id", task.ID, "error", err)
+			continue
+		}
+		if !applied {
+			l.logger.Info("retry skipped: task no longer FAILED", "task_id", task.ID)
 			continue
 		}
 		l.logger.Info("task marked for retry", "task_id", task.ID, "retry_count", task.RetryCount, "max_retries", task.MaxRetries)

--- a/internal/scheduler/subworkflow.go
+++ b/internal/scheduler/subworkflow.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -25,12 +24,29 @@ func isSubWorkflow(tool map[string]any) bool {
 	return ok && class == "Workflow"
 }
 
-// createChildSubmission creates a child submission for a sub-workflow step.
-// It converts the sub-workflow graph to a model.Workflow, stores it (deduplicated
-// by content hash), and creates a submission with tasks for each step.
+// createChildSubmission creates the child submission paired 1:1 with a
+// persisted sub-workflow proxy task. It converts the sub-workflow graph to a
+// model.Workflow, stores it (deduplicated by content hash), and creates a
+// PENDING submission plus WAITING step instances that flow through the normal
+// tick machinery like any other submission.
+//
+// Idempotent per proxy: if a child already exists for this task (dispatch
+// re-entered, or repair raced a slow write), it is returned as-is.
+//
+// INVARIANT: the workflow dedup below (GetWorkflowByHash + CreateWorkflow) is
+// race-free only because every dispatch and repair path runs on the single
+// scheduler goroutine — do not call this concurrently. [F10]
 func (l *Loop) createChildSubmission(ctx context.Context, parentTask *model.Task,
 	subGraph *cwl.GraphDocument, inputs map[string]any, parentSub *model.Submission,
 	parentWf *model.Workflow) (*model.Submission, error) {
+
+	existing, err := l.store.GetChildSubmissions(ctx, parentTask.ID)
+	if err != nil {
+		return nil, fmt.Errorf("check existing child submission: %w", err)
+	}
+	if len(existing) > 0 {
+		return existing[0], nil
+	}
 
 	// Convert sub-workflow graph to model.Workflow.
 	p := parser.New(l.logger)
@@ -56,12 +72,12 @@ func (l *Loop) createChildSubmission(ctx context.Context, parentTask *model.Task
 	childWf.ContentHash = hex.EncodeToString(hash[:])
 
 	// Check for existing workflow with same content.
-	existing, err := l.store.GetWorkflowByHash(ctx, childWf.ContentHash)
+	existingWf, err := l.store.GetWorkflowByHash(ctx, childWf.ContentHash)
 	if err != nil {
 		return nil, fmt.Errorf("check existing workflow: %w", err)
 	}
-	if existing != nil {
-		childWf = existing
+	if existingWf != nil {
+		childWf = existingWf
 	} else {
 		childWf.ID = "wf_" + uuid.New().String()
 		if err := l.store.CreateWorkflow(ctx, childWf); err != nil {
@@ -69,7 +85,22 @@ func (l *Loop) createChildSubmission(ctx context.Context, parentTask *model.Task
 		}
 	}
 
-	// Create child submission.
+	// Child labels: a FRESH map per child. Inheriting the parent's map
+	// wholesale would leak a grandparent's parent_task into deeper nesting
+	// levels — only the routing/debug labels are inherited, and parent_task
+	// is always overwritten per level. [F10]
+	labels := map[string]string{"parent_task": parentTask.ID}
+	for _, key := range []string{"debug", "worker_group"} {
+		if v := parentSub.Labels[key]; v != "" {
+			labels[key] = v
+		}
+	}
+
+	// Create child submission. OutputDestination is deliberately NOT
+	// inherited: every child would otherwise upload its shard of outputs to
+	// the same workspace destination, overwrite _gowe_outputs.json, and fail
+	// the parent on any upload error. The parent uploads the gathered
+	// outputs after fan-in, as today. [F6]
 	now := time.Now().UTC()
 	childSub := &model.Submission{
 		ID:           "sub_" + uuid.New().String(),
@@ -78,7 +109,7 @@ func (l *Loop) createChildSubmission(ctx context.Context, parentTask *model.Task
 		State:        model.SubmissionStatePending,
 		Inputs:       inputs,
 		Outputs:      map[string]any{},
-		Labels:       map[string]string{"parent_task": parentTask.ID},
+		Labels:       labels,
 		SubmittedBy:  parentSub.SubmittedBy,
 		ParentTaskID: parentTask.ID,
 		UserToken:    parentSub.UserToken,
@@ -87,24 +118,23 @@ func (l *Loop) createChildSubmission(ctx context.Context, parentTask *model.Task
 		CreatedAt:    now,
 	}
 
-	if err := l.store.CreateSubmission(ctx, childSub); err != nil {
-		return nil, fmt.Errorf("store child submission: %w", err)
-	}
-
-	// Create StepInstances for each child workflow step.
+	// StepInstances for each child workflow step, persisted with the
+	// submission in ONE transaction: a crash mid-creation can never leave a
+	// child submission with zero step instances, which the finalize phase
+	// would complete as an (empty) success.
+	steps := make([]*model.StepInstance, 0, len(childWf.Steps))
 	for _, step := range childWf.Steps {
-		si := &model.StepInstance{
+		steps = append(steps, &model.StepInstance{
 			ID:           "si_" + uuid.New().String(),
 			SubmissionID: childSub.ID,
 			StepID:       step.ID,
 			State:        model.StepStateWaiting,
 			Outputs:      map[string]any{},
 			CreatedAt:    now,
-		}
-
-		if err := l.store.CreateStepInstance(ctx, si); err != nil {
-			return nil, fmt.Errorf("store child step instance: %w", err)
-		}
+		})
+	}
+	if err := l.store.CreateSubmissionWithSteps(ctx, childSub, steps); err != nil {
+		return nil, fmt.Errorf("store child submission: %w", err)
 	}
 	l.cache.invalidateSteps(childSub.ID)
 
@@ -117,377 +147,12 @@ func (l *Loop) createChildSubmission(ctx context.Context, parentTask *model.Task
 	return childSub, nil
 }
 
-// executeChildSubmission synchronously processes all steps in a child submission.
-// It iterates through StepInstances in topological order, dispatching each step
-// via the standard submitStep flow.
-func (l *Loop) executeChildSubmission(ctx context.Context, childSub *model.Submission) error {
-	// Load the child workflow for step definitions and topological order.
-	childWf, err := l.cache.getWorkflow(ctx, l.store, childSub.WorkflowID)
-	if err != nil {
-		return fmt.Errorf("get child workflow: %w", err)
-	}
-	if childWf == nil {
-		return fmt.Errorf("child workflow %s not found", childSub.WorkflowID)
-	}
-
-	// Compute execution order from step dependencies.
-	order := topoSortSteps(childWf.Steps)
-
-	// Build step dependency map for checking readiness.
-	stepDeps := make(map[string][]string)
-	for _, s := range childWf.Steps {
-		stepDeps[s.ID] = s.DependsOn
-	}
-
-	// Process each step instance in topological order.
-	for _, stepID := range order {
-		// Load all step instances for this submission.
-		allSteps, err := l.cache.listStepsBySubmission(ctx, l.store, childSub.ID)
-		if err != nil {
-			return fmt.Errorf("list child step instances: %w", err)
-		}
-
-		var si *model.StepInstance
-		stepByID := make(map[string]*model.StepInstance)
-		for _, s := range allSteps {
-			stepByID[s.StepID] = s
-			if s.StepID == stepID {
-				si = s
-			}
-		}
-		if si == nil {
-			return fmt.Errorf("child step instance for step %s not found", stepID)
-		}
-
-		// Check dependencies using step-level tracking.
-		blocked := false
-		for _, depStepID := range stepDeps[stepID] {
-			dep, ok := stepByID[depStepID]
-			if !ok {
-				blocked = true
-				break
-			}
-			switch dep.State {
-			case model.StepStateFailed, model.StepStateSkipped:
-				blocked = true
-			case model.StepStateCompleted:
-				continue
-			default:
-				// Should not happen in synchronous execution
-				blocked = true
-			}
-			if blocked {
-				break
-			}
-		}
-
-		if blocked {
-			now := time.Now().UTC()
-			si.State = model.StepStateSkipped
-			si.CompletedAt = &now
-			if err := l.updateStepInstance(ctx, si); err != nil {
-				return fmt.Errorf("skip child step %s: %w", si.ID, err)
-			}
-			l.logger.Info("child step skipped (dependency blocked)",
-				"si_id", si.ID, "step_id", si.StepID)
-			continue
-		}
-
-		// Dispatch this step: transition WAITING → READY → dispatch.
-		si.State = model.StepStateReady
-		if err := l.updateStepInstance(ctx, si); err != nil {
-			return fmt.Errorf("ready child step %s: %w", si.ID, err)
-		}
-
-		if err := l.dispatchStep(ctx, si, childWf, childSub); err != nil {
-			l.logger.Error("child dispatch step failed",
-				"si_id", si.ID, "step_id", si.StepID, "error", err)
-		}
-
-		// Reload step instance to check final state.
-		si, err = l.store.GetStepInstance(ctx, si.ID)
-		if err != nil {
-			return fmt.Errorf("reload child step %s: %w", si.ID, err)
-		}
-
-		// If step is async (DISPATCHED/RUNNING), poll until all its tasks complete.
-		if si.State == model.StepStateDispatched || si.State == model.StepStateRunning {
-			if err := l.waitForStepCompletion(ctx, si, childWf); err != nil {
-				return fmt.Errorf("wait for child step %s: %w", si.ID, err)
-			}
-			si, err = l.store.GetStepInstance(ctx, si.ID)
-			if err != nil {
-				return fmt.Errorf("reload completed step %s: %w", si.ID, err)
-			}
-		}
-
-		if si.State == model.StepStateFailed {
-			l.logger.Warn("child step failed, continuing with remaining steps",
-				"si_id", si.ID, "step_id", si.StepID)
-		}
-	}
-
-	// Finalize the child submission.
-	allSteps, err := l.cache.listStepsBySubmission(ctx, l.store, childSub.ID)
-	if err != nil {
-		return fmt.Errorf("reload child steps: %w", err)
-	}
-
-	allTerminal := true
-	anyFailed := false
-	for _, si := range allSteps {
-		if !si.State.IsTerminal() {
-			allTerminal = false
-		}
-		if si.State == model.StepStateFailed {
-			anyFailed = true
-		}
-	}
-
-	if !allTerminal {
-		return fmt.Errorf("child submission %s has non-terminal steps after processing", childSub.ID)
-	}
-
-	// Collect workflow outputs from step instances.
-	stepOutputs := make(map[string]map[string]any)
-	for _, si := range allSteps {
-		if si.Outputs != nil {
-			stepOutputs[si.StepID] = si.Outputs
-		}
-	}
-
-	now := time.Now().UTC()
-	sub := &model.Submission{
-		ID:           childSub.ID,
-		WorkflowID:   childSub.WorkflowID,
-		WorkflowName: childSub.WorkflowName,
-		State:        childSub.State,
-		Inputs:       childSub.Inputs,
-		Outputs:      childSub.Outputs,
-		Labels:       childSub.Labels,
-		SubmittedBy:  childSub.SubmittedBy,
-		ParentTaskID: childSub.ParentTaskID,
-		CreatedAt:    childSub.CreatedAt,
-	}
-
-	if anyFailed {
-		sub.State = model.SubmissionStateFailed
-		sub.Error = l.buildSubmissionError(ctx, allSteps)
-	} else {
-		sub.State = model.SubmissionStateCompleted
-
-		// Collect workflow outputs using step instance outputs.
-		outputs, outErr := l.collectWorkflowOutputsFromSteps(childWf, stepOutputs, childSub.Inputs)
-		if outErr != nil {
-			l.logger.Error("collect child workflow outputs",
-				"submission_id", sub.ID, "error", outErr)
-		} else {
-			sub.Outputs = outputs
-		}
-	}
-	sub.CompletedAt = &now
-
-	if err := l.updateSubmission(ctx, sub); err != nil {
-		return fmt.Errorf("finalize child submission: %w", err)
-	}
-
-	// Propagate results back to caller.
-	childSub.State = sub.State
-	childSub.Outputs = sub.Outputs
-	childSub.CompletedAt = sub.CompletedAt
-
-	l.logger.Info("child submission finalized",
-		"child_sub_id", childSub.ID, "state", sub.State)
-
-	return nil
-}
-
-// waitForStepCompletion polls an async step's tasks until all are terminal,
-// then updates the step instance state. This mirrors the pollInFlight + advanceSteps
-// logic from the main scheduler loop but scoped to a single step.
-//
-// NOTE: This runs synchronously inside Phase 2 (dispatchReady), blocking the
-// main scheduler loop. Use a slower poll interval than the main scheduler to
-// reduce DB contention, and enforce a timeout to prevent infinite blocking.
-func (l *Loop) waitForStepCompletion(ctx context.Context, si *model.StepInstance, wf *model.Workflow) error {
-	// Use a slower poll interval for child steps (min 500ms) to reduce DB load
-	// and give workers more opportunity to check out tasks.
-	pollInterval := l.config.PollInterval
-	if pollInterval < 500*time.Millisecond {
-		pollInterval = 500 * time.Millisecond
-	}
-	ticker := time.NewTicker(pollInterval)
-	defer ticker.Stop()
-
-	// Safety timeout: 10 minutes per child step to prevent infinite blocking.
-	timeout := time.After(10 * time.Minute)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-timeout:
-			return fmt.Errorf("child step %s timed out after 10 minutes", si.ID)
-		case <-ticker.C:
-			tasks, err := l.store.ListTasksByStepInstance(ctx, si.ID)
-			if err != nil {
-				return fmt.Errorf("list tasks for step %s: %w", si.ID, err)
-			}
-
-			// Poll each non-terminal task via its executor.
-			for _, task := range tasks {
-				if task.State.IsTerminal() {
-					continue
-				}
-				exec, err := l.registry.Get(task.ExecutorType)
-				if err != nil {
-					l.logger.Error("get executor for child poll", "task_id", task.ID, "error", err)
-					continue
-				}
-				newState, err := exec.Status(ctx, task)
-				if err != nil {
-					l.logger.Error("poll child task status", "task_id", task.ID, "error", err)
-					continue
-				}
-				if newState == task.State {
-					continue
-				}
-				task.State = newState
-				if newState == model.TaskStateRunning && task.StartedAt == nil {
-					now := time.Now().UTC()
-					task.StartedAt = &now
-				}
-				if newState.IsTerminal() {
-					now := time.Now().UTC()
-					task.CompletedAt = &now
-					stdout, stderr, _ := exec.Logs(ctx, task)
-					task.Stdout = stdout
-					task.Stderr = stderr
-				}
-				if err := l.store.UpdateTask(ctx, task); err != nil {
-					l.logger.Error("update child polled task", "task_id", task.ID, "error", err)
-				}
-			}
-
-			// Re-fetch tasks to check terminal state.
-			tasks, err = l.store.ListTasksByStepInstance(ctx, si.ID)
-			if err != nil {
-				return fmt.Errorf("re-list tasks for step %s: %w", si.ID, err)
-			}
-
-			allTerminal := true
-			anyFailed := false
-			for _, t := range tasks {
-				if !t.State.IsTerminal() {
-					allTerminal = false
-					break
-				}
-				if t.State == model.TaskStateFailed {
-					anyFailed = true
-				}
-			}
-
-			if !allTerminal {
-				continue
-			}
-
-			// All tasks terminal — update step instance.
-			now := time.Now().UTC()
-			if anyFailed {
-				si.State = model.StepStateFailed
-			} else {
-				si.State = model.StepStateCompleted
-				// Merge outputs: scatter vs single task.
-				if si.ScatterCount > 0 {
-					step := findStep(wf, si.StepID)
-					if step != nil {
-						results := make([]map[string]any, len(tasks))
-						for _, t := range tasks {
-							if t.ScatterIndex >= 0 && t.ScatterIndex < len(results) {
-								results[t.ScatterIndex] = t.Outputs
-							}
-						}
-						if si.ScatterMethod == "nested_crossproduct" && len(si.ScatterDims) > 1 {
-							si.Outputs = mergeScatterResultsNested(results, step.Out, si.ScatterDims)
-						} else {
-							si.Outputs = mergeScatterResults(results, step.Out)
-						}
-					}
-				} else if len(tasks) == 1 {
-					si.Outputs = tasks[0].Outputs
-				}
-			}
-			si.CompletedAt = &now
-			if err := l.updateStepInstance(ctx, si); err != nil {
-				return fmt.Errorf("complete child step %s: %w", si.ID, err)
-			}
-			l.logger.Info("child step completed (poll)",
-				"si_id", si.ID, "step_id", si.StepID, "state", si.State)
-			return nil
-		}
-	}
-}
-
-// topoSortSteps returns step IDs in topological order using Kahn's algorithm.
-func topoSortSteps(steps []model.Step) []string {
-	inDegree := make(map[string]int, len(steps))
-	forward := make(map[string][]string, len(steps))
-
-	for _, s := range steps {
-		if _, ok := inDegree[s.ID]; !ok {
-			inDegree[s.ID] = 0
-		}
-		for _, dep := range s.DependsOn {
-			forward[dep] = append(forward[dep], s.ID)
-			inDegree[s.ID]++
-		}
-	}
-
-	var queue, order []string
-	for _, s := range steps {
-		if inDegree[s.ID] == 0 {
-			queue = append(queue, s.ID)
-		}
-	}
-
-	for len(queue) > 0 {
-		node := queue[0]
-		queue = queue[1:]
-		order = append(order, node)
-		for _, succ := range forward[node] {
-			inDegree[succ]--
-			if inDegree[succ] == 0 {
-				queue = append(queue, succ)
-			}
-		}
-	}
-
-	return order
-}
-
 // subWorkflowMarker returns a tool map that marks the task as a sub-workflow.
 func subWorkflowMarker(subWfID string) map[string]any {
 	return map[string]any{
 		"class": "Workflow",
 		"id":    subWfID,
 	}
-}
-
-// resolveSubWorkflowJob resolves inputs for a sub-workflow step (same as tool steps).
-func resolveSubWorkflowJob(tool map[string]any) string {
-	if id, ok := tool["id"].(string); ok {
-		return id
-	}
-	return ""
-}
-
-// marshalForHash serializes inputs to JSON for content hashing.
-func marshalForHash(v any) string {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return fmt.Sprintf("%v", v)
-	}
-	return string(data)
 }
 
 // buildChildRawCWL constructs a new $graph YAML document for a child submission.

--- a/internal/scheduler/subworkflow_proxy_test.go
+++ b/internal/scheduler/subworkflow_proxy_test.go
@@ -1,0 +1,1642 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/me/gowe/internal/parser"
+	"github.com/me/gowe/internal/store"
+	"github.com/me/gowe/pkg/model"
+)
+
+// --- Packed $graph fixtures -------------------------------------------------
+//
+// dispatchScatterSubWorkflow / dispatchSubWorkflowStep parse wf.RawCWL, so the
+// fixtures must be genuine packed $graph documents (createPipeline sets no
+// RawCWL and cannot exercise these paths).
+
+// scatterSubwfCWL: main scatters scatter_step over the embedded echo-wf.
+const scatterSubwfCWL = `
+cwlVersion: v1.2
+$graph:
+  - id: main
+    class: Workflow
+    requirements:
+      - class: ScatterFeatureRequirement
+      - class: SubworkflowFeatureRequirement
+    inputs:
+      letters: string[]
+    outputs:
+      results:
+        type: string[]
+        outputSource: scatter_step/out
+    steps:
+      scatter_step:
+        run: "#echo-wf"
+        scatter: letter
+        in:
+          letter: letters
+        out: [out]
+  - id: echo-wf
+    class: Workflow
+    inputs:
+      letter: string
+    outputs:
+      out:
+        type: string
+        outputSource: echo/out
+    steps:
+      echo:
+        run: "#echo-tool"
+        in:
+          msg: letter
+        out: [out]
+  - id: echo-tool
+    class: CommandLineTool
+    baseCommand: echo
+    inputs:
+      msg:
+        type: string
+        inputBinding:
+          position: 1
+    outputs:
+      out:
+        type: string
+`
+
+// whenScatterSubwfCWL: scatterSubwfCWL with a per-iteration 'when' that skips
+// the letter "b".
+const whenScatterSubwfCWL = `
+cwlVersion: v1.2
+$graph:
+  - id: main
+    class: Workflow
+    requirements:
+      - class: ScatterFeatureRequirement
+      - class: SubworkflowFeatureRequirement
+    inputs:
+      letters: string[]
+    outputs:
+      results:
+        type: string[]
+        outputSource: scatter_step/out
+    steps:
+      scatter_step:
+        run: "#echo-wf"
+        scatter: letter
+        when: '$(inputs.letter != "b")'
+        in:
+          letter: letters
+        out: [out]
+  - id: echo-wf
+    class: Workflow
+    inputs:
+      letter: string
+    outputs:
+      out:
+        type: string
+        outputSource: echo/out
+    steps:
+      echo:
+        run: "#echo-tool"
+        in:
+          msg: letter
+        out: [out]
+  - id: echo-tool
+    class: CommandLineTool
+    baseCommand: echo
+    inputs:
+      msg:
+        type: string
+        inputBinding:
+          position: 1
+    outputs:
+      out:
+        type: string
+`
+
+// inertScatterSubwfCWL: like scatterSubwfCWL, but the child tool targets the
+// worker executor. With no workers online the child's step defers in
+// pre-flight, so children stay PENDING across ticks — this makes cancel
+// reconciliation deterministic (children cannot self-complete before the
+// scheduler cancels them).
+const inertScatterSubwfCWL = `
+cwlVersion: v1.2
+$graph:
+  - id: main
+    class: Workflow
+    requirements:
+      - class: ScatterFeatureRequirement
+      - class: SubworkflowFeatureRequirement
+    inputs:
+      letters: string[]
+    outputs:
+      results:
+        type: string[]
+        outputSource: scatter_step/out
+    steps:
+      scatter_step:
+        run: "#echo-wf"
+        scatter: letter
+        in:
+          letter: letters
+        out: [out]
+  - id: echo-wf
+    class: Workflow
+    inputs:
+      letter: string
+    outputs:
+      out:
+        type: string
+        outputSource: echo/out
+    steps:
+      echo:
+        run: "#echo-tool"
+        in:
+          msg: letter
+        out: [out]
+  - id: echo-tool
+    class: CommandLineTool
+    baseCommand: echo
+    hints:
+      "gowe:Execution":
+        executor: worker
+    inputs:
+      msg:
+        type: string
+        inputBinding:
+          position: 1
+    outputs:
+      out:
+        type: string
+`
+
+// nestedScatterSubwfCWL: two scatter inputs with nested_crossproduct.
+const nestedScatterSubwfCWL = `
+cwlVersion: v1.2
+$graph:
+  - id: main
+    class: Workflow
+    requirements:
+      - class: ScatterFeatureRequirement
+      - class: SubworkflowFeatureRequirement
+    inputs:
+      letters: string[]
+      nums: string[]
+    outputs: []
+    steps:
+      combine_step:
+        run: "#combine-wf"
+        scatter: [letter, num]
+        scatterMethod: nested_crossproduct
+        in:
+          letter: letters
+          num: nums
+        out: [out]
+  - id: combine-wf
+    class: Workflow
+    inputs:
+      letter: string
+      num: string
+    outputs:
+      out:
+        type: string
+        outputSource: echo/out
+    steps:
+      echo:
+        run: "#echo-tool"
+        in:
+          msg: letter
+        out: [out]
+  - id: echo-tool
+    class: CommandLineTool
+    baseCommand: echo
+    inputs:
+      msg:
+        type: string
+        inputBinding:
+          position: 1
+    outputs:
+      out:
+        type: string
+`
+
+// headOfLineCWL: scatterSubwfCWL plus an independent side step that must
+// dispatch (and complete inline via the local executor) in the same tick as
+// the in-flight scatter sub-workflow.
+const headOfLineCWL = `
+cwlVersion: v1.2
+$graph:
+  - id: main
+    class: Workflow
+    requirements:
+      - class: ScatterFeatureRequirement
+      - class: SubworkflowFeatureRequirement
+    inputs:
+      letters: string[]
+    outputs: []
+    steps:
+      scatter_step:
+        run: "#echo-wf"
+        scatter: letter
+        in:
+          letter: letters
+        out: [out]
+      side_step:
+        run: "#side-tool"
+        in: {}
+        out: []
+  - id: echo-wf
+    class: Workflow
+    inputs:
+      letter: string
+    outputs:
+      out:
+        type: string
+        outputSource: echo/out
+    steps:
+      echo:
+        run: "#echo-tool"
+        in:
+          msg: letter
+        out: [out]
+  - id: echo-tool
+    class: CommandLineTool
+    baseCommand: echo
+    inputs:
+      msg:
+        type: string
+        inputBinding:
+          position: 1
+    outputs:
+      out:
+        type: string
+  - id: side-tool
+    class: CommandLineTool
+    baseCommand: [echo, side]
+    inputs: []
+    outputs: []
+`
+
+// nonScatterSubwfCWL: a plain (non-scatter) sub-workflow step whose child
+// really executes an echo through the local executor.
+const nonScatterSubwfCWL = `
+cwlVersion: v1.2
+$graph:
+  - id: main
+    class: Workflow
+    requirements:
+      - class: SubworkflowFeatureRequirement
+    inputs:
+      msg: string
+    outputs: []
+    steps:
+      subwf_step:
+        run: "#child-wf"
+        in:
+          msg: msg
+        out: []
+  - id: child-wf
+    class: Workflow
+    inputs:
+      msg: string
+    outputs: []
+    steps:
+      echo:
+        run: "#echo-tool"
+        in:
+          msg: msg
+        out: []
+  - id: echo-tool
+    class: CommandLineTool
+    baseCommand: echo
+    inputs:
+      msg:
+        type: string
+        inputBinding:
+          position: 1
+    outputs: []
+`
+
+// twoLevelScatterSubwfCWL: main scatters mid_step over "#mid-wf"; mid-wf in
+// turn scatters leaf_step over "#leaf-wf"; leaf-wf runs an inert
+// worker-executor echo so grandchildren stay in flight until cancelled. The
+// non-scattered `reps` input is passed through from main so mid-wf has an
+// array to scatter over without nested-array workflow inputs.
+const twoLevelScatterSubwfCWL = `
+cwlVersion: v1.2
+$graph:
+  - id: main
+    class: Workflow
+    requirements:
+      - class: ScatterFeatureRequirement
+      - class: SubworkflowFeatureRequirement
+    inputs:
+      letters: string[]
+      reps: string[]
+    outputs: []
+    steps:
+      mid_step:
+        run: "#mid-wf"
+        scatter: letter
+        in:
+          letter: letters
+          reps: reps
+        out: [out]
+  - id: mid-wf
+    class: Workflow
+    requirements:
+      - class: ScatterFeatureRequirement
+      - class: SubworkflowFeatureRequirement
+    inputs:
+      letter: string
+      reps: string[]
+    outputs:
+      out:
+        type: string[]
+        outputSource: leaf_step/out
+    steps:
+      leaf_step:
+        run: "#leaf-wf"
+        scatter: rep
+        in:
+          rep: reps
+        out: [out]
+  - id: leaf-wf
+    class: Workflow
+    inputs:
+      rep: string
+    outputs:
+      out:
+        type: string
+        outputSource: echo/out
+    steps:
+      echo:
+        run: "#echo-tool"
+        in:
+          msg: rep
+        out: [out]
+  - id: echo-tool
+    class: CommandLineTool
+    baseCommand: echo
+    hints:
+      "gowe:Execution":
+        executor: worker
+    inputs:
+      msg:
+        type: string
+        inputBinding:
+          position: 1
+    outputs:
+      out:
+        type: string
+`
+
+// --- Helpers ----------------------------------------------------------------
+
+// registerGraphWorkflow parses a packed $graph document the same way workflow
+// registration does, stores the resulting model.Workflow (with RawCWL), a
+// PENDING submission, and one WAITING StepInstance per step. Returns the
+// submission ID.
+func registerGraphWorkflow(t *testing.T, st store.Store, rawCWL string, inputs map[string]any,
+	labels map[string]string, outputDest string) string {
+	t.Helper()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	p := parser.New(logger)
+	graph, err := p.ParseGraph([]byte(rawCWL))
+	if err != nil {
+		t.Fatalf("ParseGraph: %v", err)
+	}
+	wf, err := p.ToModel(graph, "subwf-proxy-test")
+	if err != nil {
+		t.Fatalf("ToModel: %v", err)
+	}
+	now := time.Now().UTC()
+	wf.ID = "wf_" + uuid.New().String()
+	wf.RawCWL = rawCWL
+	wf.Class = "Workflow"
+	wf.CreatedAt = now
+	wf.UpdatedAt = now
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	sub := &model.Submission{
+		ID:                "sub_" + uuid.New().String(),
+		WorkflowID:        wf.ID,
+		WorkflowName:      wf.Name,
+		State:             model.SubmissionStatePending,
+		Inputs:            inputs,
+		Outputs:           map[string]any{},
+		Labels:            labels,
+		OutputDestination: outputDest,
+		CreatedAt:         now,
+	}
+	if err := st.CreateSubmission(ctx, sub); err != nil {
+		t.Fatalf("CreateSubmission: %v", err)
+	}
+
+	for _, step := range wf.Steps {
+		si := &model.StepInstance{
+			ID:           "si_" + uuid.New().String(),
+			SubmissionID: sub.ID,
+			StepID:       step.ID,
+			State:        model.StepStateWaiting,
+			Outputs:      map[string]any{},
+			CreatedAt:    now,
+		}
+		if err := st.CreateStepInstance(ctx, si); err != nil {
+			t.Fatalf("CreateStepInstance(%s): %v", step.ID, err)
+		}
+	}
+	return sub.ID
+}
+
+// subworkflowProxies returns the submission's subworkflow tasks sorted by
+// ScatterIndex.
+func subworkflowProxies(t *testing.T, st store.Store, subID string) []*model.Task {
+	t.Helper()
+	tasks, err := st.ListTasksBySubmission(context.Background(), subID)
+	if err != nil {
+		t.Fatalf("ListTasksBySubmission: %v", err)
+	}
+	var proxies []*model.Task
+	for _, task := range tasks {
+		if task.ExecutorType == model.ExecutorTypeSubworkflow {
+			proxies = append(proxies, task)
+		}
+	}
+	sort.Slice(proxies, func(i, j int) bool { return proxies[i].ScatterIndex < proxies[j].ScatterIndex })
+	return proxies
+}
+
+// onlyChild returns the single child submission of a proxy task.
+func onlyChild(t *testing.T, st store.Store, taskID string) *model.Submission {
+	t.Helper()
+	children, err := st.GetChildSubmissions(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("GetChildSubmissions(%s): %v", taskID, err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("expected exactly 1 child for task %s, got %d", taskID, len(children))
+	}
+	return children[0]
+}
+
+// finalizeChildAs drives a child submission (and all its step instances) to a
+// terminal state directly in the store, standing in for the child's own
+// execution.
+func finalizeChildAs(t *testing.T, st store.Store, childID string, state model.SubmissionState,
+	outputs map[string]any, subErr *model.SubmissionError) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	var stepState model.StepInstanceState
+	switch state {
+	case model.SubmissionStateCompleted:
+		stepState = model.StepStateCompleted
+	case model.SubmissionStateFailed:
+		stepState = model.StepStateFailed
+	case model.SubmissionStateCancelled:
+		stepState = model.StepStateSkipped
+	default:
+		t.Fatalf("finalizeChildAs: unsupported state %q", state)
+	}
+
+	steps, err := st.ListStepsBySubmission(ctx, childID)
+	if err != nil {
+		t.Fatalf("ListStepsBySubmission(%s): %v", childID, err)
+	}
+	for _, si := range steps {
+		si.State = stepState
+		si.CompletedAt = &now
+		if err := st.UpdateStepInstance(ctx, si); err != nil {
+			t.Fatalf("UpdateStepInstance(%s): %v", si.ID, err)
+		}
+	}
+
+	child, err := st.GetSubmission(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetSubmission(%s): %v", childID, err)
+	}
+	child.State = state
+	if outputs != nil {
+		child.Outputs = outputs
+	}
+	child.Error = subErr
+	child.CompletedAt = &now
+	if err := st.UpdateSubmission(ctx, child); err != nil {
+		t.Fatalf("UpdateSubmission(%s): %v", childID, err)
+	}
+}
+
+// completeChildSteps marks every step of a child COMPLETED with the given
+// outputs but leaves the submission itself PENDING, so the scheduler's own
+// finalize phase completes the child (out-of-order fan-in scenarios).
+func completeChildSteps(t *testing.T, st store.Store, childID string, outputs map[string]any) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	steps, err := st.ListStepsBySubmission(ctx, childID)
+	if err != nil {
+		t.Fatalf("ListStepsBySubmission(%s): %v", childID, err)
+	}
+	for _, si := range steps {
+		si.State = model.StepStateCompleted
+		si.Outputs = outputs
+		si.CompletedAt = &now
+		if err := st.UpdateStepInstance(ctx, si); err != nil {
+			t.Fatalf("UpdateStepInstance(%s): %v", si.ID, err)
+		}
+	}
+}
+
+// cancelParentLikeHandler mimics the server's cancel handler: terminal
+// submission write plus CancelNonTerminalSteps/Tasks fan-out.
+func cancelParentLikeHandler(t *testing.T, st store.Store, subID string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	sub, err := st.GetSubmission(ctx, subID)
+	if err != nil {
+		t.Fatalf("GetSubmission(%s): %v", subID, err)
+	}
+	sub.State = model.SubmissionStateCancelled
+	sub.CompletedAt = &now
+	if err := st.UpdateSubmission(ctx, sub); err != nil {
+		t.Fatalf("UpdateSubmission(cancel): %v", err)
+	}
+	if _, err := st.CancelNonTerminalSteps(ctx, subID, now); err != nil {
+		t.Fatalf("CancelNonTerminalSteps: %v", err)
+	}
+	if _, err := st.CancelNonTerminalTasks(ctx, subID, now); err != nil {
+		t.Fatalf("CancelNonTerminalTasks: %v", err)
+	}
+}
+
+// dispatchOnly runs phases 1+2 (advanceWaiting + dispatchReady) so tests can
+// observe the freshly-dispatched state before pollInFlight/advanceSteps mutate
+// it further in the same tick.
+func dispatchOnly(t *testing.T, sched *Loop) {
+	t.Helper()
+	ctx := context.Background()
+	sched.cache = newTickCache()
+	affected := make(map[string]bool)
+	if err := sched.advanceWaiting(ctx, affected); err != nil {
+		t.Fatalf("advanceWaiting: %v", err)
+	}
+	if err := sched.dispatchReady(ctx, affected); err != nil {
+		t.Fatalf("dispatchReady: %v", err)
+	}
+}
+
+// --- Test 1: dispatch -------------------------------------------------------
+
+// TestScatterSubwf_Dispatch verifies the non-blocking dispatch snapshot: the
+// step goes DISPATCHED with scatter metadata in the same transaction that
+// persists N RUNNING proxy tasks, and each proxy is paired with a PENDING
+// child submission carrying the combo inputs, the inherited routing labels
+// (fresh map, parent_task overwritten), and NO OutputDestination.
+func TestScatterSubwf_Dispatch(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+		map[string]any{"letters": []any{"a", "b", "c"}},
+		map[string]string{"debug": "true", "worker_group": "wg1", "project": "not-inherited"},
+		"ws:///user@host/results/")
+
+	dispatchOnly(t, sched)
+
+	// Step instance: DISPATCHED with scatter metadata.
+	si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+	if si.State != model.StepStateDispatched {
+		t.Errorf("si.State = %q, want DISPATCHED", si.State)
+	}
+	if si.ScatterCount != 3 {
+		t.Errorf("si.ScatterCount = %d, want 3", si.ScatterCount)
+	}
+	if si.ScatterMethod != "dotproduct" {
+		t.Errorf("si.ScatterMethod = %q, want dotproduct", si.ScatterMethod)
+	}
+
+	// Proxy tasks: RUNNING, Job=combo, ScatterIndex 0..2, MaxRetries=0.
+	proxies := subworkflowProxies(t, st, subID)
+	if len(proxies) != 3 {
+		t.Fatalf("expected 3 proxy tasks, got %d", len(proxies))
+	}
+	letters := []string{"a", "b", "c"}
+	for i, proxy := range proxies {
+		if proxy.State != model.TaskStateRunning {
+			t.Errorf("proxy %d state = %q, want RUNNING", i, proxy.State)
+		}
+		if proxy.ScatterIndex != i {
+			t.Errorf("proxy %d ScatterIndex = %d, want %d", i, proxy.ScatterIndex, i)
+		}
+		if proxy.MaxRetries != 0 {
+			t.Errorf("proxy %d MaxRetries = %d, want 0", i, proxy.MaxRetries)
+		}
+		if got := proxy.Job["letter"]; got != letters[i] {
+			t.Errorf("proxy %d Job[letter] = %v, want %q", i, got, letters[i])
+		}
+		if got := proxy.Inputs["letter"]; got != letters[i] {
+			t.Errorf("proxy %d Inputs[letter] = %v, want %q", i, got, letters[i])
+		}
+
+		// Child: PENDING, linked by ParentTaskID, combo inputs, fresh labels.
+		child := onlyChild(t, st, proxy.ID)
+		if child.State != model.SubmissionStatePending {
+			t.Errorf("child %d state = %q, want PENDING", i, child.State)
+		}
+		if child.ParentTaskID != proxy.ID {
+			t.Errorf("child %d ParentTaskID = %q, want %q", i, child.ParentTaskID, proxy.ID)
+		}
+		if got := child.Inputs["letter"]; got != letters[i] {
+			t.Errorf("child %d Inputs[letter] = %v, want %q", i, got, letters[i])
+		}
+		if child.Labels["parent_task"] != proxy.ID {
+			t.Errorf("child %d parent_task label = %q, want %q", i, child.Labels["parent_task"], proxy.ID)
+		}
+		if child.Labels["debug"] != "true" {
+			t.Errorf("child %d debug label = %q, want true", i, child.Labels["debug"])
+		}
+		if child.Labels["worker_group"] != "wg1" {
+			t.Errorf("child %d worker_group label = %q, want wg1", i, child.Labels["worker_group"])
+		}
+		if _, ok := child.Labels["project"]; ok {
+			t.Errorf("child %d inherited unrelated label 'project' (labels must be a fresh map)", i)
+		}
+
+		// OutputDestination must NOT be inherited [F6]. GetChildSubmissions
+		// does not select the column, so re-read the full row.
+		full, err := st.GetSubmission(ctx, child.ID)
+		if err != nil {
+			t.Fatalf("GetSubmission(child %d): %v", i, err)
+		}
+		if full.OutputDestination != "" {
+			t.Errorf("child %d OutputDestination = %q, want empty", i, full.OutputDestination)
+		}
+
+		// Child step instances exist and are WAITING.
+		childSteps, err := st.ListStepsBySubmission(ctx, child.ID)
+		if err != nil {
+			t.Fatalf("ListStepsBySubmission(child %d): %v", i, err)
+		}
+		if len(childSteps) != 1 || childSteps[0].State != model.StepStateWaiting {
+			t.Errorf("child %d steps = %d (state %v), want 1 WAITING",
+				i, len(childSteps), childSteps)
+		}
+	}
+}
+
+// TestScatterSubwf_Dispatch_WhenSkip verifies that a when-skipped combination
+// becomes a terminal SUCCESS task with null outputs and no child submission,
+// exactly like plain scatter.
+func TestScatterSubwf_Dispatch_WhenSkip(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, whenScatterSubwfCWL,
+		map[string]any{"letters": []any{"a", "b", "c"}}, nil, "")
+
+	dispatchOnly(t, sched)
+
+	proxies := subworkflowProxies(t, st, subID)
+	if len(proxies) != 3 {
+		t.Fatalf("expected 3 tasks (2 proxies + 1 when-skip), got %d", len(proxies))
+	}
+
+	skipped := proxies[1] // letter "b"
+	if skipped.State != model.TaskStateSuccess {
+		t.Errorf("when-skipped task state = %q, want SUCCESS", skipped.State)
+	}
+	if out, ok := skipped.Outputs["out"]; !ok || out != nil {
+		t.Errorf("when-skipped task Outputs = %v, want {out: null}", skipped.Outputs)
+	}
+	children, err := st.GetChildSubmissions(ctx, skipped.ID)
+	if err != nil {
+		t.Fatalf("GetChildSubmissions: %v", err)
+	}
+	if len(children) != 0 {
+		t.Errorf("when-skipped task has %d children, want 0", len(children))
+	}
+
+	for _, i := range []int{0, 2} {
+		if proxies[i].State != model.TaskStateRunning {
+			t.Errorf("proxy %d state = %q, want RUNNING", i, proxies[i].State)
+		}
+		onlyChild(t, st, proxies[i].ID)
+	}
+
+	// Finalize the non-skipped children; the fan-in must complete the step
+	// with a null hole at the skipped index (when-skip synthetics are SUCCESS,
+	// not SKIPPED, so the anySkipped guard must not fire).
+	finalizeChildAs(t, st, onlyChild(t, st, proxies[0].ID).ID,
+		model.SubmissionStateCompleted, map[string]any{"out": "A"}, nil)
+	finalizeChildAs(t, st, onlyChild(t, st, proxies[2].ID).ID,
+		model.SubmissionStateCompleted, map[string]any{"out": "C"}, nil)
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+
+	si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+	if si.State != model.StepStateCompleted {
+		t.Fatalf("si.State = %q, want COMPLETED", si.State)
+	}
+	out, ok := si.Outputs["out"].([]any)
+	if !ok || len(out) != 3 {
+		t.Fatalf("si.Outputs[out] = %v, want a 3-element array", si.Outputs["out"])
+	}
+	if out[0] != "A" || out[1] != nil || out[2] != "C" {
+		t.Errorf("si.Outputs[out] = %v, want [A <nil> C] (null hole at the skipped index)", out)
+	}
+}
+
+// --- Test 2: pollInFlight advancement / reconciliation / repair -------------
+
+// TestScatterSubwf_PollAdvancement verifies the child→proxy state copy:
+// COMPLETED→SUCCESS (outputs verbatim), FAILED→FAILED (child error in
+// stderr), CANCELLED→FAILED ("cancelled" in stderr) — and that the parent
+// step and submission then fail with the child's detail.
+func TestScatterSubwf_PollAdvancement(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+		map[string]any{"letters": []any{"a", "b", "c"}}, nil, "")
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 1: %v", err)
+	}
+	proxies := subworkflowProxies(t, st, subID)
+	if len(proxies) != 3 {
+		t.Fatalf("expected 3 proxies, got %d", len(proxies))
+	}
+
+	finalizeChildAs(t, st, onlyChild(t, st, proxies[0].ID).ID,
+		model.SubmissionStateCompleted, map[string]any{"out": "A"}, nil)
+	finalizeChildAs(t, st, onlyChild(t, st, proxies[1].ID).ID,
+		model.SubmissionStateFailed, nil,
+		&model.SubmissionError{Code: "STEP_FAILED", Message: "boom"})
+	finalizeChildAs(t, st, onlyChild(t, st, proxies[2].ID).ID,
+		model.SubmissionStateCancelled, nil, nil)
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 2: %v", err)
+	}
+
+	proxies = subworkflowProxies(t, st, subID)
+	if proxies[0].State != model.TaskStateSuccess {
+		t.Errorf("proxy 0 state = %q, want SUCCESS", proxies[0].State)
+	}
+	if got := proxies[0].Outputs["out"]; got != "A" {
+		t.Errorf("proxy 0 Outputs[out] = %v, want A", got)
+	}
+	if proxies[1].State != model.TaskStateFailed {
+		t.Errorf("proxy 1 state = %q, want FAILED", proxies[1].State)
+	}
+	if !strings.Contains(proxies[1].Stderr, "boom") || !strings.Contains(proxies[1].Stderr, "STEP_FAILED") {
+		t.Errorf("proxy 1 Stderr = %q, want the child error detail", proxies[1].Stderr)
+	}
+	if proxies[2].State != model.TaskStateFailed {
+		t.Errorf("proxy 2 state = %q, want FAILED (child CANCELLED maps to FAILED)", proxies[2].State)
+	}
+	if !strings.Contains(proxies[2].Stderr, "cancelled") {
+		t.Errorf("proxy 2 Stderr = %q, want it to mention cancellation", proxies[2].Stderr)
+	}
+
+	si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+	if si.State != model.StepStateFailed {
+		t.Errorf("si.State = %q, want FAILED", si.State)
+	}
+	sub, err := st.GetSubmission(ctx, subID)
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	if sub.State != model.SubmissionStateFailed {
+		t.Errorf("sub.State = %q, want FAILED", sub.State)
+	}
+	if sub.Error == nil || !strings.Contains(sub.Error.Context.Stderr, "boom") {
+		t.Errorf("sub.Error = %+v, want the child failure detail propagated", sub.Error)
+	}
+}
+
+// TestScatterSubwf_Reconciliation verifies pollInFlight branch (a): when the
+// proxy's own submission is terminal (cancel handler crashed between its
+// submission and step/task writes), the children are cancelled, the proxies
+// SKIPPED, and the step conditionally SKIPPED.
+func TestScatterSubwf_Reconciliation(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	// Inert fixture: children cannot self-complete before reconciliation.
+	subID := registerGraphWorkflow(t, st, inertScatterSubwfCWL,
+		map[string]any{"letters": []any{"a", "b"}}, nil, "")
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 1: %v", err)
+	}
+	proxies := subworkflowProxies(t, st, subID)
+	if len(proxies) != 2 {
+		t.Fatalf("expected 2 proxies, got %d", len(proxies))
+	}
+
+	// Crash-window cancel: ONLY the submission goes terminal.
+	sub, err := st.GetSubmission(ctx, subID)
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	now := time.Now().UTC()
+	sub.State = model.SubmissionStateCancelled
+	sub.CompletedAt = &now
+	if err := st.UpdateSubmission(ctx, sub); err != nil {
+		t.Fatalf("UpdateSubmission(cancel): %v", err)
+	}
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 2: %v", err)
+	}
+
+	for i, proxy := range subworkflowProxies(t, st, subID) {
+		if proxy.State != model.TaskStateSkipped {
+			t.Errorf("proxy %d state = %q, want SKIPPED", i, proxy.State)
+		}
+		child := onlyChild(t, st, proxy.ID)
+		if child.State != model.SubmissionStateCancelled {
+			t.Errorf("child %d state = %q, want CANCELLED", i, child.State)
+		}
+	}
+	si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+	if si.State != model.StepStateSkipped {
+		t.Errorf("si.State = %q, want SKIPPED", si.State)
+	}
+	// The submission must stay CANCELLED.
+	sub, _ = st.GetSubmission(ctx, subID)
+	if sub.State != model.SubmissionStateCancelled {
+		t.Errorf("sub.State = %q, want CANCELLED", sub.State)
+	}
+}
+
+// TestScatterSubwf_RepairFromJob verifies pollInFlight branch (b): a proxy
+// whose child vanished (crash between the dispatch transaction and child
+// creation) gets a new child rebuilt from the persisted task.Job, and the
+// scatter then completes normally.
+func TestScatterSubwf_RepairFromJob(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+		map[string]any{"letters": []any{"a", "b", "c"}}, nil, "")
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 1: %v", err)
+	}
+	proxies := subworkflowProxies(t, st, subID)
+	if len(proxies) != 3 {
+		t.Fatalf("expected 3 proxies, got %d", len(proxies))
+	}
+
+	// Simulate the crash window: children never got created.
+	for _, proxy := range proxies {
+		if err := st.DeleteSubmission(ctx, onlyChild(t, st, proxy.ID).ID); err != nil {
+			t.Fatalf("DeleteSubmission: %v", err)
+		}
+	}
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 2 (repair): %v", err)
+	}
+
+	letters := []string{"a", "b", "c"}
+	for i, proxy := range subworkflowProxies(t, st, subID) {
+		if proxy.State != model.TaskStateRunning {
+			t.Errorf("proxy %d state = %q, want RUNNING after repair", i, proxy.State)
+		}
+		child := onlyChild(t, st, proxy.ID)
+		if child.State != model.SubmissionStatePending {
+			t.Errorf("repaired child %d state = %q, want PENDING", i, child.State)
+		}
+		if got := child.Inputs["letter"]; got != letters[i] {
+			t.Errorf("repaired child %d Inputs[letter] = %v, want %q (from task.Job)", i, got, letters[i])
+		}
+	}
+
+	// The repaired children drive the scatter to normal completion.
+	for i, proxy := range subworkflowProxies(t, st, subID) {
+		finalizeChildAs(t, st, onlyChild(t, st, proxy.ID).ID,
+			model.SubmissionStateCompleted, map[string]any{"out": strings.ToUpper(letters[i])}, nil)
+	}
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 3: %v", err)
+	}
+	sub, err := st.GetSubmission(ctx, subID)
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	if sub.State != model.SubmissionStateCompleted {
+		t.Fatalf("sub.State = %q, want COMPLETED", sub.State)
+	}
+	results, _ := sub.Outputs["results"].([]any)
+	want := []any{"A", "B", "C"}
+	if fmt.Sprint(results) != fmt.Sprint(want) {
+		t.Errorf("results = %v, want %v", results, want)
+	}
+}
+
+// --- Test 3: fan-in ---------------------------------------------------------
+
+// TestScatterSubwf_FanIn_OutOfOrder verifies that children finishing out of
+// order still gather in ScatterIndex order.
+func TestScatterSubwf_FanIn_OutOfOrder(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+		map[string]any{"letters": []any{"a", "b", "c"}}, nil, "")
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 1: %v", err)
+	}
+	proxies := subworkflowProxies(t, st, subID)
+	if len(proxies) != 3 {
+		t.Fatalf("expected 3 proxies, got %d", len(proxies))
+	}
+
+	// Child 2 finishes first; children 0 and 1 only have their steps done, so
+	// the scheduler's own finalize phase completes them one tick later.
+	finalizeChildAs(t, st, onlyChild(t, st, proxies[2].ID).ID,
+		model.SubmissionStateCompleted, map[string]any{"out": "C"}, nil)
+	completeChildSteps(t, st, onlyChild(t, st, proxies[0].ID).ID, map[string]any{"out": "A"})
+	completeChildSteps(t, st, onlyChild(t, st, proxies[1].ID).ID, map[string]any{"out": "B"})
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 2: %v", err)
+	}
+	proxies = subworkflowProxies(t, st, subID)
+	if proxies[2].State != model.TaskStateSuccess {
+		t.Fatalf("proxy 2 state = %q, want SUCCESS (finished first)", proxies[2].State)
+	}
+	if proxies[0].State == model.TaskStateSuccess && proxies[1].State == model.TaskStateSuccess {
+		t.Fatal("proxies 0/1 already SUCCESS — completion is not out of order")
+	}
+	si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+	if si.State.IsTerminal() {
+		t.Fatalf("si terminal (%q) before all proxies finished", si.State)
+	}
+
+	// Remaining children finalize; fan-in must order by ScatterIndex.
+	for i := 0; i < 3; i++ {
+		if err := sched.Tick(ctx); err != nil {
+			t.Fatalf("Tick %d: %v", i+3, err)
+		}
+	}
+	si = getStepInstancesByStep(t, st, subID)["scatter_step"]
+	if si.State != model.StepStateCompleted {
+		t.Fatalf("si.State = %q, want COMPLETED", si.State)
+	}
+	got, _ := si.Outputs["out"].([]any)
+	want := []any{"A", "B", "C"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("si.Outputs[out] = %v, want %v (ScatterIndex order)", got, want)
+	}
+
+	sub, _ := st.GetSubmission(ctx, subID)
+	if sub.State != model.SubmissionStateCompleted {
+		t.Errorf("sub.State = %q, want COMPLETED", sub.State)
+	}
+	results, _ := sub.Outputs["results"].([]any)
+	if fmt.Sprint(results) != fmt.Sprint(want) {
+		t.Errorf("workflow results = %v, want %v", results, want)
+	}
+}
+
+// TestScatterSubwf_FanIn_NestedCrossproduct verifies nested_crossproduct
+// dims are persisted at dispatch and honored at fan-in.
+func TestScatterSubwf_FanIn_NestedCrossproduct(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, nestedScatterSubwfCWL,
+		map[string]any{"letters": []any{"x", "y"}, "nums": []any{"1", "2", "3"}}, nil, "")
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 1: %v", err)
+	}
+	si := getStepInstancesByStep(t, st, subID)["combine_step"]
+	if si.ScatterCount != 6 {
+		t.Fatalf("si.ScatterCount = %d, want 6", si.ScatterCount)
+	}
+	if si.ScatterMethod != "nested_crossproduct" {
+		t.Errorf("si.ScatterMethod = %q, want nested_crossproduct", si.ScatterMethod)
+	}
+	if fmt.Sprint(si.ScatterDims) != fmt.Sprint([]int{2, 3}) {
+		t.Errorf("si.ScatterDims = %v, want [2 3]", si.ScatterDims)
+	}
+
+	proxies := subworkflowProxies(t, st, subID)
+	if len(proxies) != 6 {
+		t.Fatalf("expected 6 proxies, got %d", len(proxies))
+	}
+	for _, proxy := range proxies {
+		out := fmt.Sprintf("%v-%v", proxy.Job["letter"], proxy.Job["num"])
+		finalizeChildAs(t, st, onlyChild(t, st, proxy.ID).ID,
+			model.SubmissionStateCompleted, map[string]any{"out": out}, nil)
+	}
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 2: %v", err)
+	}
+	si = getStepInstancesByStep(t, st, subID)["combine_step"]
+	if si.State != model.StepStateCompleted {
+		t.Fatalf("si.State = %q, want COMPLETED", si.State)
+	}
+	want := []any{
+		[]any{"x-1", "x-2", "x-3"},
+		[]any{"y-1", "y-2", "y-3"},
+	}
+	if fmt.Sprint(si.Outputs["out"]) != fmt.Sprint(want) {
+		t.Errorf("si.Outputs[out] = %v, want %v", si.Outputs["out"], want)
+	}
+}
+
+// TestScatterSubwf_FanIn_Guards unit-tests the advanceSteps fan-in guards
+// directly against hand-built task sets: an incomplete distinct-index set
+// waits, duplicate rows do not oversize the gathered array, and a SKIPPED
+// task in the set skips the step instead of completing over the hole. [F5,M2]
+func TestScatterSubwf_FanIn_Guards(t *testing.T) {
+	type taskSpec struct {
+		index int
+		state model.TaskState
+		out   any
+	}
+	tests := []struct {
+		name         string
+		scatterCount int
+		tasks        []taskSpec
+		wantState    model.StepInstanceState
+		wantOut      []any // only checked for COMPLETED
+	}{
+		{
+			name:         "incomplete distinct index set waits",
+			scatterCount: 3,
+			tasks: []taskSpec{
+				{0, model.TaskStateSuccess, "A"},
+				{1, model.TaskStateSuccess, "B"},
+			},
+			wantState: model.StepStateDispatched, // unchanged: fan-in must wait
+		},
+		{
+			name:         "duplicate legacy rows do not oversize",
+			scatterCount: 2,
+			tasks: []taskSpec{
+				{0, model.TaskStateSuccess, "A"},
+				{0, model.TaskStateSuccess, "A"},
+				{1, model.TaskStateSuccess, "B"},
+			},
+			wantState: model.StepStateCompleted,
+			wantOut:   []any{"A", "B"},
+		},
+		{
+			name:         "skipped task in set skips the step",
+			scatterCount: 2,
+			tasks: []taskSpec{
+				{0, model.TaskStateSuccess, "A"},
+				{1, model.TaskStateSkipped, nil},
+			},
+			wantState: model.StepStateSkipped,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched, st := testSetup(t)
+			ctx := context.Background()
+
+			subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+				map[string]any{"letters": []any{"a", "b", "c"}}, nil, "")
+
+			// Hand-build the dispatched state (bypassing dispatch) so the
+			// task set can be inconsistent on purpose.
+			si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+			si.State = model.StepStateDispatched
+			si.ScatterCount = tt.scatterCount
+			si.ScatterMethod = "dotproduct"
+			if err := st.UpdateStepInstance(ctx, si); err != nil {
+				t.Fatalf("UpdateStepInstance: %v", err)
+			}
+			now := time.Now().UTC()
+			for _, spec := range tt.tasks {
+				task := &model.Task{
+					ID:             "task_" + uuid.New().String(),
+					SubmissionID:   subID,
+					StepID:         "scatter_step",
+					StepInstanceID: si.ID,
+					State:          spec.state,
+					ExecutorType:   model.ExecutorTypeSubworkflow,
+					ScatterIndex:   spec.index,
+					Inputs:         map[string]any{},
+					Outputs:        map[string]any{"out": spec.out},
+					CompletedAt:    &now,
+					CreatedAt:      now,
+				}
+				if err := st.CreateTask(ctx, task); err != nil {
+					t.Fatalf("CreateTask: %v", err)
+				}
+			}
+
+			sched.cache = newTickCache()
+			if err := sched.advanceSteps(ctx, map[string]bool{}); err != nil {
+				t.Fatalf("advanceSteps: %v", err)
+			}
+
+			got := getStepInstancesByStep(t, st, subID)["scatter_step"]
+			if got.State != tt.wantState {
+				t.Fatalf("si.State = %q, want %q", got.State, tt.wantState)
+			}
+			if tt.wantState == model.StepStateCompleted {
+				out, _ := got.Outputs["out"].([]any)
+				if fmt.Sprint(out) != fmt.Sprint(tt.wantOut) {
+					t.Errorf("si.Outputs[out] = %v, want %v", out, tt.wantOut)
+				}
+			}
+		})
+	}
+}
+
+// --- Test 4: head-of-line ---------------------------------------------------
+
+// TestScatterSubwf_HeadOfLine verifies that an unrelated READY step dispatches
+// (and completes) in the same tick as a mid-flight scatter sub-workflow — the
+// old serial implementation blocked the whole tick until the scatter finished.
+func TestScatterSubwf_HeadOfLine(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, headOfLineCWL,
+		map[string]any{"letters": []any{"a", "b", "c"}}, nil, "")
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 1: %v", err)
+	}
+
+	siByStep := getStepInstancesByStep(t, st, subID)
+	if siByStep["side_step"].State != model.StepStateCompleted {
+		t.Errorf("side_step state = %q, want COMPLETED in the same tick", siByStep["side_step"].State)
+	}
+	scatterState := siByStep["scatter_step"].State
+	if scatterState != model.StepStateDispatched && scatterState != model.StepStateRunning {
+		t.Errorf("scatter_step state = %q, want DISPATCHED or RUNNING (mid-flight)", scatterState)
+	}
+	if proxies := subworkflowProxies(t, st, subID); len(proxies) != 3 {
+		t.Errorf("expected 3 in-flight proxies, got %d", len(proxies))
+	}
+}
+
+// --- Test 5: MaxRetries=0 invariant -----------------------------------------
+
+// TestScatterSubwf_ProxyNotRetried verifies a FAILED proxy is never picked up
+// by markRetries, even with a non-zero scheduler MaxRetries default —
+// retrying would erase the child's error. [F8]
+func TestScatterSubwf_ProxyNotRetried(t *testing.T) {
+	sched, st := testSetup(t)
+	sched.config.MaxRetries = 3 // proxies must override this with 0
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+		map[string]any{"letters": []any{"a", "b"}}, nil, "")
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 1: %v", err)
+	}
+	proxies := subworkflowProxies(t, st, subID)
+	finalizeChildAs(t, st, onlyChild(t, st, proxies[0].ID).ID,
+		model.SubmissionStateFailed, nil,
+		&model.SubmissionError{Code: "STEP_FAILED", Message: "child exploded"})
+	finalizeChildAs(t, st, onlyChild(t, st, proxies[1].ID).ID,
+		model.SubmissionStateCompleted, map[string]any{"out": "B"}, nil)
+
+	// Tick 2 fails the proxy; tick 3 would be the retry pickup.
+	for i := 2; i <= 3; i++ {
+		if err := sched.Tick(ctx); err != nil {
+			t.Fatalf("Tick %d: %v", i, err)
+		}
+	}
+
+	proxy, err := st.GetTask(ctx, proxies[0].ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if proxy.State != model.TaskStateFailed {
+		t.Errorf("proxy state = %q, want FAILED (never RETRYING)", proxy.State)
+	}
+	if proxy.RetryCount != 0 {
+		t.Errorf("proxy RetryCount = %d, want 0", proxy.RetryCount)
+	}
+	if !strings.Contains(proxy.Stderr, "child exploded") {
+		t.Errorf("proxy Stderr = %q, child error must be preserved", proxy.Stderr)
+	}
+	sub, _ := st.GetSubmission(ctx, subID)
+	if sub.State != model.SubmissionStateFailed {
+		t.Errorf("sub.State = %q, want FAILED", sub.State)
+	}
+}
+
+// --- Test 8: non-scatter single-proxy path ----------------------------------
+
+// TestSubwf_NonScatter_EndToEnd runs a plain sub-workflow step through the
+// full tick loop: one proxy (ScatterIndex -1), one child that really executes
+// its echo step via the local executor, then proxy SUCCESS and parent
+// COMPLETED.
+func TestSubwf_NonScatter_EndToEnd(t *testing.T) {
+	sched, st := testSetup(t)
+	sched.config.MaxRetries = 0
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, nonScatterSubwfCWL,
+		map[string]any{"msg": "hello-child"}, nil, "")
+
+	var sub *model.Submission
+	for tick := 1; tick <= 10; tick++ {
+		if err := sched.Tick(ctx); err != nil {
+			t.Fatalf("Tick %d: %v", tick, err)
+		}
+		var err error
+		sub, err = st.GetSubmission(ctx, subID)
+		if err != nil {
+			t.Fatalf("GetSubmission: %v", err)
+		}
+		if sub.State.IsTerminal() {
+			break
+		}
+	}
+	if sub.State != model.SubmissionStateCompleted {
+		t.Fatalf("sub.State = %q, want COMPLETED", sub.State)
+	}
+
+	proxies := subworkflowProxies(t, st, subID)
+	if len(proxies) != 1 {
+		t.Fatalf("expected 1 proxy task, got %d", len(proxies))
+	}
+	proxy := proxies[0]
+	if proxy.ScatterIndex != -1 {
+		t.Errorf("proxy ScatterIndex = %d, want -1", proxy.ScatterIndex)
+	}
+	if proxy.MaxRetries != 0 {
+		t.Errorf("proxy MaxRetries = %d, want 0", proxy.MaxRetries)
+	}
+	if proxy.State != model.TaskStateSuccess {
+		t.Errorf("proxy state = %q, want SUCCESS", proxy.State)
+	}
+
+	si := getStepInstancesByStep(t, st, subID)["subwf_step"]
+	if si.State != model.StepStateCompleted {
+		t.Errorf("si.State = %q, want COMPLETED", si.State)
+	}
+	if si.ScatterCount != 0 {
+		t.Errorf("si.ScatterCount = %d, want 0 (non-scatter)", si.ScatterCount)
+	}
+
+	// The child really ran its echo through the local executor.
+	child := onlyChild(t, st, proxy.ID)
+	if child.State != model.SubmissionStateCompleted {
+		t.Errorf("child state = %q, want COMPLETED", child.State)
+	}
+	childTasks, err := st.ListTasksBySubmission(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("ListTasksBySubmission(child): %v", err)
+	}
+	if len(childTasks) != 1 {
+		t.Fatalf("expected 1 child task, got %d", len(childTasks))
+	}
+	if childTasks[0].State != model.TaskStateSuccess {
+		t.Errorf("child task state = %q, want SUCCESS", childTasks[0].State)
+	}
+	if !strings.Contains(childTasks[0].Stdout, "hello-child") {
+		t.Errorf("child task Stdout = %q, want it to contain hello-child", childTasks[0].Stdout)
+	}
+}
+
+// --- Test 10: empty scatter -------------------------------------------------
+
+// TestScatterSubwf_EmptyScatter verifies an empty scatter completes inline
+// with empty gathered outputs — no proxies, no children, no hang. [M1]
+func TestScatterSubwf_EmptyScatter(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+		map[string]any{"letters": []any{}}, nil, "")
+
+	if err := sched.Tick(ctx); err != nil {
+		t.Fatalf("Tick 1: %v", err)
+	}
+
+	si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+	if si.State != model.StepStateCompleted {
+		t.Fatalf("si.State = %q, want COMPLETED (inline, no hang)", si.State)
+	}
+	out, ok := si.Outputs["out"].([]any)
+	if !ok || len(out) != 0 {
+		t.Errorf("si.Outputs[out] = %v, want empty array", si.Outputs["out"])
+	}
+
+	tasks, err := st.ListTasksBySubmission(ctx, subID)
+	if err != nil {
+		t.Fatalf("ListTasksBySubmission: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks for empty scatter, got %d", len(tasks))
+	}
+
+	sub, err := st.GetSubmission(ctx, subID)
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	if sub.State != model.SubmissionStateCompleted {
+		t.Errorf("sub.State = %q, want COMPLETED", sub.State)
+	}
+	results, ok := sub.Outputs["results"].([]any)
+	if !ok || len(results) != 0 {
+		t.Errorf("sub.Outputs[results] = %v, want empty array", sub.Outputs["results"])
+	}
+}
+
+// --- Test 11: cancel-vs-dispatch interleave ---------------------------------
+
+// TestScatterSubwf_CancelVsDispatch verifies the step ends SKIPPED (never
+// COMPLETED) whether the cancel lands before, during, or after the dispatch
+// transaction. [F2,M2]
+func TestScatterSubwf_CancelVsDispatch(t *testing.T) {
+	t.Run("cancel before dispatch", func(t *testing.T) {
+		sched, st := testSetup(t)
+		ctx := context.Background()
+
+		subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+			map[string]any{"letters": []any{"a", "b"}}, nil, "")
+		cancelParentLikeHandler(t, st, subID)
+
+		for i := 0; i < 2; i++ {
+			if err := sched.Tick(ctx); err != nil {
+				t.Fatalf("Tick: %v", err)
+			}
+		}
+		if tasks, _ := st.ListTasksBySubmission(ctx, subID); len(tasks) != 0 {
+			t.Errorf("expected 0 tasks, got %d", len(tasks))
+		}
+		si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+		if si.State != model.StepStateSkipped {
+			t.Errorf("si.State = %q, want SKIPPED", si.State)
+		}
+		sub, _ := st.GetSubmission(ctx, subID)
+		if sub.State != model.SubmissionStateCancelled {
+			t.Errorf("sub.State = %q, want CANCELLED", sub.State)
+		}
+	})
+
+	t.Run("cancel during dispatch", func(t *testing.T) {
+		// The cancel handler runs between the step's READY snapshot and the
+		// dispatch transaction: the transaction clobbers the handler's
+		// SKIPPED with DISPATCHED, and the proxies/children are created after
+		// the handler's fan-out snapshot. The post-dispatch re-read must undo
+		// all of it.
+		sched, st := testSetup(t)
+		ctx := context.Background()
+
+		subID := registerGraphWorkflow(t, st, scatterSubwfCWL,
+			map[string]any{"letters": []any{"a", "b"}}, nil, "")
+
+		// Phase-1 only: step goes READY; snapshot it and the submission.
+		sched.cache = newTickCache()
+		if err := sched.advanceWaiting(ctx, map[string]bool{}); err != nil {
+			t.Fatalf("advanceWaiting: %v", err)
+		}
+		subSnap, err := st.GetSubmission(ctx, subID)
+		if err != nil {
+			t.Fatalf("GetSubmission: %v", err)
+		}
+		wf, err := st.GetWorkflow(ctx, subSnap.WorkflowID)
+		if err != nil {
+			t.Fatalf("GetWorkflow: %v", err)
+		}
+		siSnap := getStepInstancesByStep(t, st, subID)["scatter_step"]
+		if siSnap.State != model.StepStateReady {
+			t.Fatalf("si snapshot state = %q, want READY", siSnap.State)
+		}
+
+		// Cancel lands now (handler mimic: submission + steps + tasks).
+		cancelParentLikeHandler(t, st, subID)
+
+		// Dispatch proceeds from the stale READY snapshot.
+		if err := sched.dispatchStep(ctx, siSnap, wf, subSnap); err != nil {
+			t.Fatalf("dispatchStep: %v", err)
+		}
+
+		si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+		if si.State != model.StepStateSkipped {
+			t.Errorf("si.State = %q, want SKIPPED (re-skipped after clobber)", si.State)
+		}
+		proxies := subworkflowProxies(t, st, subID)
+		if len(proxies) != 2 {
+			t.Fatalf("expected 2 proxies, got %d", len(proxies))
+		}
+		for i, proxy := range proxies {
+			if proxy.State != model.TaskStateSkipped {
+				t.Errorf("proxy %d state = %q, want SKIPPED", i, proxy.State)
+			}
+			child := onlyChild(t, st, proxy.ID)
+			if child.State != model.SubmissionStateCancelled {
+				t.Errorf("child %d state = %q, want CANCELLED", i, child.State)
+			}
+		}
+
+		// Subsequent ticks must not resurrect anything.
+		for i := 0; i < 3; i++ {
+			if err := sched.Tick(ctx); err != nil {
+				t.Fatalf("Tick: %v", err)
+			}
+		}
+		si = getStepInstancesByStep(t, st, subID)["scatter_step"]
+		if si.State != model.StepStateSkipped {
+			t.Errorf("after ticks: si.State = %q, want SKIPPED", si.State)
+		}
+		sub, _ := st.GetSubmission(ctx, subID)
+		if sub.State != model.SubmissionStateCancelled {
+			t.Errorf("after ticks: sub.State = %q, want CANCELLED", sub.State)
+		}
+	})
+
+	t.Run("cancel after dispatch", func(t *testing.T) {
+		sched, st := testSetup(t)
+		ctx := context.Background()
+
+		subID := registerGraphWorkflow(t, st, inertScatterSubwfCWL,
+			map[string]any{"letters": []any{"a", "b"}}, nil, "")
+
+		if err := sched.Tick(ctx); err != nil {
+			t.Fatalf("Tick 1: %v", err)
+		}
+		cancelParentLikeHandler(t, st, subID)
+
+		// The handler's CancelNonTerminalTasks fan-out EXCLUDES subworkflow
+		// proxies: they must still be RUNNING here so the scheduler's
+		// reconciliation (the only proxy cancel path) can reach the children.
+		for i, proxy := range subworkflowProxies(t, st, subID) {
+			if proxy.State != model.TaskStateRunning {
+				t.Errorf("proxy %d state = %q, want RUNNING right after handler cancel", i, proxy.State)
+			}
+		}
+
+		// One tick: pollSubworkflowTask observes the terminal parent, cancels
+		// each child, and terminalizes the proxy SKIPPED.
+		if err := sched.Tick(ctx); err != nil {
+			t.Fatalf("Tick 2: %v", err)
+		}
+		for i, proxy := range subworkflowProxies(t, st, subID) {
+			if proxy.State != model.TaskStateSkipped {
+				t.Errorf("proxy %d state = %q, want SKIPPED after reconciliation", i, proxy.State)
+			}
+			child := onlyChild(t, st, proxy.ID)
+			if child.State != model.SubmissionStateCancelled {
+				t.Errorf("child %d state = %q, want CANCELLED (cascade reached the child)", i, child.State)
+			}
+		}
+
+		for i := 0; i < 2; i++ {
+			if err := sched.Tick(ctx); err != nil {
+				t.Fatalf("Tick: %v", err)
+			}
+		}
+		si := getStepInstancesByStep(t, st, subID)["scatter_step"]
+		if si.State != model.StepStateSkipped {
+			t.Errorf("si.State = %q, want SKIPPED (never COMPLETED)", si.State)
+		}
+		for i, proxy := range subworkflowProxies(t, st, subID) {
+			if proxy.State != model.TaskStateSkipped {
+				t.Errorf("proxy %d state = %q, want SKIPPED (not resurrected)", i, proxy.State)
+			}
+		}
+		sub, _ := st.GetSubmission(ctx, subID)
+		if sub.State != model.SubmissionStateCancelled {
+			t.Errorf("sub.State = %q, want CANCELLED", sub.State)
+		}
+	})
+}
+
+// --- Test 12: recursive cancel cascade over nested scatter -------------------
+
+// TestScatterSubwf_NestedCancelCascade verifies the cancel cascade reaches
+// arbitrarily nested sub-workflows with no explicit recursion: cancelling the
+// top parent leaves its proxies RUNNING (CancelNonTerminalTasks excludes
+// them); reconciliation then cancels the mid-level children one tick at a
+// time, whose own proxies stay RUNNING until the next reconciliation cancels
+// the grandchildren — until every submission in the tree is CANCELLED and
+// every proxy SKIPPED.
+func TestScatterSubwf_NestedCancelCascade(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+
+	subID := registerGraphWorkflow(t, st, twoLevelScatterSubwfCWL,
+		map[string]any{"letters": []any{"a", "b"}, "reps": []any{"1", "2"}}, nil, "")
+
+	// Tick 1: top-level dispatch (2 proxies + 2 mid children).
+	// Tick 2: mid children dispatch (2 leaf proxies + 2 grandchildren each).
+	for i := 1; i <= 2; i++ {
+		if err := sched.Tick(ctx); err != nil {
+			t.Fatalf("Tick %d: %v", i, err)
+		}
+	}
+
+	topProxies := subworkflowProxies(t, st, subID)
+	if len(topProxies) != 2 {
+		t.Fatalf("expected 2 top-level proxies, got %d", len(topProxies))
+	}
+	var midChildIDs []string
+	var midProxyIDs []string
+	var grandchildIDs []string
+	for _, proxy := range topProxies {
+		mid := onlyChild(t, st, proxy.ID)
+		midChildIDs = append(midChildIDs, mid.ID)
+		midProxies := subworkflowProxies(t, st, mid.ID)
+		if len(midProxies) != 2 {
+			t.Fatalf("expected 2 leaf proxies under mid child %s, got %d", mid.ID, len(midProxies))
+		}
+		for _, midProxy := range midProxies {
+			midProxyIDs = append(midProxyIDs, midProxy.ID)
+			grandchildIDs = append(grandchildIDs, onlyChild(t, st, midProxy.ID).ID)
+		}
+	}
+	if len(grandchildIDs) != 4 {
+		t.Fatalf("expected 4 grandchildren, got %d", len(grandchildIDs))
+	}
+
+	// Cancel the top parent. The proxies must survive the handler fan-out.
+	cancelParentLikeHandler(t, st, subID)
+	for i, proxy := range subworkflowProxies(t, st, subID) {
+		if proxy.State != model.TaskStateRunning {
+			t.Errorf("top proxy %d state = %q, want RUNNING right after handler cancel", i, proxy.State)
+		}
+	}
+
+	// The cascade advances one level per reconciliation pass; give it enough
+	// ticks to reach the deepest level.
+	for i := 0; i < 4; i++ {
+		if err := sched.Tick(ctx); err != nil {
+			t.Fatalf("cascade Tick %d: %v", i+1, err)
+		}
+	}
+
+	for i, proxy := range subworkflowProxies(t, st, subID) {
+		if proxy.State != model.TaskStateSkipped {
+			t.Errorf("top proxy %d state = %q, want SKIPPED", i, proxy.State)
+		}
+	}
+	for _, midID := range midChildIDs {
+		mid, err := st.GetSubmission(ctx, midID)
+		if err != nil {
+			t.Fatalf("GetSubmission(mid %s): %v", midID, err)
+		}
+		if mid.State != model.SubmissionStateCancelled {
+			t.Errorf("mid child %s state = %q, want CANCELLED", midID, mid.State)
+		}
+	}
+	for _, proxyID := range midProxyIDs {
+		proxy, err := st.GetTask(ctx, proxyID)
+		if err != nil {
+			t.Fatalf("GetTask(mid proxy %s): %v", proxyID, err)
+		}
+		if proxy.State != model.TaskStateSkipped {
+			t.Errorf("mid proxy %s state = %q, want SKIPPED", proxyID, proxy.State)
+		}
+	}
+	for _, gcID := range grandchildIDs {
+		gc, err := st.GetSubmission(ctx, gcID)
+		if err != nil {
+			t.Fatalf("GetSubmission(grandchild %s): %v", gcID, err)
+		}
+		if gc.State != model.SubmissionStateCancelled {
+			t.Errorf("grandchild %s state = %q, want CANCELLED", gcID, gc.State)
+		}
+	}
+
+	sub, err := st.GetSubmission(ctx, subID)
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	if sub.State != model.SubmissionStateCancelled {
+		t.Errorf("sub.State = %q, want CANCELLED (must not flip)", sub.State)
+	}
+}

--- a/internal/server/handler_submissions.go
+++ b/internal/server/handler_submissions.go
@@ -301,6 +301,43 @@ func (s *Server) handleCancelSubmission(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+// hasActiveChildSubmissions reports whether any child submission spawned by the
+// given submission's subworkflow proxy tasks (recursively, any depth) is still
+// non-terminal. The visited set guards against cycles.
+func (s *Server) hasActiveChildSubmissions(ctx context.Context, submissionID string, visited map[string]bool) (bool, error) {
+	if visited[submissionID] {
+		return false, nil
+	}
+	visited[submissionID] = true
+
+	tasks, err := s.store.ListTasksBySubmission(ctx, submissionID)
+	if err != nil {
+		return false, fmt.Errorf("list tasks for %s: %w", submissionID, err)
+	}
+	for _, task := range tasks {
+		if task.ExecutorType != model.ExecutorTypeSubworkflow {
+			continue
+		}
+		children, err := s.store.GetChildSubmissions(ctx, task.ID)
+		if err != nil {
+			return false, fmt.Errorf("list children of task %s: %w", task.ID, err)
+		}
+		for _, child := range children {
+			if !child.State.IsTerminal() {
+				return true, nil
+			}
+			active, err := s.hasActiveChildSubmissions(ctx, child.ID, visited)
+			if err != nil {
+				return false, err
+			}
+			if active {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 func (s *Server) handleDeleteSubmission(w http.ResponseWriter, r *http.Request) {
 	reqID := RequestIDFromContext(r.Context())
 	id := chi.URLParam(r, "id")
@@ -332,6 +369,22 @@ func (s *Server) handleDeleteSubmission(w http.ResponseWriter, r *http.Request) 
 	if !requireSubmissionAccess(sub, userCtx) {
 		respondError(w, reqID, http.StatusForbidden, &model.APIError{
 			Code: model.ErrForbidden, Message: "access denied: you can only access your own submissions",
+		})
+		return
+	}
+
+	// Deleting the rows would also delete any subworkflow proxy tasks — the
+	// scheduler's only handle for cascading a cancel to child submissions. If
+	// active children exist (at any nesting depth), refuse: cancel first and
+	// let the cascade finish, then delete.
+	if active, err := s.hasActiveChildSubmissions(r.Context(), id, map[string]bool{}); err != nil {
+		respondError(w, reqID, http.StatusInternalServerError,
+			&model.APIError{Code: model.ErrInternal, Message: err.Error()})
+		return
+	} else if active {
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code:    model.ErrConflict,
+			Message: "submission has active child submissions; cancel it and wait for them to finish before deleting",
 		})
 		return
 	}

--- a/internal/server/handler_workers.go
+++ b/internal/server/handler_workers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -337,11 +338,17 @@ func (s *Server) handleWorkerTaskComplete(w http.ResponseWriter, r *http.Request
 		s.store.UpdateWorker(r.Context(), worker)
 	}
 
+	// task.ExitCode is *int: log the value (or "<nil>") rather than the
+	// pointer address.
+	exitCode := "<nil>"
+	if task.ExitCode != nil {
+		exitCode = strconv.Itoa(*task.ExitCode)
+	}
 	s.logger.Info("task completed by worker",
 		"task_id", task.ID,
 		"worker_id", workerID,
 		"state", task.State,
-		"exit_code", task.ExitCode,
+		"exit_code", exitCode,
 	)
 
 	respondOK(w, reqID, map[string]any{"task_id": task.ID, "state": task.State})

--- a/internal/server/resolve_refs_test.go
+++ b/internal/server/resolve_refs_test.go
@@ -36,6 +36,9 @@ func (m *mockStore) UpdateWorkflow(context.Context, *model.Workflow) error { ret
 func (m *mockStore) DeleteWorkflow(context.Context, string) error          { return nil }
 
 func (m *mockStore) CreateSubmission(context.Context, *model.Submission) error { return nil }
+func (m *mockStore) CreateSubmissionWithSteps(context.Context, *model.Submission, []*model.StepInstance) error {
+	return nil
+}
 func (m *mockStore) GetSubmission(context.Context, string) (*model.Submission, error) {
 	return nil, nil
 }
@@ -76,7 +79,10 @@ func (m *mockStore) CancelNonTerminalSteps(context.Context, string, time.Time) (
 	return 0, nil
 }
 
-func (m *mockStore) CreateTask(context.Context, *model.Task) error        { return nil }
+func (m *mockStore) CreateTask(context.Context, *model.Task) error { return nil }
+func (m *mockStore) CreateTasksAndDispatchStep(context.Context, []*model.Task, *model.StepInstance) error {
+	return nil
+}
 func (m *mockStore) GetTask(context.Context, string) (*model.Task, error) { return nil, nil }
 func (m *mockStore) ListTasksBySubmission(context.Context, string) ([]*model.Task, error) {
 	return nil, nil
@@ -89,6 +95,9 @@ func (m *mockStore) ListTasksByStepInstance(context.Context, string) ([]*model.T
 }
 func (m *mockStore) UpdateTask(context.Context, *model.Task) error              { return nil }
 func (m *mockStore) TerminalizeTask(context.Context, *model.Task) (bool, error) { return true, nil }
+func (m *mockStore) CASTaskState(context.Context, string, model.TaskState, model.TaskState) (bool, error) {
+	return true, nil
+}
 func (m *mockStore) ListSubmissionsAwaitingOutputStaging(context.Context) ([]*model.Submission, error) {
 	return nil, nil
 }

--- a/internal/store/dispatch_tx_test.go
+++ b/internal/store/dispatch_tx_test.go
@@ -1,0 +1,427 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/me/gowe/pkg/model"
+)
+
+// --- CreateTasksAndDispatchStep tests ---
+
+// dispatchFixture creates a workflow, submission, and a READY step instance,
+// returning the store and the step instance.
+func dispatchFixture(t *testing.T) (*SQLiteStore, *model.StepInstance) {
+	t.Helper()
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	sub := sampleSubmission(wf.ID)
+	if err := st.CreateSubmission(ctx, sub); err != nil {
+		t.Fatalf("create submission: %v", err)
+	}
+
+	si := &model.StepInstance{
+		ID:           "si_dispatch-1",
+		SubmissionID: sub.ID,
+		StepID:       "assemble",
+		State:        model.StepStateReady,
+		Outputs:      map[string]any{},
+		CreatedAt:    time.Now().UTC().Truncate(time.Millisecond),
+	}
+	if err := st.CreateStepInstance(ctx, si); err != nil {
+		t.Fatalf("create step instance: %v", err)
+	}
+	return st, si
+}
+
+// dispatchTasks builds n proxy-style tasks bound to the step instance.
+func dispatchTasks(si *model.StepInstance, n int) []*model.Task {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	tasks := make([]*model.Task, 0, n)
+	for i := 0; i < n; i++ {
+		tasks = append(tasks, &model.Task{
+			ID:             fmt.Sprintf("task_dispatch-%d", i),
+			SubmissionID:   si.SubmissionID,
+			StepID:         si.StepID,
+			StepInstanceID: si.ID,
+			State:          model.TaskStateRunning,
+			ExecutorType:   model.ExecutorTypeSubworkflow,
+			Inputs:         map[string]any{},
+			Outputs:        map[string]any{},
+			Job:            map[string]any{"item": fmt.Sprintf("value-%d", i)},
+			ScatterIndex:   i,
+			MaxRetries:     0,
+			CreatedAt:      now,
+		})
+	}
+	return tasks
+}
+
+func TestCreateTasksAndDispatchStep(t *testing.T) {
+	st, si := dispatchFixture(t)
+	ctx := context.Background()
+
+	tasks := dispatchTasks(si, 3)
+	si.State = model.StepStateDispatched
+	si.ScatterCount = 3
+	si.ScatterMethod = "dotproduct"
+	si.ScatterDims = []int{3}
+
+	if err := st.CreateTasksAndDispatchStep(ctx, tasks, si); err != nil {
+		t.Fatalf("CreateTasksAndDispatchStep: %v", err)
+	}
+
+	got, err := st.ListTasksByStepInstance(ctx, si.ID)
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 tasks, got %d", len(got))
+	}
+	for i, task := range got {
+		if task.ExecutorType != model.ExecutorTypeSubworkflow {
+			t.Errorf("task %d executor = %q, want %q", i, task.ExecutorType, model.ExecutorTypeSubworkflow)
+		}
+		if task.State != model.TaskStateRunning {
+			t.Errorf("task %d state = %q, want %q", i, task.State, model.TaskStateRunning)
+		}
+	}
+
+	gotSI, err := st.GetStepInstance(ctx, si.ID)
+	if err != nil {
+		t.Fatalf("get step instance: %v", err)
+	}
+	if gotSI.State != model.StepStateDispatched {
+		t.Errorf("step state = %q, want %q", gotSI.State, model.StepStateDispatched)
+	}
+	if gotSI.ScatterCount != 3 || gotSI.ScatterMethod != "dotproduct" {
+		t.Errorf("scatter fields = (%d, %q), want (3, dotproduct)", gotSI.ScatterCount, gotSI.ScatterMethod)
+	}
+	if len(gotSI.ScatterDims) != 1 || gotSI.ScatterDims[0] != 3 {
+		t.Errorf("scatter dims = %v, want [3]", gotSI.ScatterDims)
+	}
+}
+
+func TestCreateTasksAndDispatchStep_Atomic(t *testing.T) {
+	tests := []struct {
+		name    string
+		corrupt func(tasks []*model.Task, si *model.StepInstance)
+	}{
+		{
+			name: "duplicate task ID mid-batch",
+			corrupt: func(tasks []*model.Task, si *model.StepInstance) {
+				tasks[2].ID = tasks[0].ID // primary-key collision on the third insert
+			},
+		},
+		{
+			name: "step instance does not exist",
+			corrupt: func(tasks []*model.Task, si *model.StepInstance) {
+				si.ID = "si_nonexistent"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, si := dispatchFixture(t)
+			ctx := context.Background()
+			originalSI := si.ID
+
+			tasks := dispatchTasks(si, 3)
+			si.State = model.StepStateDispatched
+			si.ScatterCount = 3
+			tt.corrupt(tasks, si)
+
+			if err := st.CreateTasksAndDispatchStep(ctx, tasks, si); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			// NOTHING may have persisted: no task rows, step instance unchanged.
+			got, err := st.ListTasksBySubmission(ctx, si.SubmissionID)
+			if err != nil {
+				t.Fatalf("list tasks: %v", err)
+			}
+			if len(got) != 0 {
+				t.Errorf("expected 0 tasks after rollback, got %d", len(got))
+			}
+			gotSI, err := st.GetStepInstance(ctx, originalSI)
+			if err != nil {
+				t.Fatalf("get step instance: %v", err)
+			}
+			if gotSI.State != model.StepStateReady {
+				t.Errorf("step state = %q, want %q (unchanged)", gotSI.State, model.StepStateReady)
+			}
+			if gotSI.ScatterCount != 0 {
+				t.Errorf("scatter count = %d, want 0 (unchanged)", gotSI.ScatterCount)
+			}
+		})
+	}
+}
+
+// --- CASTaskState tests ---
+
+// TestCASTaskState verifies the generic compare-and-set is guarded: a task
+// that concurrently left the `from` state (e.g. a cancel SKIPPED it) must not
+// be moved by a stale snapshot — neither the retry marking (FAILED→RETRYING)
+// nor the retry claiming (RETRYING→SCHEDULED).
+func TestCASTaskState(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       model.TaskState
+		from        model.TaskState
+		to          model.TaskState
+		wantApplied bool
+		wantState   model.TaskState
+	}{
+		// Retry marking: FAILED→RETRYING.
+		{"failed task flips to retrying", model.TaskStateFailed,
+			model.TaskStateFailed, model.TaskStateRetrying, true, model.TaskStateRetrying},
+		{"skipped task is left alone", model.TaskStateSkipped,
+			model.TaskStateFailed, model.TaskStateRetrying, false, model.TaskStateSkipped},
+		{"success task is left alone", model.TaskStateSuccess,
+			model.TaskStateFailed, model.TaskStateRetrying, false, model.TaskStateSuccess},
+		{"running task is left alone", model.TaskStateRunning,
+			model.TaskStateFailed, model.TaskStateRetrying, false, model.TaskStateRunning},
+		// Retry claiming: RETRYING→SCHEDULED.
+		{"retrying task is claimed to scheduled", model.TaskStateRetrying,
+			model.TaskStateRetrying, model.TaskStateScheduled, true, model.TaskStateScheduled},
+		{"claim refused: task cancelled since snapshot", model.TaskStateSkipped,
+			model.TaskStateRetrying, model.TaskStateScheduled, false, model.TaskStateSkipped},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := testStore(t)
+			ctx := context.Background()
+
+			wf := sampleWorkflow()
+			if err := st.CreateWorkflow(ctx, wf); err != nil {
+				t.Fatalf("create workflow: %v", err)
+			}
+			sub := sampleSubmission(wf.ID)
+			if err := st.CreateSubmission(ctx, sub); err != nil {
+				t.Fatalf("create submission: %v", err)
+			}
+			task := sampleTask(sub.ID)
+			task.State = tt.state
+			if err := st.CreateTask(ctx, task); err != nil {
+				t.Fatalf("create task: %v", err)
+			}
+
+			applied, err := st.CASTaskState(ctx, task.ID, tt.from, tt.to)
+			if err != nil {
+				t.Fatalf("CASTaskState: %v", err)
+			}
+			if applied != tt.wantApplied {
+				t.Errorf("applied = %v, want %v", applied, tt.wantApplied)
+			}
+
+			got, err := st.GetTask(ctx, task.ID)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			if got.State != tt.wantState {
+				t.Errorf("state = %q, want %q", got.State, tt.wantState)
+			}
+		})
+	}
+}
+
+// --- GetChildSubmissions tests ---
+
+func TestGetChildSubmissions_Error(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	parent := sampleSubmission(wf.ID)
+	if err := st.CreateSubmission(ctx, parent); err != nil {
+		t.Fatalf("create parent submission: %v", err)
+	}
+	task := sampleTask(parent.ID)
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	child := sampleSubmission(wf.ID)
+	child.ID = "sub_child-1"
+	child.ParentTaskID = task.ID
+	if err := st.CreateSubmission(ctx, child); err != nil {
+		t.Fatalf("create child submission: %v", err)
+	}
+
+	// Fail the child with a structured error; GetChildSubmissions must
+	// surface it so the scheduler can propagate the detail into the proxy
+	// task's stderr.
+	child.State = model.SubmissionStateFailed
+	child.Error = &model.SubmissionError{Code: "STEP_FAILED", Message: "boom"}
+	if err := st.UpdateSubmission(ctx, child); err != nil {
+		t.Fatalf("update child submission: %v", err)
+	}
+
+	children, err := st.GetChildSubmissions(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetChildSubmissions: %v", err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(children))
+	}
+	got := children[0]
+	if got.State != model.SubmissionStateFailed {
+		t.Errorf("state = %q, want %q", got.State, model.SubmissionStateFailed)
+	}
+	if got.Error == nil {
+		t.Fatal("expected Error to be populated")
+	}
+	if got.Error.Code != "STEP_FAILED" || got.Error.Message != "boom" {
+		t.Errorf("error = %+v, want Code=STEP_FAILED Message=boom", got.Error)
+	}
+}
+
+// TestGetChildSubmissions_StrictScan verifies a corrupt child row surfaces as
+// an error instead of being silently skipped: converting "child exists but is
+// unreadable" into "no child" would make the scheduler's repair path create a
+// duplicate child submission.
+func TestGetChildSubmissions_StrictScan(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	parent := sampleSubmission(wf.ID)
+	if err := st.CreateSubmission(ctx, parent); err != nil {
+		t.Fatalf("create parent submission: %v", err)
+	}
+	task := sampleTask(parent.ID)
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	child := sampleSubmission(wf.ID)
+	child.ID = "sub_child-corrupt"
+	child.ParentTaskID = task.ID
+	if err := st.CreateSubmission(ctx, child); err != nil {
+		t.Fatalf("create child submission: %v", err)
+	}
+
+	// Corrupt the child row directly (invalid JSON in inputs).
+	if _, err := st.db.ExecContext(ctx,
+		`UPDATE submissions SET inputs = '{not-json' WHERE id = ?`, child.ID); err != nil {
+		t.Fatalf("corrupt child row: %v", err)
+	}
+
+	children, err := st.GetChildSubmissions(ctx, task.ID)
+	if err == nil {
+		t.Fatalf("expected error for corrupt child row, got %d children", len(children))
+	}
+	if !strings.Contains(err.Error(), child.ID) {
+		t.Errorf("error = %q, want it to name the corrupt row %s", err, child.ID)
+	}
+}
+
+// --- CreateSubmissionWithSteps tests ---
+
+func submissionWithSteps(wfID string, n int) (*model.Submission, []*model.StepInstance) {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	sub := sampleSubmission(wfID)
+	sub.ID = "sub_with-steps-1"
+	steps := make([]*model.StepInstance, 0, n)
+	for i := 0; i < n; i++ {
+		steps = append(steps, &model.StepInstance{
+			ID:           fmt.Sprintf("si_with-steps-%d", i),
+			SubmissionID: sub.ID,
+			StepID:       fmt.Sprintf("step%d", i),
+			State:        model.StepStateWaiting,
+			Outputs:      map[string]any{},
+			CreatedAt:    now,
+		})
+	}
+	return sub, steps
+}
+
+func TestCreateSubmissionWithSteps(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	sub, steps := submissionWithSteps(wf.ID, 3)
+	sub.UserToken = "secret-token"
+
+	if err := st.CreateSubmissionWithSteps(ctx, sub, steps); err != nil {
+		t.Fatalf("CreateSubmissionWithSteps: %v", err)
+	}
+
+	got, err := st.GetSubmission(ctx, sub.ID)
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	if got == nil {
+		t.Fatal("submission not persisted")
+	}
+	// Token round-trips through the CreateSubmission encryption path.
+	if got.UserToken != "secret-token" {
+		t.Errorf("UserToken = %q, want %q (encryption path must match CreateSubmission)", got.UserToken, "secret-token")
+	}
+	gotSteps, err := st.ListStepsBySubmission(ctx, sub.ID)
+	if err != nil {
+		t.Fatalf("ListStepsBySubmission: %v", err)
+	}
+	if len(gotSteps) != 3 {
+		t.Fatalf("expected 3 step instances, got %d", len(gotSteps))
+	}
+	for _, si := range gotSteps {
+		if si.State != model.StepStateWaiting {
+			t.Errorf("step %s state = %q, want WAITING", si.ID, si.State)
+		}
+	}
+}
+
+// TestCreateSubmissionWithSteps_Atomic verifies all-or-nothing: a step insert
+// failing mid-batch must roll back the submission row too, so a crash window
+// can never leave a zero-step child submission for finalize to complete as an
+// empty success.
+func TestCreateSubmissionWithSteps_Atomic(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	sub, steps := submissionWithSteps(wf.ID, 3)
+	steps[2].ID = steps[0].ID // primary-key collision on the third insert
+
+	if err := st.CreateSubmissionWithSteps(ctx, sub, steps); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// NOTHING may have persisted: no submission row, no step rows.
+	got, err := st.GetSubmission(ctx, sub.ID)
+	if err != nil {
+		t.Fatalf("GetSubmission: %v", err)
+	}
+	if got != nil {
+		t.Errorf("submission row persisted after rollback (state %q)", got.State)
+	}
+	gotSteps, err := st.ListStepsBySubmission(ctx, sub.ID)
+	if err != nil {
+		t.Fatalf("ListStepsBySubmission: %v", err)
+	}
+	if len(gotSteps) != 0 {
+		t.Errorf("expected 0 step instances after rollback, got %d", len(gotSteps))
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -422,7 +422,14 @@ func (s *SQLiteStore) DeleteWorkflow(ctx context.Context, id string) error {
 
 func (s *SQLiteStore) CreateSubmission(ctx context.Context, sub *model.Submission) error {
 	s.logger.Debug("sql", "op", "insert", "table", "submissions", "id", sub.ID)
+	return s.insertSubmission(ctx, s.db, sub)
+}
 
+// insertSubmission marshals the submission (including token encryption) and
+// runs the shared INSERT on the given execer. It is the single insert path
+// behind CreateSubmission and CreateSubmissionWithSteps so both persist the
+// same field set.
+func (s *SQLiteStore) insertSubmission(ctx context.Context, ex execer, sub *model.Submission) error {
 	inputsJSON, err := json.Marshal(sub.Inputs)
 	if err != nil {
 		return fmt.Errorf("marshal inputs: %w", err)
@@ -455,7 +462,7 @@ func (s *SQLiteStore) CreateSubmission(ctx context.Context, sub *model.Submissio
 		return err
 	}
 
-	_, err = s.db.ExecContext(ctx,
+	_, err = ex.ExecContext(ctx,
 		`INSERT INTO submissions (id, workflow_id, workflow_name, state, inputs, outputs, labels, submitted_by, created_at, completed_at, user_token, token_expiry, auth_provider, parent_task_id, output_destination, output_state)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sub.ID, sub.WorkflowID, sub.WorkflowName, string(sub.State),
@@ -465,6 +472,33 @@ func (s *SQLiteStore) CreateSubmission(ctx context.Context, sub *model.Submissio
 		sub.OutputDestination, sub.OutputState,
 	)
 	return err
+}
+
+// CreateSubmissionWithSteps creates a submission and all its step instances in
+// ONE transaction (all-or-nothing): a crash or a bad step insert mid-batch can
+// never leave a submission row without its step instances — the zero-step
+// window that would let the scheduler's finalize phase complete an empty child
+// submission. Token encryption follows the CreateSubmission path via the
+// shared insertSubmission helper.
+func (s *SQLiteStore) CreateSubmissionWithSteps(ctx context.Context, sub *model.Submission, steps []*model.StepInstance) error {
+	s.logger.Debug("sql", "op", "insert_with_steps", "table", "submissions", "id", sub.ID, "steps", len(steps))
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if err := s.insertSubmission(ctx, tx, sub); err != nil {
+		return fmt.Errorf("insert submission %s: %w", sub.ID, err)
+	}
+	for _, si := range steps {
+		if err := s.insertStepInstance(ctx, tx, si); err != nil {
+			return fmt.Errorf("insert step instance %s: %w", si.ID, err)
+		}
+	}
+
+	return tx.Commit()
 }
 
 func (s *SQLiteStore) GetSubmission(ctx context.Context, id string) (*model.Submission, error) {
@@ -868,11 +902,17 @@ func (s *SQLiteStore) UpdateSubmissionInputs(ctx context.Context, id string, inp
 	return nil
 }
 
+// GetChildSubmissions returns every submission whose parent_task_id matches
+// the given proxy task. The scan is deliberately STRICT (unlike the lenient
+// scanSubmissionRows): a corrupt row must surface as an error, never be
+// silently skipped — the scheduler treats "no children" as a crash window and
+// repairs it by creating a new child, so converting "child exists but is
+// unreadable" into "no child" would create a duplicate child submission.
 func (s *SQLiteStore) GetChildSubmissions(ctx context.Context, parentTaskID string) ([]*model.Submission, error) {
 	s.logger.Debug("sql", "op", "list_children", "table", "submissions", "parent_task_id", parentTaskID)
 
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, workflow_id, workflow_name, state, inputs, outputs, labels, submitted_by, created_at, completed_at, parent_task_id
+		`SELECT id, workflow_id, workflow_name, state, inputs, outputs, labels, submitted_by, created_at, completed_at, parent_task_id, error
 		 FROM submissions WHERE parent_task_id = ? ORDER BY created_at`, parentTaskID)
 	if err != nil {
 		return nil, err
@@ -882,38 +922,40 @@ func (s *SQLiteStore) GetChildSubmissions(ctx context.Context, parentTaskID stri
 	var subs []*model.Submission
 	for rows.Next() {
 		var sub model.Submission
-		var inputsJSON, outputsJSON, labelsJSON string
+		var inputsJSON, outputsJSON, labelsJSON, errorJSON string
 		var state, createdAt string
 		var completedAt *string
 
 		if err := rows.Scan(&sub.ID, &sub.WorkflowID, &sub.WorkflowName, &state,
 			&inputsJSON, &outputsJSON, &labelsJSON,
-			&sub.SubmittedBy, &createdAt, &completedAt, &sub.ParentTaskID); err != nil {
+			&sub.SubmittedBy, &createdAt, &completedAt, &sub.ParentTaskID, &errorJSON); err != nil {
 			return nil, err
 		}
 
 		sub.State = model.SubmissionState(state)
+		if errorJSON != "" {
+			var subErr model.SubmissionError
+			if err := unmarshalJSON(errorJSON, &subErr, "error"); err != nil {
+				return nil, fmt.Errorf("corrupt child submission row %s: %w", sub.ID, err)
+			}
+			sub.Error = &subErr
+		}
 		if err := unmarshalJSON(inputsJSON, &sub.Inputs, "inputs"); err != nil {
-			slog.Error("skipping corrupt submission row", "id", sub.ID, "error", err)
-			continue
+			return nil, fmt.Errorf("corrupt child submission row %s: %w", sub.ID, err)
 		}
 		if err := unmarshalJSON(outputsJSON, &sub.Outputs, "outputs"); err != nil {
-			slog.Error("skipping corrupt submission row", "id", sub.ID, "error", err)
-			continue
+			return nil, fmt.Errorf("corrupt child submission row %s: %w", sub.ID, err)
 		}
 		if err := unmarshalJSON(labelsJSON, &sub.Labels, "labels"); err != nil {
-			slog.Error("skipping corrupt submission row", "id", sub.ID, "error", err)
-			continue
+			return nil, fmt.Errorf("corrupt child submission row %s: %w", sub.ID, err)
 		}
 		if sub.CreatedAt, err = parseTimeOrZero(createdAt); err != nil {
-			slog.Error("skipping corrupt submission row", "id", sub.ID, "error", err)
-			continue
+			return nil, fmt.Errorf("corrupt child submission row %s: %w", sub.ID, err)
 		}
 		if completedAt != nil {
 			t, err := parseTimeOrZero(*completedAt)
 			if err != nil {
-				slog.Error("skipping corrupt submission row", "id", sub.ID, "error", err)
-				continue
+				return nil, fmt.Errorf("corrupt child submission row %s: %w", sub.ID, err)
 			}
 			sub.CompletedAt = &t
 		}
@@ -927,7 +969,14 @@ func (s *SQLiteStore) GetChildSubmissions(ctx context.Context, parentTaskID stri
 
 func (s *SQLiteStore) CreateStepInstance(ctx context.Context, si *model.StepInstance) error {
 	s.logger.Debug("sql", "op", "insert", "table", "step_instances", "id", si.ID)
+	return s.insertStepInstance(ctx, s.db, si)
+}
 
+// insertStepInstance marshals the step instance and runs the shared INSERT on
+// the given execer. It is the single insert path behind CreateStepInstance,
+// BatchCreateStepInstances, and CreateSubmissionWithSteps so all persist the
+// same field set.
+func (s *SQLiteStore) insertStepInstance(ctx context.Context, ex execer, si *model.StepInstance) error {
 	outputsJSON, err := json.Marshal(si.Outputs)
 	if err != nil {
 		return fmt.Errorf("marshal outputs: %w", err)
@@ -944,7 +993,7 @@ func (s *SQLiteStore) CreateStepInstance(ctx context.Context, si *model.StepInst
 		return fmt.Errorf("marshal scatter_dims: %w", err)
 	}
 
-	_, err = s.db.ExecContext(ctx,
+	_, err = ex.ExecContext(ctx,
 		`INSERT INTO step_instances (id, submission_id, step_id, state, scatter_count, scatter_method, scatter_dims, outputs, created_at, completed_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		si.ID, si.SubmissionID, si.StepID, string(si.State),
@@ -967,37 +1016,8 @@ func (s *SQLiteStore) BatchCreateStepInstances(ctx context.Context, steps []*mod
 	}
 	defer tx.Rollback()
 
-	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO step_instances (id, submission_id, step_id, state, scatter_count, scatter_method, scatter_dims, outputs, created_at, completed_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return fmt.Errorf("prepare: %w", err)
-	}
-	defer stmt.Close()
-
 	for _, si := range steps {
-		outputsJSON, err := json.Marshal(si.Outputs)
-		if err != nil {
-			return fmt.Errorf("marshal outputs: %w", err)
-		}
-
-		var completedAt *string
-		if si.CompletedAt != nil {
-			v := si.CompletedAt.Format(time.RFC3339Nano)
-			completedAt = &v
-		}
-
-		scatterDimsJSON, err := json.Marshal(si.ScatterDims)
-		if err != nil {
-			return fmt.Errorf("marshal scatter_dims: %w", err)
-		}
-
-		_, err = stmt.ExecContext(ctx,
-			si.ID, si.SubmissionID, si.StepID, string(si.State),
-			si.ScatterCount, si.ScatterMethod, string(scatterDimsJSON), string(outputsJSON),
-			si.CreatedAt.Format(time.RFC3339Nano), completedAt,
-		)
-		if err != nil {
+		if err := s.insertStepInstance(ctx, tx, si); err != nil {
 			return fmt.Errorf("insert step instance %s: %w", si.ID, err)
 		}
 	}
@@ -1049,7 +1069,14 @@ func (s *SQLiteStore) GetStepInstance(ctx context.Context, id string) (*model.St
 
 func (s *SQLiteStore) UpdateStepInstance(ctx context.Context, si *model.StepInstance) error {
 	s.logger.Debug("sql", "op", "update", "table", "step_instances", "id", si.ID)
+	return s.execStepInstanceUpdate(ctx, s.db, si)
+}
 
+// execStepInstanceUpdate marshals the mutable step-instance columns and runs
+// the shared UPDATE on the given execer. It is the single write path behind
+// UpdateStepInstance and CreateTasksAndDispatchStep so both persist the same
+// field set.
+func (s *SQLiteStore) execStepInstanceUpdate(ctx context.Context, ex execer, si *model.StepInstance) error {
 	outputsJSON, err := json.Marshal(si.Outputs)
 	if err != nil {
 		return fmt.Errorf("marshal outputs: %w", err)
@@ -1066,7 +1093,7 @@ func (s *SQLiteStore) UpdateStepInstance(ctx context.Context, si *model.StepInst
 		return fmt.Errorf("marshal scatter_dims: %w", err)
 	}
 
-	result, err := s.db.ExecContext(ctx,
+	result, err := ex.ExecContext(ctx,
 		`UPDATE step_instances SET state=?, scatter_count=?, scatter_method=?, scatter_dims=?, outputs=?, completed_at=? WHERE id=?`,
 		string(si.State), si.ScatterCount, si.ScatterMethod, string(scatterDimsJSON), string(outputsJSON), completedAt, si.ID,
 	)
@@ -1173,9 +1200,22 @@ func (s *SQLiteStore) scanStepInstances(rows *sql.Rows) ([]*model.StepInstance, 
 
 // --- Task operations ---
 
+// execer abstracts *sql.DB and *sql.Tx so shared write helpers can run
+// standalone or inside a transaction.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
 func (s *SQLiteStore) CreateTask(ctx context.Context, task *model.Task) error {
 	s.logger.Debug("sql", "op", "insert", "table", "tasks", "id", task.ID)
+	return s.insertTask(ctx, s.db, task)
+}
 
+// insertTask marshals the task (including runtime-hint encryption) and runs
+// the shared INSERT on the given execer. It is the single insert path behind
+// CreateTask and CreateTasksAndDispatchStep so both persist the same field
+// set.
+func (s *SQLiteStore) insertTask(ctx context.Context, ex execer, task *model.Task) error {
 	inputsJSON, err := json.Marshal(task.Inputs)
 	if err != nil {
 		return fmt.Errorf("marshal inputs: %w", err)
@@ -1211,7 +1251,7 @@ func (s *SQLiteStore) CreateTask(ctx context.Context, task *model.Task) error {
 		completedAt = &s
 	}
 
-	_, err = s.db.ExecContext(ctx,
+	_, err = ex.ExecContext(ctx,
 		`INSERT INTO tasks (id, submission_id, step_id, step_instance_id, state, executor_type, external_id,
 		 bvbrc_app_id, inputs, outputs, depends_on, priority, retry_count, max_retries,
 		 stdout, stderr, exit_code, created_at, started_at, completed_at,
@@ -1227,6 +1267,33 @@ func (s *SQLiteStore) CreateTask(ctx context.Context, task *model.Task) error {
 		task.ScatterIndex,
 	)
 	return err
+}
+
+// CreateTasksAndDispatchStep creates every task of a dispatched step and
+// persists the step instance's new state in ONE transaction: either all task
+// rows and the step update land, or none do. A crash (or a bad task) mid-batch
+// can therefore never leave a DISPATCHED step with a partial task set — the
+// step stays READY and the dispatch is cleanly retried next tick.
+func (s *SQLiteStore) CreateTasksAndDispatchStep(ctx context.Context, tasks []*model.Task, si *model.StepInstance) error {
+	s.logger.Debug("sql", "op", "create_tasks_dispatch_step", "table", "tasks", "count", len(tasks), "step_instance_id", si.ID)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	for _, task := range tasks {
+		if err := s.insertTask(ctx, tx, task); err != nil {
+			return fmt.Errorf("insert task %s: %w", task.ID, err)
+		}
+	}
+
+	if err := s.execStepInstanceUpdate(ctx, tx, si); err != nil {
+		return fmt.Errorf("update step_instance %s: %w", si.ID, err)
+	}
+
+	return tx.Commit()
 }
 
 func (s *SQLiteStore) GetTask(ctx context.Context, id string) (*model.Task, error) {
@@ -1412,6 +1479,25 @@ func (s *SQLiteStore) TerminalizeTask(ctx context.Context, task *model.Task) (bo
 	return n > 0, nil
 }
 
+// CASTaskState moves a task from one exact state to another (compare-and-set).
+// Returns applied=false (no error) when the task is no longer in the `from`
+// state — e.g. a concurrent cancel SKIPPED it — so a stale snapshot can never
+// resurrect a terminal task (retry marking FAILED→RETRYING, retry claiming
+// RETRYING→SCHEDULED). Only the state column is written; any bookkeeping
+// happens in the caller after a successful claim.
+func (s *SQLiteStore) CASTaskState(ctx context.Context, id string, from, to model.TaskState) (bool, error) {
+	s.logger.Debug("sql", "op", "cas_state", "table", "tasks", "id", id, "from", from, "to", to)
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE tasks SET state=? WHERE id=? AND state=?`,
+		string(to), id, string(from))
+	if err != nil {
+		return false, fmt.Errorf("cas task %s state %s->%s: %w", id, from, to, err)
+	}
+	n, _ := result.RowsAffected()
+	return n > 0, nil
+}
+
 func (s *SQLiteStore) GetTasksByState(ctx context.Context, state model.TaskState) ([]*model.Task, error) {
 	s.logger.Debug("sql", "op", "list_by_state", "table", "tasks", "state", state)
 
@@ -1449,16 +1535,22 @@ func (s *SQLiteStore) GetActiveTasks(ctx context.Context) ([]*model.Task, error)
 	return s.scanTasks(rows)
 }
 
+// CancelNonTerminalTasks SKIPs every non-terminal task of a submission EXCEPT
+// sub-workflow proxy tasks (executor_type='subworkflow'): proxies are cancelled
+// by the scheduler's per-tick reconciliation (pollSubworkflowTask), which is
+// the only path that also cancels the proxy's child submission — skipping a
+// proxy here would remove it from the RUNNING scan and orphan its child.
 func (s *SQLiteStore) CancelNonTerminalTasks(ctx context.Context, submissionID string, completedAt time.Time) (int, error) {
 	s.logger.Debug("sql", "op", "cancel_non_terminal_tasks", "submission_id", submissionID)
 
 	result, err := s.db.ExecContext(ctx,
 		`UPDATE tasks
 		 SET state = ?, completed_at = ?
-		 WHERE submission_id = ? AND state NOT IN (?, ?, ?)`,
+		 WHERE submission_id = ? AND state NOT IN (?, ?, ?) AND executor_type != ?`,
 		string(model.TaskStateSkipped), completedAt.Format(time.RFC3339Nano),
 		submissionID,
-		string(model.TaskStateSuccess), string(model.TaskStateFailed), string(model.TaskStateSkipped))
+		string(model.TaskStateSuccess), string(model.TaskStateFailed), string(model.TaskStateSkipped),
+		string(model.ExecutorTypeSubworkflow))
 	if err != nil {
 		return 0, fmt.Errorf("cancel non-terminal tasks: %w", err)
 	}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1708,12 +1708,24 @@ func TestCancelNonTerminalTasks(t *testing.T) {
 		}
 	}
 
+	// A RUNNING sub-workflow proxy must be EXCLUDED: it is cancelled by the
+	// scheduler's reconciliation (which also cancels its child submission),
+	// so it must stay in the RUNNING scan.
+	proxy := sampleTask(sub.ID)
+	proxy.ID = "task_subwf_proxy"
+	proxy.State = model.TaskStateRunning
+	proxy.ExecutorType = model.ExecutorTypeSubworkflow
+	if err := st.CreateTask(ctx, proxy); err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
 	cancelled, err := st.CancelNonTerminalTasks(ctx, sub.ID, cancelTime)
 	if err != nil {
 		t.Fatalf("cancel: %v", err)
 	}
 
-	// 4 non-terminal (PENDING, SCHEDULED, QUEUED, RUNNING) should be cancelled.
+	// 4 non-terminal (PENDING, SCHEDULED, QUEUED, RUNNING) should be cancelled;
+	// the subworkflow proxy is not among them.
 	if cancelled != 4 {
 		t.Errorf("cancelled = %d, want 4", cancelled)
 	}
@@ -1733,6 +1745,10 @@ func TestCancelNonTerminalTasks(t *testing.T) {
 		if stateMap[id] != model.TaskStateSkipped {
 			t.Errorf("%s state = %q, want SKIPPED", id, stateMap[id])
 		}
+	}
+	// The subworkflow proxy stays RUNNING for the scheduler to reconcile.
+	if stateMap["task_subwf_proxy"] != model.TaskStateRunning {
+		t.Errorf("task_subwf_proxy state = %q, want RUNNING (excluded from cancel fan-out)", stateMap["task_subwf_proxy"])
 	}
 	// Terminal states should be unchanged.
 	if stateMap["task_success"] != model.TaskStateSuccess {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,6 +20,11 @@ type Store interface {
 
 	// Submission CRUD
 	CreateSubmission(ctx context.Context, sub *model.Submission) error
+	// CreateSubmissionWithSteps creates a submission and all its step
+	// instances in a single transaction (all-or-nothing): a failure mid-batch
+	// leaves no submission row behind, closing the zero-step crash window in
+	// child-submission creation.
+	CreateSubmissionWithSteps(ctx context.Context, sub *model.Submission, steps []*model.StepInstance) error
 	GetSubmission(ctx context.Context, id string) (*model.Submission, error)
 	ListSubmissions(ctx context.Context, opts model.ListOptions) ([]*model.Submission, int, error)
 	UpdateSubmission(ctx context.Context, sub *model.Submission) error
@@ -50,6 +55,11 @@ type Store interface {
 
 	// Task operations
 	CreateTask(ctx context.Context, task *model.Task) error
+	// CreateTasksAndDispatchStep creates every task of a dispatched step and
+	// persists the step instance's new state in a single transaction
+	// (all-or-nothing): a failure mid-batch leaves no tasks behind and the
+	// step instance untouched.
+	CreateTasksAndDispatchStep(ctx context.Context, tasks []*model.Task, si *model.StepInstance) error
 	GetTask(ctx context.Context, id string) (*model.Task, error)
 	ListTasksBySubmission(ctx context.Context, submissionID string) ([]*model.Task, error)
 	ListTasksBySubmissionPaged(ctx context.Context, submissionID string, opts model.ListOptions) ([]*model.Task, int, error)
@@ -58,9 +68,18 @@ type Store interface {
 	// TerminalizeTask is UpdateTask guarded by a compare-and-set: the write is
 	// skipped (applied=false, no error) when the task is already terminal.
 	TerminalizeTask(ctx context.Context, task *model.Task) (bool, error)
+	// CASTaskState moves a task `from`→`to` only while it is still exactly in
+	// `from`; applied=false (no error) otherwise, so a stale snapshot can
+	// never overwrite a concurrent terminal write (e.g. a cancel that SKIPPED
+	// the task). Used for retry marking (FAILED→RETRYING) and retry claiming
+	// (RETRYING→SCHEDULED).
+	CASTaskState(ctx context.Context, id string, from, to model.TaskState) (bool, error)
 	GetTasksByState(ctx context.Context, state model.TaskState) ([]*model.Task, error)
 	GetActiveTasks(ctx context.Context) ([]*model.Task, error)
 	GetTaskSummaries(ctx context.Context, submissionIDs []string) (map[string]model.TaskSummary, error)
+	// CancelNonTerminalTasks SKIPs a submission's non-terminal tasks EXCEPT
+	// sub-workflow proxies: those are cancelled by the scheduler's per-tick
+	// reconciliation so the cancel cascade reaches their child submissions.
 	CancelNonTerminalTasks(ctx context.Context, submissionID string, completedAt time.Time) (int, error)
 	ResetFailedTasks(ctx context.Context, submissionID string) (int, error)
 	ResetFailedSteps(ctx context.Context, submissionID string) (int, error)

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -106,4 +106,7 @@ const (
 	ExecutorTypeContainer ExecutorType = "container"
 	ExecutorTypeApptainer ExecutorType = "apptainer"
 	ExecutorTypeWorker    ExecutorType = "worker"
+	// ExecutorTypeSubworkflow marks scheduler-internal proxy tasks that pair
+	// 1:1 with child submissions; it is never a registered executor backend.
+	ExecutorTypeSubworkflow ExecutorType = "subworkflow"
 )

--- a/scripts/test-scatter-subwf.sh
+++ b/scripts/test-scatter-subwf.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# test-scatter-subwf.sh — E2E acceptance test for issue #164
+# (scatter over a sub-workflow must run children in parallel, not block the
+# scheduler, and be cancellable).
+#
+# Acceptance criteria verified here:
+#   AC1: 6-item scatter over a 2-step sub-workflow (each child sleeps 10 s)
+#        with 2 workers completes in < 60 s (serial baseline ~80-90 s) AND
+#        child sleep-task execution intervals observably overlap.
+#   AC2: a trivial single-tool submission made mid-scatter gets a task
+#        within ~3 s (non-blocking scheduler).
+#   AC4: gathered `msgs` output is ordered by scatter combination (a..f).
+#   AC3: 20-item run, cancel the parent after the first child completes:
+#        no PENDING child ever starts running afterwards, parent goes
+#        terminal CANCELLED within ~15 s and STAYS CANCELLED.
+#   AC3-DB: cancel cascade verified directly in the SQLite DB — every child
+#        submission of the parent's proxy tasks reaches CANCELLED (not
+#        RUNNING, not COMPLETED-as-orphan) within ~5 s of the parent going
+#        CANCELLED, and holds no active tasks.
+#
+# Environment: builds via apptainer golang:1.24 (Go is not installed
+# natively). Server on :8095 (NEVER :8091 — production), all state in /tmp.
+# Set SKIP_BUILD=1 to reuse existing binaries in $BIN_DIR.
+
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT=8095
+BASE="http://localhost:${PORT}/api/v1"
+BIN_DIR="${BIN_DIR:-/tmp/gowe164-bin}"
+WORK=/tmp/gowe164
+DB=/tmp/gowe164.db
+SERVER_LOG=/tmp/gowe164-server.log
+SERVER_PID=""
+W1_PID=""
+W2_PID=""
+
+# ---------------------------------------------------------------- helpers --
+
+cleanup() {
+    # Kill only processes we started, by saved PID.
+    for pid in "$SERVER_PID" "$W1_PID" "$W2_PID"; do
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null
+        fi
+    done
+    sleep 1
+    for pid in "$SERVER_PID" "$W1_PID" "$W2_PID"; do
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill -9 "$pid" 2>/dev/null
+        fi
+    done
+}
+trap cleanup EXIT
+
+fail() {
+    echo ""
+    echo "FAIL: $*" >&2
+    echo "--- last 40 server log lines ---" >&2
+    tail -40 "$SERVER_LOG" >&2 2>/dev/null || true
+    exit 1
+}
+
+pass() { echo "PASS: $*"; }
+
+now_s() { date +%s.%N; }
+
+elapsed() { # elapsed <start> -> seconds with 1 decimal
+    python3 -c "import sys; print(f'{float(sys.argv[2])-float(sys.argv[1]):.1f}')" "$1" "$(now_s)"
+}
+
+api() { curl -sf --max-time 10 "$@"; }
+
+sub_state() { # sub_state <id>
+    api "$BASE/submissions/$1" | jq -r '.data.state'
+}
+
+submit() { # submit <cwl> <inputs> -> submission id on stdout
+    # HOME is redirected to a scratch dir so the user's real ~/.gowe
+    # credentials are never picked up — submissions must be anonymous.
+    local out
+    out="$(HOME=/tmp/gowe164/home "$BIN_DIR/gowe" submit "$1" -i "$2" \
+        --server "http://localhost:$PORT" --no-upload 2>&1)" \
+        || { echo "$out" >&2; return 1; }
+    echo "$out" | sed -n 's/^Submission created: \([^ ]*\).*/\1/p'
+}
+
+# proxy_task_ids <parent-sub-id> -> JSON array of subworkflow proxy task IDs
+proxy_task_ids() {
+    api "$BASE/submissions/$1/tasks?limit=500" \
+        | jq -c '[.data // [] | .[] | select(.executor_type == "subworkflow") | .id]'
+}
+
+# children <proxy-ids-json> -> JSON array of {id, state} for child submissions.
+# The list endpoint does not return parent_task_id, but children carry a
+# "parent_task" label pointing at their proxy task.
+children() {
+    api "$BASE/submissions?limit=500" \
+        | jq -c --argjson ids "$1" \
+          '[.data // [] | .[] | select((.labels.parent_task // "") as $p | $ids | index($p) != null) | {id, state}]'
+}
+
+# ------------------------------------------------------------------ build --
+
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+    echo "== Building binaries into $BIN_DIR (apptainer golang:1.24) =="
+    mkdir -p /tmp/gomod "$BIN_DIR"
+    apptainer exec --bind /tmp/gomod:/go docker://golang:1.24 bash -c "
+        cd '$REPO' &&
+        go build -o '$BIN_DIR/gowe-server' ./cmd/server &&
+        go build -o '$BIN_DIR/gowe'        ./cmd/cli &&
+        go build -o '$BIN_DIR/gowe-worker' ./cmd/worker
+    " || { echo "FAIL: build failed" >&2; exit 1; }
+fi
+for b in gowe-server gowe gowe-worker; do
+    [ -x "$BIN_DIR/$b" ] || { echo "FAIL: missing binary $BIN_DIR/$b" >&2; exit 1; }
+done
+
+# --------------------------------------------------------------- fixtures --
+
+rm -rf "$WORK" /tmp/gowe164-w1 /tmp/gowe164-w2 /tmp/gowe164-out
+rm -f "$DB" "$DB"-wal "$DB"-shm "$SERVER_LOG" /tmp/gowe164-w1.log /tmp/gowe164-w2.log
+mkdir -p "$WORK" "$WORK/home" /tmp/gowe164-w1 /tmp/gowe164-w2 /tmp/gowe164-out
+
+cat > "$WORK/scatter-sub.cwl" <<'EOF'
+cwlVersion: v1.2
+class: Workflow
+requirements:
+  ScatterFeatureRequirement: {}
+  SubworkflowFeatureRequirement: {}
+inputs:
+  items: string[]
+steps:
+  work:
+    scatter: item
+    in: { item: items }
+    out: [msg]
+    run:
+      class: Workflow
+      inputs: { item: string }
+      steps:
+        a:
+          in: { item: item }
+          out: [t]
+          run:
+            class: CommandLineTool
+            baseCommand: [bash, -c]
+            inputs:
+              item: { type: string }
+            arguments: ["sleep 10 && echo $(inputs.item) > out.txt"]
+            outputs:
+              t: { type: File, outputBinding: { glob: out.txt } }
+        b:
+          in: { t: a/t }
+          out: [msg]
+          run:
+            class: CommandLineTool
+            baseCommand: [cat]
+            inputs:
+              t: { type: File, inputBinding: { position: 1 } }
+            outputs:
+              msg: { type: stdout }
+      outputs:
+        msg: { type: File, outputSource: b/msg }
+outputs:
+  msgs:
+    type: File[]
+    outputSource: work/msg
+EOF
+
+echo 'items: [a, b, c, d, e, f]' > "$WORK/inputs6.yml"
+echo 'items: [x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20]' > "$WORK/inputs20.yml"
+
+cat > "$WORK/trivial.cwl" <<'EOF'
+cwlVersion: v1.2
+class: Workflow
+inputs:
+  msg: string
+steps:
+  echo:
+    in: { msg: msg }
+    out: [out]
+    run:
+      class: CommandLineTool
+      baseCommand: echo
+      inputs:
+        msg: { type: string, inputBinding: { position: 1 } }
+      outputs:
+        out: { type: stdout }
+outputs:
+  out: { type: File, outputSource: echo/out }
+EOF
+echo 'msg: hello' > "$WORK/trivial-inputs.yml"
+
+# ------------------------------------------------------- server + workers --
+
+echo "== Starting server on :$PORT and 2 workers (--runtime none) =="
+"$BIN_DIR/gowe-server" --addr ":$PORT" --db "$DB" --default-executor worker \
+    --allow-anonymous --scheduler-poll 1s --debug > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+for i in $(seq 1 30); do
+    curl -sf --max-time 2 "http://localhost:$PORT/api/v1/health" >/dev/null 2>&1 && break
+    kill -0 "$SERVER_PID" 2>/dev/null || fail "server exited during startup"
+    [ "$i" = 30 ] && fail "server did not become healthy on :$PORT"
+    sleep 0.5
+done
+
+"$BIN_DIR/gowe-worker" --server "http://localhost:$PORT" --name w1 --runtime none \
+    --workdir /tmp/gowe164-w1 --stage-out file:///tmp/gowe164-out --poll 500ms \
+    > /tmp/gowe164-w1.log 2>&1 &
+W1_PID=$!
+"$BIN_DIR/gowe-worker" --server "http://localhost:$PORT" --name w2 --runtime none \
+    --workdir /tmp/gowe164-w2 --stage-out file:///tmp/gowe164-out --poll 500ms \
+    > /tmp/gowe164-w2.log 2>&1 &
+W2_PID=$!
+sleep 2
+kill -0 "$W1_PID" 2>/dev/null || fail "worker w1 exited during startup"
+kill -0 "$W2_PID" 2>/dev/null || fail "worker w2 exited during startup"
+
+# ============================================ AC1 + AC2: parallelism run ==
+
+echo ""
+echo "== AC1: 6-item x 10 s scatter-over-subworkflow, 2 workers =="
+T0="$(now_s)"
+P1="$(submit "$WORK/scatter-sub.cwl" "$WORK/inputs6.yml")" || fail "AC1 submit failed"
+[ -n "$P1" ] || fail "AC1: could not parse submission id from gowe submit output"
+echo "   parent submission: $P1"
+
+# AC2 mid-run: wait until the scatter is actually in flight, then submit a
+# trivial workflow and measure time until it has a task.
+sleep 4
+echo "== AC2: trivial submission mid-scatter =="
+T_AC2="$(now_s)"
+P2="$(submit "$WORK/trivial.cwl" "$WORK/trivial-inputs.yml")" || fail "AC2 submit failed"
+[ -n "$P2" ] || fail "AC2: could not parse submission id"
+AC2_ELAPSED=""
+for i in $(seq 1 40); do
+    NTASKS="$(api "$BASE/submissions/$P2/tasks" | jq '.data | length')"
+    if [ "${NTASKS:-0}" -ge 1 ]; then
+        AC2_ELAPSED="$(elapsed "$T_AC2")"
+        break
+    fi
+    sleep 0.2
+done
+[ -n "$AC2_ELAPSED" ] || fail "AC2: trivial submission $P2 got no task within 8 s (head-of-line blocking)"
+AC2_OK="$(python3 -c "print(1 if float('$AC2_ELAPSED') <= 4.0 else 0)")"
+[ "$AC2_OK" = "1" ] || fail "AC2: trivial submission got a task only after ${AC2_ELAPSED}s (> 4 s budget)"
+pass "AC2: trivial submission $P2 got a task in ${AC2_ELAPSED}s"
+
+# Wait for AC1 parent to finish.
+AC1_STATE=""
+for i in $(seq 1 120); do
+    AC1_STATE="$(sub_state "$P1")"
+    case "$AC1_STATE" in COMPLETED|FAILED|CANCELLED) break ;; esac
+    sleep 1
+done
+AC1_WALL="$(elapsed "$T0")"
+[ "$AC1_STATE" = "COMPLETED" ] || fail "AC1: parent $P1 ended in state '$AC1_STATE' after ${AC1_WALL}s (want COMPLETED)"
+AC1_OK="$(python3 -c "print(1 if float('$AC1_WALL') < 60.0 else 0)")"
+[ "$AC1_OK" = "1" ] || fail "AC1: wall time ${AC1_WALL}s >= 60 s (serial baseline ~80-90 s; children not parallel)"
+
+# Overlap check: gather the sleep-step ("a") task intervals of every child
+# and require at least one overlapping pair.
+IDS1="$(proxy_task_ids "$P1")"
+[ "$(echo "$IDS1" | jq 'length')" = "6" ] || fail "AC1: expected 6 subworkflow proxy tasks, got $(echo "$IDS1" | jq 'length')"
+CH1="$(children "$IDS1")"
+[ "$(echo "$CH1" | jq 'length')" = "6" ] || fail "AC1: expected 6 child submissions, got $(echo "$CH1" | jq 'length')"
+
+INTERVALS="$WORK/ac1-intervals.txt"
+: > "$INTERVALS"
+for cid in $(echo "$CH1" | jq -r '.[].id'); do
+    api "$BASE/submissions/$cid/tasks" \
+        | jq -r --arg c "$cid" '.data[] | select(.step_id == "a") | "\($c) \(.started_at) \(.completed_at)"' \
+        >> "$INTERVALS"
+done
+echo "   child sleep-task intervals (child start end):"
+sed 's/^/     /' "$INTERVALS"
+OVERLAPS="$(python3 - "$INTERVALS" <<'PYEOF'
+import re
+import sys
+from datetime import datetime
+
+def ts(s):
+    # RFC3339 with nanoseconds (Go) — too precise for fromisoformat on
+    # older Pythons; parse the seconds fraction manually.
+    m = re.match(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?", s)
+    base = datetime.strptime(m.group(1), "%Y-%m-%dT%H:%M:%S")
+    frac = float("0." + m.group(2)) if m.group(2) else 0.0
+    return base.timestamp() + frac
+
+iv = []
+for line in open(sys.argv[1]):
+    parts = line.split()
+    if len(parts) != 3 or "null" in parts:
+        continue
+    iv.append((ts(parts[1]), ts(parts[2]), parts[0]))
+iv.sort()
+n = 0
+for i in range(len(iv)):
+    for j in range(i + 1, len(iv)):
+        if iv[j][0] < iv[i][1] and iv[i][0] < iv[j][1]:
+            n += 1
+print(n)
+PYEOF
+)"
+[ "${OVERLAPS:-0}" -ge 1 ] || fail "AC1: no overlapping child sleep-task intervals — children ran serially (wall ${AC1_WALL}s)"
+pass "AC1: parent COMPLETED in ${AC1_WALL}s (< 60 s) with $OVERLAPS overlapping child execution pairs"
+
+# Log evidence of overlap (checkout/complete interleaving in the server log).
+echo "   server-log evidence (task checkout/completion interleaving):"
+grep -E 'task (checked out|completed by worker)' "$SERVER_LOG" | head -12 | sed 's/^/     /'
+
+# ================================================= AC4: gathered outputs ==
+
+echo ""
+echo "== AC4: gathered msgs ordered a..f =="
+MSGS_JSON="$(api "$BASE/submissions/$P1" | jq -c '.data.outputs.msgs')"
+[ "$MSGS_JSON" != "null" ] && [ -n "$MSGS_JSON" ] || fail "AC4: parent outputs have no 'msgs' array"
+NMSGS="$(echo "$MSGS_JSON" | jq 'length')"
+[ "$NMSGS" = "6" ] || fail "AC4: expected 6 msgs entries, got $NMSGS: $MSGS_JSON"
+GATHERED=""
+for i in 0 1 2 3 4 5; do
+    LOC="$(echo "$MSGS_JSON" | jq -r ".[$i].location // .[$i].path")"
+    FPATH="${LOC#file://}"
+    [ -f "$FPATH" ] || fail "AC4: msgs[$i] file not found at '$FPATH' (location: $LOC)"
+    GATHERED="$GATHERED$(cat "$FPATH" | tr -d '[:space:]')"
+done
+[ "$GATHERED" = "abcdef" ] || fail "AC4: gathered msgs content order is '$GATHERED', want 'abcdef'"
+pass "AC4: msgs gathered in scatter order (a b c d e f)"
+
+# ==================================================== AC3: cancellation ==
+
+echo ""
+echo "== AC3: 20-item run, cancel parent after first child completes =="
+P3="$(submit "$WORK/scatter-sub.cwl" "$WORK/inputs20.yml")" || fail "AC3 submit failed"
+[ -n "$P3" ] || fail "AC3: could not parse submission id"
+echo "   parent submission: $P3"
+
+# Wait for the 20 proxy tasks / children to exist.
+IDS3="[]"
+for i in $(seq 1 30); do
+    IDS3="$(proxy_task_ids "$P3")"
+    [ "$(echo "$IDS3" | jq 'length')" = "20" ] && break
+    sleep 1
+done
+[ "$(echo "$IDS3" | jq 'length')" = "20" ] || fail "AC3: expected 20 proxy tasks, got $(echo "$IDS3" | jq 'length')"
+
+# Wait for the first child to COMPLETE. Task checkout is FIFO, so with 20
+# children on 2 workers all step-"a" (10 s sleep) tasks run before any
+# step "b": the first child completes only after ~(20/2)*10 s.
+FIRST_DONE=""
+for i in $(seq 1 180); do
+    CH3="$(children "$IDS3")"
+    NDONE="$(echo "$CH3" | jq '[.[] | select(.state == "COMPLETED")] | length')"
+    if [ "${NDONE:-0}" -ge 1 ]; then FIRST_DONE=1; break; fi
+    sleep 1
+done
+[ -n "$FIRST_DONE" ] || fail "AC3: no child completed within 180 s"
+
+echo "   first child completed; cancelling parent $P3"
+T_CANCEL="$(now_s)"
+api -X PUT "$BASE/submissions/$P3/cancel" >/dev/null || fail "AC3: cancel request failed"
+
+# Snapshot immediately after the cancel is accepted: children RUNNING at
+# this instant may legitimately finish either way; anything else must never
+# start running afterwards.
+CH3="$(children "$IDS3")"
+RUNNING_AT_CANCEL="$(echo "$CH3" | jq -c '[.[] | select(.state == "RUNNING") | .id]')"
+NONTERM_AT_CANCEL="$(echo "$CH3" | jq -c '[.[] | select(.state == "PENDING" or .state == "RUNNING") | .id]')"
+# Children allowed to end COMPLETED: already COMPLETED at the cancel instant,
+# or RUNNING right then (their in-flight task may legitimately finish first).
+ALLOWED_COMPLETED="$(echo "$CH3" | jq -c '[.[] | select(.state == "COMPLETED" or .state == "RUNNING") | .id]')"
+echo "   at cancel-accept: $(echo "$CH3" | jq -c 'group_by(.state) | map({(.[0].state): length}) | add')"
+
+# Watch until the parent is terminal: no child outside RUNNING_AT_CANCEL may
+# ever be observed RUNNING.
+PARENT_STATE=""
+CANCEL_ELAPSED=""
+while :; do
+    CH3="$(children "$IDS3")"
+    LATE="$(echo "$CH3" | jq -c --argjson ok "$RUNNING_AT_CANCEL" \
+        '[.[] | select(.state == "RUNNING") | select(.id as $i | $ok | index($i) == null) | .id]')"
+    [ "$LATE" = "[]" ] || fail "AC3: children left PENDING and started RUNNING after cancel: $LATE"
+    PARENT_STATE="$(sub_state "$P3")"
+    case "$PARENT_STATE" in COMPLETED|FAILED|CANCELLED) CANCEL_ELAPSED="$(elapsed "$T_CANCEL")"; break ;; esac
+    TOOLONG="$(python3 -c "print(1 if float('$(elapsed "$T_CANCEL")') > 20.0 else 0)")"
+    [ "$TOOLONG" = "1" ] && fail "AC3: parent $P3 not terminal 20 s after cancel (state: $PARENT_STATE)"
+    sleep 0.5
+done
+[ "$PARENT_STATE" = "CANCELLED" ] || fail "AC3: parent terminal state is '$PARENT_STATE' after cancel, want CANCELLED"
+AC3_OK="$(python3 -c "print(1 if float('$CANCEL_ELAPSED') <= 15.0 else 0)")"
+[ "$AC3_OK" = "1" ] || fail "AC3: parent went terminal only ${CANCEL_ELAPSED}s after cancel (> 15 s budget)"
+
+# --- AC3-DB: cancel cascade, asserted directly against the database --------
+# Within ~5 s of the parent reaching CANCELLED, every child submission of the
+# parent's subworkflow proxy tasks must be CANCELLED in the DB. Only children
+# that were COMPLETED, or RUNNING (race window), at the cancel instant may end
+# COMPLETED. No child may sit in PENDING/RUNNING, and no child may hold an
+# active task (PENDING/SCHEDULED/QUEUED/RUNNING).
+db_children() { # -> JSON [{id,state}] of P3's proxy-task children, from the DB
+    sqlite3 -json "file:$DB?mode=ro" \
+        "SELECT s.id, s.state FROM submissions s
+         JOIN tasks t ON s.parent_task_id = t.id
+         WHERE t.submission_id = '$P3' AND t.executor_type = 'subworkflow'
+         ORDER BY s.id;" 2>/dev/null || echo "[]"
+}
+DB_CASCADE_ELAPSED=""
+T_DB="$(now_s)"
+DB_CH="[]"
+DB_BAD="[]"
+for i in $(seq 1 14); do   # 14 x 0.5 s = 7 s hard ceiling, budget 5 s below
+    DB_CH="$(db_children)"
+    DB_N="$(echo "$DB_CH" | jq 'length')"
+    # Violations: any non-terminal child, or any child terminal in a state
+    # other than CANCELLED without being in the allowed-COMPLETED set.
+    DB_BAD="$(echo "$DB_CH" | jq -c --argjson ok "$ALLOWED_COMPLETED" \
+        '[.[] | select(
+            (.state == "PENDING" or .state == "RUNNING")
+            or (.state != "CANCELLED" and ((.id as $i | $ok | index($i)) == null))
+            or (.state == "FAILED")
+         )]')"
+    if [ "$DB_N" = "20" ] && [ "$DB_BAD" = "[]" ]; then
+        DB_CASCADE_ELAPSED="$(elapsed "$T_DB")"
+        break
+    fi
+    sleep 0.5
+done
+[ -n "$DB_CASCADE_ELAPSED" ] || fail "AC3-DB: cascade incomplete 7 s after parent CANCELLED — children in DB ($(echo "$DB_CH" | jq 'length') rows), violations: $DB_BAD"
+DB_OK="$(python3 -c "print(1 if float('$DB_CASCADE_ELAPSED') <= 5.0 else 0)")"
+[ "$DB_OK" = "1" ] || fail "AC3-DB: children reached CANCELLED only ${DB_CASCADE_ELAPSED}s after parent terminal (> 5 s budget)"
+# No child may hold an active task in the DB.
+DB_ACTIVE="$(sqlite3 -json "file:$DB?mode=ro" \
+    "SELECT ct.id, ct.state, ct.submission_id FROM tasks ct
+     WHERE ct.submission_id IN (
+        SELECT s.id FROM submissions s
+        JOIN tasks t ON s.parent_task_id = t.id
+        WHERE t.submission_id = '$P3' AND t.executor_type = 'subworkflow')
+     AND ct.state IN ('PENDING','SCHEDULED','QUEUED','RUNNING');" 2>/dev/null)"
+[ -z "$DB_ACTIVE" ] || [ "$DB_ACTIVE" = "[]" ] || fail "AC3-DB: children still hold active tasks in DB: $DB_ACTIVE"
+DB_DIST="$(echo "$DB_CH" | jq -c 'group_by(.state) | map({(.[0].state): length}) | add')"
+pass "AC3-DB: all 20 children terminal in DB ${DB_CASCADE_ELAPSED}s after parent CANCELLED, no active child tasks; DB states: $DB_DIST"
+
+# Settle, then verify: parent STAYS CANCELLED (CAS — no resurrection), and
+# every child is terminal with no ex-PENDING child having run.
+sleep 5
+PARENT_STATE="$(sub_state "$P3")"
+[ "$PARENT_STATE" = "CANCELLED" ] || fail "AC3: parent did not STAY CANCELLED — now '$PARENT_STATE' (finalize clobbered the cancel)"
+CH3="$(children "$IDS3")"
+NONTERM="$(echo "$CH3" | jq -c '[.[] | select(.state == "PENDING" or .state == "RUNNING") | .id]')"
+[ "$NONTERM" = "[]" ] || fail "AC3: non-terminal children remain after cancel settled: $NONTERM"
+ESCAPED="$(echo "$CH3" | jq -c --argjson nt "$NONTERM_AT_CANCEL" --argjson run "$RUNNING_AT_CANCEL" \
+    '[.[] | select(.id as $i | $nt | index($i) != null) | select(.id as $i | $run | index($i) == null) | select(.state != "CANCELLED") | {id, state}]')"
+[ "$ESCAPED" = "[]" ] || fail "AC3: children that were PENDING at cancel did not end CANCELLED: $ESCAPED"
+# Running children were killed: no child may retain an active worker task.
+for cid in $(echo "$CH3" | jq -r '.[].id'); do
+    ACTIVE="$(api "$BASE/submissions/$cid/tasks?limit=500" \
+        | jq -c '[.data // [] | .[] | select(.state == "PENDING" or .state == "SCHEDULED" or .state == "QUEUED" or .state == "RUNNING") | .id]')"
+    [ "$ACTIVE" = "[]" ] || fail "AC3: child $cid still has active tasks after cancel settled: $ACTIVE"
+done
+FINAL_DIST="$(echo "$CH3" | jq -c 'group_by(.state) | map({(.[0].state): length}) | add')"
+pass "AC3: parent CANCELLED ${CANCEL_ELAPSED}s after cancel and stayed CANCELLED; children final states: $FINAL_DIST"
+
+echo ""
+echo "ALL ACCEPTANCE CRITERIA PASSED"
+echo "  AC1 wall: ${AC1_WALL}s (< 60 s), overlapping pairs: $OVERLAPS"
+echo "  AC2 dispatch latency: ${AC2_ELAPSED}s"
+echo "  AC3 cancel-to-terminal: ${CANCEL_ELAPSED}s"
+echo "  AC3-DB cascade-to-CANCELLED (all 20 children, in DB): ${DB_CASCADE_ELAPSED}s"
+echo "  AC4 output order: a b c d e f"
+exit 0


### PR DESCRIPTION
## Summary

**PR 2 of 5** for #164 ([implementation spec](https://github.com/wilke/GoWe/issues/164#issuecomment-5235047430)) — the core rewrite. Fixes all three defects (serial children, engine-wide head-of-line blocking, uncancellable runs) at their shared root: `dispatchScatterSubWorkflow` no longer executes children inline on the tick thread.

## Design

Each scatter combination → one persisted **proxy task** (`executor_type=subworkflow`, `ScatterIndex`, `Job=combo`, `MaxRetries=0`, RUNNING from birth, never QUEUED — invisible to worker checkout and the stuck detector) paired 1:1 with a **child submission**. Children flow through the normal tick machinery; `pollInFlight` advances proxies from child state; the parent fans in through the existing plain-scatter `ScatterIndex` merge. Non-scatter subworkflow = N=1 case. `executeChildSubmission`/`waitForStepCompletion` (and its silent 10-min per-step timeout) deleted.

- **Durability**: transactional dispatch (`CreateTasksAndDispatchStep`) + transactional child creation (`CreateSubmissionWithSteps`) + idempotent repair from `task.Job` — restart re-attaches, never re-executes
- **Cancellation**: `CancelNonTerminalTasks` excludes proxies so the reconciliation cascade stays reachable — children and grandchildren are cancelled one level per tick; DELETE returns 409 while descendants are active; guarded writes everywhere (`TerminalizeTask`, `CASTaskState` retry claim + stranded-SCHEDULED reclaim, `persistSubmitOutcome`) so nothing resurrects concurrently-cancelled work
- **Fan-in**: full distinct-index set required, results sized by `ScatterCount`, SKIPPED tasks yield a SKIPPED step (never COMPLETED-with-null-holes)

## Measured acceptance criteria (live E2E, `scripts/test-scatter-subwf.sh`)

| AC | Result |
|---|---|
| AC1 parallelism | 6×10s scatter, 2 workers: **36.2 s** (serial ≈ 85 s), children overlapping in 3 waves |
| AC2 no head-of-line | unrelated submission dispatched **0.5 s** into a running scatter |
| AC3 cancellable | parent terminal **0.1 s** after cancel, stays CANCELLED; all 14 running children CANCELLED in DB within **0.6 s**, zero active tasks |
| AC4 gather order | `msgs` = a b c d e f (combination order) |
| AC5 regressions | full suite green; plain-scatter path untouched |

## Process

Built with a 6-agent workflow (store → core → 3 review lenses + live E2E agent), then a 3-agent fix round for the 6 findings that survived adversarial verification (cancel-cascade reachability, nested-cancel recursion, zero-step-child crash window, corrupt-row duplicate-child hazard, retry-resurrect race, unscoped SKIPPED guard), then a re-verify round whose 3 residual findings (stranded-SCHEDULED liveness, submit-outcome guard, delete-path orphaning) are fixed here as well. Load-bearing tests mutation-verified; ~1400 lines of new tests including a 2-level nested cancel cascade.

## Notes for later PRs

- PR 3 (cancel fan-out in the handler) becomes belt-and-braces: the scheduler cascade now does the work; the handler fan-out will make it synchronous
- PR 4 will add `parent_task_id` to list responses + default child exclusion (children currently appear in listings)
- E2E nit deferred: a cancel-during-sleep phase to exercise the worker heartbeat kill path live

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg