### PR TITLE
feat(server,ui): exclude child submissions from listings by default

### DIFF
--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -485,6 +485,23 @@ Response (HTTP 201):
 
 ## 7. Monitor Job Status
 
+### List Submissions
+
+```
+GET /api/v1/submissions?state=RUNNING&limit=20&offset=0
+```
+
+Standard list parameters (`limit`, `offset`, `state`, `search`, `workflow_id`,
+`date_start`, `date_end`, `sort`, `dir`) plus:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `include_children` | `false` | Child submissions — those spawned by a parent's scatter/sub-workflow step (`parent_task_id` set) — are excluded from the rows and the pagination total by default. Pass `include_children=true` to list them too. Children remain individually reachable via `GET /api/v1/submissions/{id}` and via their parent regardless of this flag. |
+
+Each returned submission carries `parent_task_id` (empty for top-level
+submissions), so callers using `include_children=true` can tell parents and
+children apart.
+
 ### Poll Submission State
 
 ```

--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -239,6 +239,9 @@ func (l *Loop) listSubmissionsByState(ctx context.Context, state string) ([]*mod
 		// created_at ASC keeps the page walk stable under concurrent inserts
 		// (new rows land after the current position); the seen-map dedupes the
 		// residual boundary shifts from concurrent removals.
+		// ExcludeChildren must stay unset here: child submissions (scatter /
+		// sub-workflow fan-out) are scheduled through this walk like any other
+		// submission and would deadlock if hidden.
 		subs, total, err := l.store.ListSubmissions(ctx, model.ListOptions{
 			State: state, Limit: model.MaxListLimit, Offset: offset,
 			SortBy: "created_at", SortDir: "asc",

--- a/internal/scheduler/loop_test.go
+++ b/internal/scheduler/loop_test.go
@@ -525,6 +525,62 @@ func TestTick_EmptyTick(t *testing.T) {
 	}
 }
 
+// TestListSubmissionsByState_IncludesChildren guards the scheduler's view of
+// the submission table: child submissions (spawned by sub-workflow proxy
+// tasks, ParentTaskID set) are hidden from user-facing listings via
+// ListOptions.ExcludeChildren, but the scheduler must keep seeing them —
+// they need scheduling like any other submission. If someone "helpfully"
+// sets ExcludeChildren in listSubmissionsByState, children would never run.
+func TestListSubmissionsByState_IncludesChildren(t *testing.T) {
+	sched, st := testSetup(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	wf := &model.Workflow{
+		ID:         "wf_" + uuid.New().String(),
+		Name:       "test-workflow",
+		CWLVersion: "v1.2",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := st.CreateWorkflow(ctx, wf); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+
+	parent := &model.Submission{
+		ID:         "sub_parent",
+		WorkflowID: wf.ID,
+		State:      model.SubmissionStatePending,
+		Inputs:     map[string]any{},
+		CreatedAt:  now,
+	}
+	child := &model.Submission{
+		ID:           "sub_child",
+		WorkflowID:   wf.ID,
+		State:        model.SubmissionStatePending,
+		Inputs:       map[string]any{},
+		ParentTaskID: "task_proxy-1",
+		CreatedAt:    now,
+	}
+	for _, sub := range []*model.Submission{parent, child} {
+		if err := st.CreateSubmission(ctx, sub); err != nil {
+			t.Fatalf("CreateSubmission %s: %v", sub.ID, err)
+		}
+	}
+
+	subs, err := sched.listSubmissionsByState(ctx, "PENDING")
+	if err != nil {
+		t.Fatalf("listSubmissionsByState: %v", err)
+	}
+	got := make(map[string]bool, len(subs))
+	for _, s := range subs {
+		got[s.ID] = true
+	}
+	if !got["sub_parent"] || !got["sub_child"] {
+		t.Errorf("listSubmissionsByState = %v, want both parent and child (children must remain schedulable)", got)
+	}
+}
+
 // TestStart_StopsOnContextCancel verifies that Start returns when its context
 // is cancelled.
 func TestStart_StopsOnContextCancel(t *testing.T) {

--- a/internal/server/handler_submissions.go
+++ b/internal/server/handler_submissions.go
@@ -161,6 +161,11 @@ func (s *Server) handleListSubmissions(w http.ResponseWriter, r *http.Request) {
 
 	opts := parseListOptions(r)
 
+	// Child submissions (scatter/sub-workflow fan-out) are hidden by default
+	// so a 64-shard run does not flood the listing; pass include_children=true
+	// to see them.
+	opts.ExcludeChildren = r.URL.Query().Get("include_children") != "true"
+
 	// Non-admin users only see their own submissions.
 	userCtx := UserFromContext(r.Context())
 	if userCtx != nil && !userCtx.User.IsAdmin() {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -207,11 +207,18 @@ func seedSubworkflowChild(t *testing.T, srv *Server, wfID, parentSubID, suffix s
 	if err := srv.store.CreateTask(ctx, proxy); err != nil {
 		t.Fatalf("seed proxy task: %v", err)
 	}
+	// The scheduler copies the parent's owner onto child submissions
+	// (subworkflow dispatch); mirror that so owner-filtered listings see both.
+	parentSub, err := srv.store.GetSubmission(ctx, parentSubID)
+	if err != nil || parentSub == nil {
+		t.Fatalf("seed child: load parent submission: %v", err)
+	}
 	child := &model.Submission{
 		ID:           "sub_child_" + suffix,
 		WorkflowID:   wfID,
 		State:        model.SubmissionStateRunning,
 		Inputs:       map[string]any{},
+		SubmittedBy:  parentSub.SubmittedBy,
 		ParentTaskID: proxy.ID,
 		CreatedAt:    time.Now().UTC(),
 	}
@@ -995,6 +1002,47 @@ func TestListSubmissions(t *testing.T) {
 	env = doGet(t, srv, "/api/v1/submissions/")
 	if env.Pagination.Total != 1 {
 		t.Errorf("total = %d, want 1", env.Pagination.Total)
+	}
+}
+
+// Child submissions (scatter/sub-workflow fan-out) are hidden from the list
+// endpoint by default and only appear with include_children=true.
+func TestListSubmissions_ExcludeChildrenByDefault(t *testing.T) {
+	srv := testServer()
+	wfID, parentSubID := createTestSubmission(t, srv)
+	_, childSubID := seedSubworkflowChild(t, srv, wfID, parentSubID, "list")
+
+	listIDs := func(env envelope) map[string]bool {
+		t.Helper()
+		var subs []map[string]any
+		if err := json.Unmarshal(env.Data, &subs); err != nil {
+			t.Fatalf("decode list: %v", err)
+		}
+		ids := make(map[string]bool, len(subs))
+		for _, s := range subs {
+			ids[s["id"].(string)] = true
+		}
+		return ids
+	}
+
+	// Default: child hidden from rows and total.
+	env := doGet(t, srv, "/api/v1/submissions/")
+	if env.Pagination.Total != 1 {
+		t.Errorf("default total = %d, want 1 (child excluded)", env.Pagination.Total)
+	}
+	ids := listIDs(env)
+	if !ids[parentSubID] || ids[childSubID] {
+		t.Errorf("default list ids = %v, want parent only", ids)
+	}
+
+	// include_children=true: both visible.
+	env = doGet(t, srv, "/api/v1/submissions/?include_children=true")
+	if env.Pagination.Total != 2 {
+		t.Errorf("include_children total = %d, want 2", env.Pagination.Total)
+	}
+	ids = listIDs(env)
+	if !ids[parentSubID] || !ids[childSubID] {
+		t.Errorf("include_children list ids = %v, want parent and child", ids)
 	}
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -605,6 +605,9 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 		whereClauses = append(whereClauses, "submitted_by = ?")
 		countArgs = append(countArgs, opts.SubmittedBy)
 	}
+	if opts.ExcludeChildren {
+		whereClauses = append(whereClauses, "(parent_task_id = '' OR parent_task_id IS NULL)")
+	}
 
 	whereSQL := ""
 	if len(whereClauses) > 0 {
@@ -640,7 +643,7 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 }
 
 // submissionListColumns is the column set scanned by scanSubmissionRows.
-const submissionListColumns = `id, workflow_id, workflow_name, state, inputs, outputs, labels, submitted_by, created_at, completed_at, user_token, token_expiry, auth_provider, output_destination, output_state`
+const submissionListColumns = `id, workflow_id, workflow_name, state, inputs, outputs, labels, submitted_by, created_at, completed_at, user_token, token_expiry, auth_provider, parent_task_id, output_destination, output_state`
 
 // scanSubmissionRows scans submissionListColumns rows, skipping (with an error
 // log) rows that fail token decryption or JSON/timestamp parsing so one corrupt
@@ -657,7 +660,7 @@ func (s *SQLiteStore) scanSubmissionRows(rows *sql.Rows) ([]*model.Submission, e
 		if err := rows.Scan(&sub.ID, &sub.WorkflowID, &sub.WorkflowName, &state,
 			&inputsJSON, &outputsJSON, &labelsJSON,
 			&sub.SubmittedBy, &createdAt, &completedAt,
-			&sub.UserToken, &tokenExpiry, &sub.AuthProvider,
+			&sub.UserToken, &tokenExpiry, &sub.AuthProvider, &sub.ParentTaskID,
 			&sub.OutputDestination, &sub.OutputState); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -580,6 +580,67 @@ func TestListSubmissions_StateFilter(t *testing.T) {
 	}
 }
 
+func TestListSubmissions_ExcludeChildren(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	st.CreateWorkflow(ctx, wf)
+
+	parent := sampleSubmission(wf.ID)
+	st.CreateSubmission(ctx, parent)
+
+	// Two child submissions spawned by a sub-workflow proxy task.
+	for _, id := range []string{"sub_child-1", "sub_child-2"} {
+		child := sampleSubmission(wf.ID)
+		child.ID = id
+		child.ParentTaskID = "task_proxy-1"
+		if err := st.CreateSubmission(ctx, child); err != nil {
+			t.Fatalf("create child %s: %v", id, err)
+		}
+	}
+
+	t.Run("default includes children", func(t *testing.T) {
+		subs, total, err := st.ListSubmissions(ctx, model.DefaultListOptions())
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if total != 3 {
+			t.Errorf("total = %d, want 3 (parent + 2 children)", total)
+		}
+		if len(subs) != 3 {
+			t.Errorf("len = %d, want 3", len(subs))
+		}
+		// ParentTaskID must be populated in list results so callers can
+		// identify children.
+		byID := map[string]string{}
+		for _, s := range subs {
+			byID[s.ID] = s.ParentTaskID
+		}
+		if byID[parent.ID] != "" {
+			t.Errorf("parent ParentTaskID = %q, want empty", byID[parent.ID])
+		}
+		if byID["sub_child-1"] != "task_proxy-1" || byID["sub_child-2"] != "task_proxy-1" {
+			t.Errorf("child ParentTaskID not populated: %v", byID)
+		}
+	})
+
+	t.Run("exclude children", func(t *testing.T) {
+		opts := model.DefaultListOptions()
+		opts.ExcludeChildren = true
+		subs, total, err := st.ListSubmissions(ctx, opts)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if total != 1 {
+			t.Errorf("total = %d, want 1 (children excluded from count)", total)
+		}
+		if len(subs) != 1 || subs[0].ID != parent.ID {
+			t.Errorf("expected only parent submission, got %d rows", len(subs))
+		}
+	})
+}
+
 func TestUpdateSubmission(t *testing.T) {
 	st := testStore(t)
 	ctx := context.Background()

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -197,13 +197,14 @@ func (ui *UI) HandleDashboard(w http.ResponseWriter, r *http.Request) {
 		slog.Error("dashboard: failed to list workflows", "error", err)
 	}
 
-	// Get recent submissions.
-	submissions, _, err := ui.store.ListSubmissions(r.Context(), model.ListOptions{Limit: 5})
+	// Get recent submissions (top-level only; scatter children would flood the list).
+	submissions, _, err := ui.store.ListSubmissions(r.Context(), model.ListOptions{Limit: 5, ExcludeChildren: true})
 	if err != nil {
 		slog.Error("dashboard: failed to list submissions", "error", err)
 	}
 
 	// Count submissions by state for the last 24 hours.
+	// Note: CountSubmissionsByState is global — counts include child submissions.
 	since24h := time.Now().UTC().Add(-24 * time.Hour)
 	stats24h, err := ui.store.CountSubmissionsByState(r.Context(), since24h, "")
 	if err != nil {
@@ -385,6 +386,8 @@ func (ui *UI) HandleSubmissionList(w http.ResponseWriter, r *http.Request) {
 	if sess != nil && !sess.IsAdmin() {
 		opts.SubmittedBy = sess.Username
 	}
+	// Hide child submissions (scatter/sub-workflow fan-out) from the list view.
+	opts.ExcludeChildren = true
 
 	// View mode: "cards" (default) or "table".
 	viewMode := r.URL.Query().Get("view")
@@ -500,11 +503,14 @@ func (ui *UI) HandleSubmissionDetail(w http.ResponseWriter, r *http.Request) {
 	// Compute task summary
 	sub.TaskSummary = model.ComputeTaskSummary(sub.Tasks)
 
-	// Calculate queue position if pending
-	if sub.State == model.SubmissionStatePending {
+	// Calculate queue position if pending. Child submissions (scatter items)
+	// are excluded from the pending list this searches, so a position would
+	// never match — skip them; their scheduling is driven by the parent.
+	if sub.State == model.SubmissionStatePending && sub.ParentTaskID == "" {
 		pendingSubs, _, err := ui.store.ListSubmissions(r.Context(), model.ListOptions{
-			State: "PENDING",
-			Limit: 1000,
+			State:           "PENDING",
+			Limit:           1000,
+			ExcludeChildren: true, // queue position counts top-level submissions only
 		})
 		if err != nil {
 			slog.Error("submission detail: failed to list pending submissions for queue position", "error", err)
@@ -816,6 +822,8 @@ func (ui *UI) HandleSubmissionExport(w http.ResponseWriter, r *http.Request) {
 	sess := SessionFromContext(r.Context())
 	opts := ui.parseListOptions(r)
 	opts.Limit = 10000 // Export up to 10k records
+	// Export is deliberately global: it includes child submissions (scatter
+	// items), unlike the list view, so exported data is complete.
 
 	// Non-admin users only export their own submissions.
 	if sess != nil && !sess.IsAdmin() {
@@ -1179,6 +1187,7 @@ func (ui *UI) HandleAdminStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// All-time stats (for Running/Pending which are live states).
+	// Note: CountSubmissionsByState is global — counts include child submissions.
 	allStats, err := ui.store.CountSubmissionsByState(r.Context(), time.Time{}, "")
 	if err != nil {
 		slog.Error("admin stats: failed to count submissions by state", "error", err)

--- a/pkg/model/api.go
+++ b/pkg/model/api.go
@@ -37,6 +37,12 @@ type ListOptions struct {
 	SubmittedBy string   // Filter submissions by owner (empty = no filter)
 	SortBy      string   // Optional column to sort by (validated per-query)
 	SortDir     string   // Sort direction: "asc" or "desc" (default: "desc")
+	// ExcludeChildren omits child submissions (those spawned by a parent's
+	// sub-workflow proxy task, i.e. parent_task_id set) from submission
+	// listings. User-facing lists set this so scatter fan-out does not flood
+	// the view; the scheduler must leave it unset because children need
+	// scheduling like any other submission.
+	ExcludeChildren bool
 }
 
 // DefaultListOptions returns sensible defaults.


### PR DESCRIPTION
## Summary

**PR 4 of 5** for the #164 plan. Hides scatter child submissions from listings by default (a 64-shard run previously put 64 children atop every list), while exposing `parent_task_id` in list rows and keeping children reachable via `?include_children=true`.

- Store: `ExcludeChildren` predicate applied to both count and list queries (pagination math stays consistent); `parent_task_id` added to the list column set
- API: default exclude, `include_children=true` opt-in (documented)
- UI: list, dashboard recent-list, queue-position math exclude children; CSV export and state counts deliberately global (commented); child detail pages skip the queue-position lookup
- **Guard test**: the scheduler's submission walks must keep seeing children (that's how they get scheduled) — pinned by `TestListSubmissionsByState_IncludesChildren`

Reviewer audited every `ListSubmissions` caller in the repo for correct child visibility; no must/should-fix findings, two nits fixed here.

Part of #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg