### PR TITLE
fix(server): synchronous cancel fan-out to sub-workflow child submissions

### DIFF
--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -582,10 +582,14 @@ PUT /api/v1/submissions/{id}/cancel
     "state": "CANCELLED",
     "steps_cancelled": 2,
     "tasks_cancelled": 3,
-    "tasks_already_completed": 2
+    "tasks_already_completed": 2,
+    "children_cancelled": 4
   }
 }
 ```
+
+`children_cancelled` counts descendant sub-workflow submissions (scatter
+children, at any nesting depth) cancelled synchronously at cancel-accept time.
 
 ---
 

--- a/internal/server/handler_submissions.go
+++ b/internal/server/handler_submissions.go
@@ -292,13 +292,118 @@ func (s *Server) handleCancelSubmission(w http.ResponseWriter, r *http.Request) 
 		s.logger.Error("cancel non-terminal tasks", "submission_id", sub.ID, "error", err)
 	}
 
+	// Synchronous fan-out to descendant child submissions (belt over the
+	// scheduler's braces): CancelNonTerminalTasks deliberately excludes
+	// subworkflow proxies so the scheduler's per-tick reconciliation can
+	// cascade the cancel one nesting level per tick — but that leaves
+	// children RUNNING until the scheduler gets around to them. Cancel them
+	// here, at cancel-accept time, so workers see the kill signal on their
+	// next heartbeat even if the scheduler is slow or stopped. Every write
+	// is CAS, so this is idempotent against a concurrently-running
+	// scheduler cascade (and vice versa).
+	childrenCancelled := s.cancelDescendantSubmissions(r.Context(), sub.ID, now, map[string]bool{})
+
 	respondOK(w, reqID, map[string]any{
 		"id":                      sub.ID,
 		"state":                   sub.State,
 		"steps_cancelled":         stepsCancelled,
 		"tasks_cancelled":         tasksCancelled,
 		"tasks_already_completed": max(0, len(sub.Tasks)-tasksCancelled),
+		"children_cancelled":      childrenCancelled,
 	})
+}
+
+// cancelDescendantSubmissions walks the given submission's subworkflow proxy
+// tasks and synchronously cancels every non-terminal descendant child
+// submission (any nesting depth), then retires the proxies as SKIPPED. It
+// returns the number of child submissions this call actually transitioned to
+// CANCELLED.
+//
+// This mirrors the scheduler's cancelChildSubmission cascade but runs it to
+// full depth in one pass; the scheduler's per-tick reconciliation remains the
+// backstop for cancels arriving via other paths. All writes are CAS
+// (FinalizeSubmission / TerminalizeTask skip already-terminal rows;
+// CancelNonTerminalSteps/Tasks only touch non-terminal rows), so racing the
+// scheduler is harmless in both directions. The visited set guards against
+// cycles, mirroring hasActiveChildSubmissions.
+func (s *Server) cancelDescendantSubmissions(ctx context.Context, submissionID string, now time.Time, visited map[string]bool) int {
+	if visited[submissionID] {
+		return 0
+	}
+	visited[submissionID] = true
+
+	tasks, err := s.store.ListTasksBySubmission(ctx, submissionID)
+	if err != nil {
+		s.logger.Error("cancel fan-out: list tasks", "submission_id", submissionID, "error", err)
+		return 0
+	}
+
+	cancelled := 0
+	for _, task := range tasks {
+		if task.ExecutorType != model.ExecutorTypeSubworkflow {
+			continue
+		}
+		children, err := s.store.GetChildSubmissions(ctx, task.ID)
+		if err != nil {
+			s.logger.Error("cancel fan-out: list children", "task_id", task.ID, "error", err)
+			continue
+		}
+		// A childless proxy is mid-dispatch: the scheduler may create the
+		// child at any moment. Leave the proxy RUNNING — retiring it here
+		// would disarm pollSubworkflowTask's reconciliation, the only path
+		// that cancels a child created after this walk. A childless proxy
+		// holds no worker tasks, so leaving it costs nothing.
+		if len(children) == 0 {
+			continue
+		}
+		// If any child could not be verifiably cancelled, keep the proxy
+		// RUNNING so the scheduler's reconciliation stays armed as backstop.
+		allHandled := true
+		for _, child := range children {
+			if !child.State.IsTerminal() {
+				child.State = model.SubmissionStateCancelled
+				child.CompletedAt = &now
+				applied, err := s.store.FinalizeSubmission(ctx, child)
+				if err != nil {
+					s.logger.Error("cancel fan-out: finalize child", "child_id", child.ID, "error", err)
+					allHandled = false
+					continue
+				}
+				if applied {
+					cancelled++
+					s.logger.Info("child submission cancelled (handler fan-out)", "child_id", child.ID)
+				} else if fresh, err := s.store.GetSubmission(ctx, child.ID); err == nil && fresh != nil {
+					// A concurrent writer (scheduler cascade or completion)
+					// terminalized the child first — leave its state alone.
+					s.logger.Debug("cancel fan-out: child already terminal",
+						"child_id", child.ID, "state", fresh.State)
+				}
+			}
+			// Steps/tasks: these only touch non-terminal rows, so they are
+			// safe (and useful) regardless of who terminalized the child.
+			if _, err := s.store.CancelNonTerminalSteps(ctx, child.ID, now); err != nil {
+				s.logger.Error("cancel fan-out: cancel child steps", "child_id", child.ID, "error", err)
+			}
+			if _, err := s.store.CancelNonTerminalTasks(ctx, child.ID, now); err != nil {
+				s.logger.Error("cancel fan-out: cancel child tasks", "child_id", child.ID, "error", err)
+			}
+			// Recurse even into already-terminal children: grandchildren may
+			// still be active (e.g. a scheduler cascade cancelled the child
+			// but has not reached the next nesting level yet).
+			cancelled += s.cancelDescendantSubmissions(ctx, child.ID, now, visited)
+		}
+		if !allHandled {
+			continue
+		}
+		// Every child verifiably terminal — retire the proxy as SKIPPED.
+		// CAS: an already-terminal proxy (concurrent scheduler write) stays.
+		task.State = model.TaskStateSkipped
+		task.CompletedAt = &now
+		if _, err := s.store.TerminalizeTask(ctx, task); err != nil {
+			s.logger.Error("cancel fan-out: skip proxy task", "task_id", task.ID, "error", err)
+		}
+	}
+	return cancelled
 }
 
 // hasActiveChildSubmissions reports whether any child submission spawned by the

--- a/internal/server/heartbeat_reconcile_test.go
+++ b/internal/server/heartbeat_reconcile_test.go
@@ -110,6 +110,42 @@ func TestWorkerHeartbeat_ReturnsCancelTasks(t *testing.T) {
 	}
 }
 
+// T7: a worker running tasks that belong to a CANCELLED child submission is
+// told to kill them. Cancelling the PARENT fans out to descendants
+// synchronously in the handler (no scheduler runs in testServer), so the
+// worker's next heartbeat reporting the child's task gets it back in
+// cancel_tasks — the kill signal reaches workers for descendants too.
+func TestWorkerHeartbeat_ReturnsCancelTasksForChildSubmission(t *testing.T) {
+	srv := testServer()
+	workerID := registerTestWorker(t, srv)
+	wfID, parentID := createTestSubmission(t, srv)
+	_, childID := seedSubworkflowChild(t, srv, wfID, parentID, "hb_child")
+	seedRunningWorkerTask(t, srv, childID, "task_child_running", workerID, time.Minute)
+
+	// Cancel the PARENT via the API — cancellation reaches the child only
+	// through the handler's synchronous fan-out.
+	req := httptest.NewRequest("PUT", "/api/v1/submissions/"+parentID+"/cancel", nil)
+	cw := httptest.NewRecorder()
+	srv.ServeHTTP(cw, req)
+	if cw.Code != http.StatusOK {
+		t.Fatalf("cancel parent: status=%d, body=%s", cw.Code, cw.Body.String())
+	}
+	child, err := srv.store.GetSubmission(context.Background(), childID)
+	if err != nil || child == nil || child.State != model.SubmissionStateCancelled {
+		t.Fatalf("child submission state = %v (err=%v), want CANCELLED", child, err)
+	}
+
+	// Worker heartbeats, still reporting the child's task as running.
+	_, env := doPut(t, srv, "/api/v1/workers/"+workerID+"/heartbeat", `{"running_tasks":["task_child_running"]}`)
+	var data heartbeatResp
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("decode heartbeat data: %v", err)
+	}
+	if len(data.CancelTasks) != 1 || data.CancelTasks[0] != "task_child_running" {
+		t.Fatalf("cancel_tasks = %v, want [task_child_running]", data.CancelTasks)
+	}
+}
+
 // An empty heartbeat body must still succeed (backward compatibility).
 func TestWorkerHeartbeat_EmptyBodyStillWorks(t *testing.T) {
 	srv := testServer()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/me/gowe/internal/config"
 	"github.com/me/gowe/internal/executor"
@@ -183,6 +184,41 @@ func createTestSubmissionWithTasks(t *testing.T, srv *Server) (string, string) {
 	}
 
 	return wfID, subID
+}
+
+// seedSubworkflowChild creates a RUNNING subworkflow proxy task on
+// parentSubID and a RUNNING child submission linked to it via ParentTaskID
+// (emulating the scheduler's sub-workflow dispatch), returning
+// (proxyTaskID, childSubmissionID).
+func seedSubworkflowChild(t *testing.T, srv *Server, wfID, parentSubID, suffix string) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	proxy := &model.Task{
+		ID:           "task_proxy_" + suffix,
+		SubmissionID: parentSubID,
+		StepID:       "work",
+		State:        model.TaskStateRunning,
+		ExecutorType: model.ExecutorTypeSubworkflow,
+		Inputs:       map[string]any{},
+		Outputs:      map[string]any{},
+		Job:          map[string]any{},
+		ScatterIndex: -1,
+	}
+	if err := srv.store.CreateTask(ctx, proxy); err != nil {
+		t.Fatalf("seed proxy task: %v", err)
+	}
+	child := &model.Submission{
+		ID:           "sub_child_" + suffix,
+		WorkflowID:   wfID,
+		State:        model.SubmissionStateRunning,
+		Inputs:       map[string]any{},
+		ParentTaskID: proxy.ID,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := srv.store.CreateSubmission(ctx, child); err != nil {
+		t.Fatalf("seed child submission: %v", err)
+	}
+	return proxy.ID, child.ID
 }
 
 // --- Discovery & Health (unchanged) ---
@@ -1010,6 +1046,84 @@ func TestCancelSubmission(t *testing.T) {
 	stepsCancelled, _ := data["steps_cancelled"].(float64)
 	if stepsCancelled != 2 {
 		t.Errorf("steps_cancelled = %v, want 2", data["steps_cancelled"])
+	}
+	// No sub-workflows involved: fan-out cancels nothing.
+	if cc, ok := data["children_cancelled"].(float64); !ok || cc != 0 {
+		t.Errorf("children_cancelled = %v, want 0", data["children_cancelled"])
+	}
+}
+
+// Cancelling a parent whose subworkflow proxy tasks spawned child (and
+// grandchild) submissions must cancel the whole descendant tree synchronously
+// in the handler — no scheduler tick involved (testServer runs none). The
+// proxies are retired SKIPPED and the descendants' in-flight worker tasks are
+// SKIPPED so workers get the kill signal on their next heartbeat.
+func TestCancelSubmission_FanOutCancelsDescendants(t *testing.T) {
+	srv := testServer()
+	wfID, parentID := createTestSubmission(t, srv)
+
+	childProxyID, childID := seedSubworkflowChild(t, srv, wfID, parentID, "child")
+	grandProxyID, grandchildID := seedSubworkflowChild(t, srv, wfID, childID, "grandchild")
+
+	// An in-flight worker task on each descendant.
+	seedRunningWorkerTask(t, srv, childID, "task_child_work", "w1", time.Minute)
+	seedRunningWorkerTask(t, srv, grandchildID, "task_grandchild_work", "w1", time.Minute)
+
+	req := httptest.NewRequest("PUT", "/api/v1/submissions/"+parentID+"/cancel", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	var env envelope
+	json.Unmarshal(w.Body.Bytes(), &env)
+	var data map[string]any
+	json.Unmarshal(env.Data, &data)
+	if data["state"] != "CANCELLED" {
+		t.Errorf("state = %v, want CANCELLED", data["state"])
+	}
+	if cc, ok := data["children_cancelled"].(float64); !ok || cc != 2 {
+		t.Errorf("children_cancelled = %v, want 2", data["children_cancelled"])
+	}
+
+	ctx := context.Background()
+	for _, id := range []string{childID, grandchildID} {
+		sub, err := srv.store.GetSubmission(ctx, id)
+		if err != nil || sub == nil {
+			t.Fatalf("get descendant %s: %v", id, err)
+		}
+		if sub.State != model.SubmissionStateCancelled {
+			t.Errorf("descendant %s state = %s, want CANCELLED (immediately, no scheduler)", id, sub.State)
+		}
+		if sub.CompletedAt == nil {
+			t.Errorf("descendant %s has no completed_at", id)
+		}
+	}
+	for _, id := range []string{childProxyID, grandProxyID} {
+		task, err := srv.store.GetTask(ctx, id)
+		if err != nil || task == nil {
+			t.Fatalf("get proxy %s: %v", id, err)
+		}
+		if task.State != model.TaskStateSkipped {
+			t.Errorf("proxy %s state = %s, want SKIPPED", id, task.State)
+		}
+	}
+	for _, id := range []string{"task_child_work", "task_grandchild_work"} {
+		task, err := srv.store.GetTask(ctx, id)
+		if err != nil || task == nil {
+			t.Fatalf("get worker task %s: %v", id, err)
+		}
+		if task.State != model.TaskStateSkipped {
+			t.Errorf("descendant worker task %s state = %s, want SKIPPED", id, task.State)
+		}
+	}
+
+	// Idempotent against the scheduler-side cascade: re-running the fan-out
+	// (as a concurrent scheduler tick would) cancels nothing further and
+	// leaves every state as-is.
+	if n := srv.cancelDescendantSubmissions(ctx, parentID, time.Now().UTC(), map[string]bool{}); n != 0 {
+		t.Errorf("second fan-out cancelled %d children, want 0 (idempotency)", n)
 	}
 }
 

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -703,6 +703,10 @@ func (ui *UI) HandleSubmissionCreatePost(w http.ResponseWriter, r *http.Request)
 }
 
 // HandleSubmissionCancel cancels a running submission (HTMX).
+//
+// Note: unlike the API cancel handler, this path performs no synchronous
+// fan-out to sub-workflow child submissions — the scheduler's reconciliation
+// cascade cancels them one nesting level per tick (correct, slightly slower).
 func (ui *UI) HandleSubmissionCancel(w http.ResponseWriter, r *http.Request) {
 	sess := SessionFromContext(r.Context())
 	id := ui.pathParam(r, "id")

--- a/scripts/test-scatter-subwf.sh
+++ b/scripts/test-scatter-subwf.sh
@@ -17,6 +17,13 @@
 #        submission of the parent's proxy tasks reaches CANCELLED (not
 #        RUNNING, not COMPLETED-as-orphan) within ~5 s of the parent going
 #        CANCELLED, and holds no active tasks.
+#   AC5: cancel DURING the sleeps — 20-item run cancelled while step-a
+#        sleep tasks are in flight on both workers: the cancel handler's
+#        synchronous fan-out cancels all children at cancel-accept time
+#        (children_cancelled=20 in the response), each worker kills its
+#        in-flight task after the next heartbeat ("cancelling task on
+#        server request" in the worker log), those tasks end SKIPPED, and
+#        parent + all children are CANCELLED.
 #
 # Environment: builds via apptainer golang:1.24 (Go is not installed
 # natively). Server on :8095 (NEVER :8091 — production), all state in /tmp.
@@ -398,19 +405,21 @@ AC3_OK="$(python3 -c "print(1 if float('$CANCEL_ELAPSED') <= 15.0 else 0)")"
 # that were COMPLETED, or RUNNING (race window), at the cancel instant may end
 # COMPLETED. No child may sit in PENDING/RUNNING, and no child may hold an
 # active task (PENDING/SCHEDULED/QUEUED/RUNNING).
-db_children() { # -> JSON [{id,state}] of P3's proxy-task children, from the DB
-    sqlite3 -json "file:$DB?mode=ro" \
+db_children() { # db_children <parent-id> -> JSON [{id,state}] of its proxy-task children, from the DB
+    local rows
+    rows="$(sqlite3 -json "file:$DB?mode=ro" \
         "SELECT s.id, s.state FROM submissions s
          JOIN tasks t ON s.parent_task_id = t.id
-         WHERE t.submission_id = '$P3' AND t.executor_type = 'subworkflow'
-         ORDER BY s.id;" 2>/dev/null || echo "[]"
+         WHERE t.submission_id = '$1' AND t.executor_type = 'subworkflow'
+         ORDER BY s.id;" 2>/dev/null)"
+    [ -n "$rows" ] && echo "$rows" || echo "[]"
 }
 DB_CASCADE_ELAPSED=""
 T_DB="$(now_s)"
 DB_CH="[]"
 DB_BAD="[]"
 for i in $(seq 1 14); do   # 14 x 0.5 s = 7 s hard ceiling, budget 5 s below
-    DB_CH="$(db_children)"
+    DB_CH="$(db_children "$P3")"
     DB_N="$(echo "$DB_CH" | jq 'length')"
     # Violations: any non-terminal child, or any child terminal in a state
     # other than CANCELLED without being in the allowed-COMPLETED set.
@@ -461,6 +470,125 @@ done
 FINAL_DIST="$(echo "$CH3" | jq -c 'group_by(.state) | map({(.[0].state): length}) | add')"
 pass "AC3: parent CANCELLED ${CANCEL_ELAPSED}s after cancel and stayed CANCELLED; children final states: $FINAL_DIST"
 
+# ===================================== AC5: cancel during in-flight sleeps ==
+
+echo ""
+echo "== AC5: 20-item run, cancel while step-a sleeps are in flight =="
+P4="$(submit "$WORK/scatter-sub.cwl" "$WORK/inputs20.yml")" || fail "AC5 submit failed"
+[ -n "$P4" ] || fail "AC5: could not parse submission id"
+echo "   parent submission: $P4"
+
+# Wait for the 20 proxy tasks / children to exist.
+IDS4="[]"
+for i in $(seq 1 30); do
+    IDS4="$(proxy_task_ids "$P4")"
+    [ "$(echo "$IDS4" | jq 'length')" = "20" ] && break
+    sleep 1
+done
+[ "$(echo "$IDS4" | jq 'length')" = "20" ] || fail "AC5: expected 20 proxy tasks, got $(echo "$IDS4" | jq 'length')"
+
+# Wait until BOTH workers have a child sleep task in flight (RUNNING worker
+# tasks in the DB, freshly started — each has ~10 s of sleep left, ample for
+# the 500 ms heartbeat to deliver the kill).
+ac5_running() { # -> JSON [id] of RUNNING worker tasks in P4's children
+    local rows
+    rows="$(sqlite3 -json "file:$DB?mode=ro" \
+        "SELECT ct.id FROM tasks ct
+         WHERE ct.submission_id IN (
+            SELECT s.id FROM submissions s
+            JOIN tasks t ON s.parent_task_id = t.id
+            WHERE t.submission_id = '$P4' AND t.executor_type = 'subworkflow')
+         AND ct.state = 'RUNNING' ORDER BY ct.id;" 2>/dev/null)"
+    [ -n "$rows" ] || rows="[]"
+    echo "$rows" | jq -c '[.[].id]'
+}
+RUNNING_IDS="[]"
+for i in $(seq 1 100); do
+    RUNNING_IDS="$(ac5_running)"
+    [ "$(echo "$RUNNING_IDS" | jq 'length')" -ge 2 ] && break
+    sleep 0.3
+done
+[ "$(echo "$RUNNING_IDS" | jq 'length')" -ge 2 ] \
+    || fail "AC5: never saw 2 in-flight child sleep tasks (got $RUNNING_IDS)"
+echo "   in-flight sleep tasks at cancel: $RUNNING_IDS"
+
+# Snapshot worker log lengths so we only credit kill lines logged AFTER this
+# cancel (AC3's cancel already produced some).
+W1_LINES="$(wc -l < /tmp/gowe164-w1.log)"
+W2_LINES="$(wc -l < /tmp/gowe164-w2.log)"
+
+echo "   cancelling parent $P4 mid-sleep"
+AC5_RESP="$(api -X PUT "$BASE/submissions/$P4/cancel")" || fail "AC5: cancel request failed"
+AC5_CHILDREN_CANCELLED="$(echo "$AC5_RESP" | jq -r '.data.children_cancelled')"
+[ "$AC5_CHILDREN_CANCELLED" = "20" ] \
+    || fail "AC5: cancel response children_cancelled = '$AC5_CHILDREN_CANCELLED', want 20 (synchronous handler fan-out)"
+pass "AC5: cancel response reported children_cancelled=20 (synchronous fan-out)"
+
+# (iii-a) All 20 children CANCELLED in the DB immediately (handler is
+# synchronous; small grace for the read).
+AC5_CH="[]"
+for i in $(seq 1 6); do
+    AC5_CH="$(db_children "$P4")"
+    AC5_NOT_CANCELLED="$(echo "$AC5_CH" | jq -c '[.[] | select(.state != "CANCELLED")]')"
+    [ "$(echo "$AC5_CH" | jq 'length')" = "20" ] && [ "$AC5_NOT_CANCELLED" = "[]" ] && break
+    sleep 0.5
+done
+[ "$(echo "$AC5_CH" | jq 'length')" = "20" ] && [ "$AC5_NOT_CANCELLED" = "[]" ] \
+    || fail "AC5: children not all CANCELLED right after cancel: $AC5_NOT_CANCELLED"
+pass "AC5: all 20 children CANCELLED in DB at cancel-accept time"
+
+# (i) Each worker log shows it killed its in-flight task after a heartbeat.
+# Worker log line (internal/worker/worker.go): "cancelling task on server request"
+KILL_MSG="cancelling task on server request"
+AC5_KILLED=""
+for i in $(seq 1 24); do   # 24 x 0.5 s = 12 s (heartbeat is 500 ms)
+    K1="$(tail -n "+$((W1_LINES + 1))" /tmp/gowe164-w1.log | grep -c "$KILL_MSG" || true)"
+    K2="$(tail -n "+$((W2_LINES + 1))" /tmp/gowe164-w2.log | grep -c "$KILL_MSG" || true)"
+    if [ "${K1:-0}" -ge 1 ] && [ "${K2:-0}" -ge 1 ]; then AC5_KILLED=1; break; fi
+    sleep 0.5
+done
+[ -n "$AC5_KILLED" ] || fail "AC5: workers did not log '$KILL_MSG' after cancel (w1: ${K1:-0}, w2: ${K2:-0})"
+KILLED_IDS="$( { tail -n "+$((W1_LINES + 1))" /tmp/gowe164-w1.log;
+                tail -n "+$((W2_LINES + 1))" /tmp/gowe164-w2.log; } \
+    | grep "$KILL_MSG" | sed 's/.*task_id=\([^ ]*\).*/\1/' | sort -u | jq -R . | jq -cs .)"
+echo "   worker-killed task ids: $KILLED_IDS"
+# Every task that was in flight at the cancel instant must have been killed.
+MISSED="$(echo "$RUNNING_IDS" | jq -c --argjson k "$KILLED_IDS" '[.[] | select(. as $i | $k | index($i) == null)]')"
+[ "$MISSED" = "[]" ] || fail "AC5: in-flight tasks never killed by their worker: $MISSED"
+pass "AC5: both workers killed their in-flight sleep task on heartbeat ($KILLED_IDS)"
+
+# (ii) The killed tasks end SKIPPED in the DB.
+RUNNING_IDS_SQL="$(echo "$RUNNING_IDS" | jq -r 'map("\u0027" + . + "\u0027") | join(",")')"
+AC5_NONSKIPPED="[]"
+for i in $(seq 1 20); do
+    AC5_NONSKIPPED="$(sqlite3 -json "file:$DB?mode=ro" \
+        "SELECT id, state FROM tasks
+         WHERE id IN ($RUNNING_IDS_SQL) AND state != 'SKIPPED';" 2>/dev/null)"
+    { [ -z "$AC5_NONSKIPPED" ] || [ "$AC5_NONSKIPPED" = "[]" ]; } && break
+    sleep 0.5
+done
+[ -z "$AC5_NONSKIPPED" ] || [ "$AC5_NONSKIPPED" = "[]" ] \
+    || fail "AC5: killed tasks did not end SKIPPED: $AC5_NONSKIPPED"
+pass "AC5: killed in-flight tasks ended SKIPPED"
+
+# (iii-b) Parent CANCELLED and STAYS CANCELLED; children stay CANCELLED; no
+# active tasks remain anywhere under the parent.
+sleep 3
+AC5_PARENT="$(sub_state "$P4")"
+[ "$AC5_PARENT" = "CANCELLED" ] || fail "AC5: parent state = '$AC5_PARENT' after settle, want CANCELLED"
+AC5_CH="$(db_children "$P4")"
+AC5_NOT_CANCELLED="$(echo "$AC5_CH" | jq -c '[.[] | select(.state != "CANCELLED")]')"
+[ "$AC5_NOT_CANCELLED" = "[]" ] || fail "AC5: children left non-CANCELLED after settle: $AC5_NOT_CANCELLED"
+AC5_ACTIVE="$(sqlite3 -json "file:$DB?mode=ro" \
+    "SELECT ct.id, ct.state, ct.submission_id FROM tasks ct
+     WHERE ct.submission_id IN (
+        SELECT s.id FROM submissions s
+        JOIN tasks t ON s.parent_task_id = t.id
+        WHERE t.submission_id = '$P4' AND t.executor_type = 'subworkflow')
+     AND ct.state IN ('PENDING','SCHEDULED','QUEUED','RUNNING');" 2>/dev/null)"
+[ -z "$AC5_ACTIVE" ] || [ "$AC5_ACTIVE" = "[]" ] || fail "AC5: children still hold active tasks: $AC5_ACTIVE"
+pass "AC5: parent + all 20 children CANCELLED and stable, no active child tasks"
+
 echo ""
 echo "ALL ACCEPTANCE CRITERIA PASSED"
 echo "  AC1 wall: ${AC1_WALL}s (< 60 s), overlapping pairs: $OVERLAPS"
@@ -468,4 +596,5 @@ echo "  AC2 dispatch latency: ${AC2_ELAPSED}s"
 echo "  AC3 cancel-to-terminal: ${CANCEL_ELAPSED}s"
 echo "  AC3-DB cascade-to-CANCELLED (all 20 children, in DB): ${DB_CASCADE_ELAPSED}s"
 echo "  AC4 output order: a b c d e f"
+echo "  AC5 cancel-during-sleep: children_cancelled=20 at accept, workers killed $KILLED_IDS"
 exit 0


### PR DESCRIPTION
## Summary

**PR 3 of 5** for the #164 plan. The API cancel handler now fans out to descendant child submissions synchronously — children are CANCELLED at cancel-accept, workers get kill signals on the next heartbeat, instead of the scheduler cascade's one-level-per-tick latency. The scheduler cascade stays as the backstop for other paths.

## Review-driven safety rules

- Proxy tasks are retired SKIPPED **only after every child is verifiably terminal**; on any child error the proxy stays RUNNING so the scheduler reconciliation remains armed
- A **childless proxy is never retired** — it's mid-dispatch; retiring it would orphan a child created after the handler's walk (the structural hole PR 2 closed)
- All writes CAS — fully idempotent against the concurrent scheduler cascade

## Testing

- Handler fan-out with 2-level nesting: children + grandchildren CANCELLED with zero scheduler ticks, `children_cancelled` counted
- Heartbeat kill-signal test (plan T7): descendant task IDs returned to the owning worker
- **E2E AC5 (new)**: cancel during in-flight sleeps — `children_cancelled=20` at accept, both workers killed their running tasks, tasks SKIPPED. Full script green post-fixes with a fresh build.

Part of #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg