### PR TITLE
docs: specify scatter-over-subworkflow execution; ADR-0011; upgrade guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ Submission  (PENDING → RUNNING → COMPLETED/FAILED/CANCELLED)
        └─ Task  (PENDING → SCHEDULED → QUEUED → RUNNING → SUCCESS/FAILED)
 ```
 
-Scatter steps produce N StepInstances, each with its own Tasks. The scheduler advances these through 6 phases each tick: (1) advance WAITING→READY when deps met, (2) dispatch READY→create Tasks, (3) retry FAILED tasks, (4) poll in-flight async tasks, (5) advance step instances, (6) finalize submissions.
+A scatter step produces ONE StepInstance owning N Tasks (one per combination, carrying ScatterIndex; outputs merge back in index order). The scheduler advances these through 6 phases each tick: (1) advance WAITING→READY when deps met, (2) dispatch READY→create Tasks, (3) retry FAILED tasks, (4) poll in-flight async tasks, (5) advance step instances, (6) finalize submissions.
+
+Sub-workflow steps are never executed inline: each (scatter combination of a) sub-workflow step gets a persisted proxy task (`executor_type: subworkflow`, RUNNING from birth, `MaxRetries: 0`, `Job` = resolved child inputs) paired 1:1 with a child submission (`parent_task_id` = proxy id) that flows through the same tick machinery. pollInFlight advances the proxy from the child's state (child CANCELLED → proxy FAILED), repairs missing children after a crash, and reconciles cancels one nesting level per tick; the cancel handler also fans out to descendants synchronously. See SPECIFICATION.md §7.4 and ADR-0011.
 
 ### Executor Registry
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Submission  (PENDING → RUNNING → COMPLETED / FAILED / CANCELLED)
        └─ Task  (PENDING → SCHEDULED → QUEUED → RUNNING → SUCCESS / FAILED)
 ```
 
-Scatter steps produce N StepInstances, each with its own Tasks. The scheduler advances these through 6 phases each tick: (1) advance WAITING→READY when deps met, (2) dispatch READY→create Tasks, (3) retry FAILED tasks, (4) poll in-flight async tasks, (5) advance step instances, (6) finalize submissions.
+A scatter step produces one StepInstance owning N Tasks (one per combination, merged back in ScatterIndex order); sub-workflow steps run as child submissions paired 1:1 with `subworkflow` proxy tasks (see [SPECIFICATION.md](SPECIFICATION.md) §7.4). The scheduler advances these through 6 phases each tick: (1) advance WAITING→READY when deps met, (2) dispatch READY→create Tasks, (3) retry FAILED tasks, (4) poll in-flight async tasks, (5) advance step instances, (6) finalize submissions.
 
 ### Executor Selection
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # GoWe Specification
 
-> **Status**: Living specification · **Version**: draft-7 (2026-07-07)
+> **Status**: Living specification · **Version**: draft-8 (2026-08-09)
 > **Applies to**: GoWe server, worker, CLI, and `cwl-runner`
 > **Companion documents**: [`docs/adr/`](docs/adr/) (why), [`docs/cwl-hints.md`](docs/cwl-hints.md)
 > (hint reference), [`docs/GoWe-Vocabulary.md`](docs/GoWe-Vocabulary.md) (concepts),
@@ -48,7 +48,7 @@ These terms are normative. Code, docs, and API responses MUST use them consisten
 | **Tool** | A reusable single operation. CWL `class: CommandLineTool` or `ExpressionTool`. The unit of reuse. |
 | **Step** | One node in a Workflow's DAG; binds a Tool (or sub-Workflow) to input sources. Not executable alone. |
 | **Submission** (a.k.a. **Run**) | One execution of a Workflow with concrete input values. Top-level tracking entity. |
-| **StepInstance** | One runtime instance of a Step within a Submission. A scatter Step yields **N** StepInstances. |
+| **StepInstance** | One runtime instance of a Step within a Submission. A scatter Step yields **one** StepInstance owning N Tasks (§7.2). |
 | **Task** | A concrete, schedulable unit of work bound to resolved inputs and assigned to an Executor. |
 | **Executor** | A pluggable backend that knows *how* to run a Task in one environment. |
 | **Scheduler** | The engine loop that advances the model, resolves dependencies, dispatches, retries, and finalizes. |
@@ -164,8 +164,8 @@ transitions MUST be rejected (`pkg/model`). Rationale: [ADR-0003](docs/adr/0003-
 
 ```
 Submission                       one run of a workflow
-  └── StepInstance               one per step; scatter ⇒ N
-        └── Task                 concrete work unit
+  └── StepInstance               one per step
+        └── Task                 concrete work unit; scatter ⇒ N (one per combination)
 ```
 
 ### 6.1 Submission states
@@ -209,7 +209,8 @@ with `FAILED → RETRYING → QUEUED` while retries remain.
 | SKIPPED | Conditional skip (`when` false), **or** cancellation of a non-terminal Task when its Submission is cancelled. |
 
 > Worker-bound tasks MAY transition directly `PENDING → QUEUED`, bypassing `SCHEDULED`, so
-> they are immediately available for checkout.
+> they are immediately available for checkout. Sub-workflow proxy tasks (§7.4) are created
+> directly in `RUNNING` and never pass through `QUEUED`.
 
 ### 6.4 State propagation
 
@@ -230,7 +231,7 @@ phases in order; a phase that errors MUST NOT silently skip later ticks. Referen
 | 1.5 | (Server mode) Pre-stage workspace inputs for PENDING submissions. |
 | 2 | Dispatch `READY` StepInstances: resolve inputs, create Tasks, submit to executors. |
 | 2.5 | Re-submit `RETRYING` tasks. |
-| 3 | Poll `QUEUED`/`RUNNING` tasks on async executors for status. |
+| 3 | Poll `QUEUED`/`RUNNING` tasks on async executors for status; advance sub-workflow proxy tasks from their child submission's state (§7.4). |
 | 3.5 | Detect stuck `QUEUED` worker tasks (progress-based) and recover them. |
 | 4 | Advance `DISPATCHED`/`RUNNING` StepInstances when all their Tasks are terminal. |
 | 5 | Finalize submissions whose StepInstances are all terminal. |
@@ -245,14 +246,110 @@ StepInstance level.
 
 ### 7.2 Scatter
 
-A scatter Step MUST expand into N StepInstances according to its `scatterMethod`. Each
-StepInstance owns its own Tasks and advances independently.
+A scatter Step over a CommandLineTool or sub-workflow expands into exactly **one**
+StepInstance owning **N Tasks** — one per scatter combination according to its
+`scatterMethod` — each Task carrying its combination's `ScatterIndex`. At dispatch the
+StepInstance records `ScatterCount`, and — while Tasks remain in flight —
+`ScatterMethod` and (for `nested_crossproduct`) `ScatterDims`. Scatter over an
+ExpressionTool is executed inline by the scheduler and produces no Task rows: the
+StepInstance completes at dispatch, and the when-skip rule below does not apply to it.
+Reference: `dispatchScatterStep` and `advanceSteps` in `internal/scheduler/loop.go`.
+
+- The StepInstance MUST NOT complete until every distinct `ScatterIndex` in
+  `[0, ScatterCount)` has a terminal Task. Merged outputs MUST be sized by `ScatterCount`,
+  never by task-row count, so duplicate task rows for an index neither hang nor oversize
+  the result.
+- Outputs MUST be merged in `ScatterIndex` order (re-nested per `ScatterDims` for
+  `nested_crossproduct`), regardless of completion order.
+- A combination whose `when` evaluates false yields a terminal `SUCCESS` Task with null
+  outputs, keeping the index set complete.
+- An empty scatter (N = 0) MUST complete the StepInstance immediately with empty merged
+  outputs; it MUST NOT be left `DISPATCHED` with zero Tasks.
+- A `SKIPPED` Task in the set — which arises only from cancellation — MUST make the
+  StepInstance `SKIPPED`, never `COMPLETED`: completing over it would emit an output array
+  with null holes under a cancelled Submission.
 
 ### 7.3 Retry
 
 On Task `FAILED`, the scheduler MUST transition it to `RETRYING` and re-queue it if and only
 if retry attempts remain per the task's retry policy; otherwise the failure propagates to the
 StepInstance and Submission.
+
+Re-queueing MUST claim the task with a compare-and-set `RETRYING → SCHEDULED` so that a
+concurrent cancellation (`SKIPPED`) is never overwritten; a failed claim leaves the task
+alone. A `SCHEDULED` task observed at the start of the retry phase is a stranded claim from
+a crash mid-resubmit and MUST be swept back to `RETRYING` before claiming.
+
+### 7.4 Sub-workflow steps (proxy tasks and child submissions)
+
+A Step whose `run` is a `Workflow` MUST NOT be executed inline on the scheduler goroutine.
+Reference: `dispatchSubWorkflowStep`, `dispatchScatterSubWorkflow`, and
+`pollSubworkflowTask` in `internal/scheduler/loop.go`; rationale:
+[ADR-0011](docs/adr/0011-scatter-subworkflow-proxy-tasks.md).
+
+**Proxy tasks.** Dispatch creates one **proxy Task** per scatter combination (a non-scatter
+sub-workflow is the N = 1 case, `ScatterIndex` −1). A proxy MUST have:
+
+- `ExecutorType: subworkflow` — a scheduler-internal type, never a registered backend
+  (§8.1);
+- state `RUNNING` from creation — never `QUEUED`, so worker checkout, the stuck detector,
+  and requeue/reconcile (which all filter on `executor_type = 'worker'`) never see it;
+- `MaxRetries: 0` — a `FAILED` proxy MUST NOT re-enter the retry cycle (§7.3), which would
+  erase the child's error;
+- `Job` holding the fully-resolved child inputs for its combination.
+
+**Child submissions.** Each proxy pairs 1:1 with a **child Submission**
+(`ParentTaskID` = proxy task id) built from the sub-workflow graph. Children are ordinary
+Submissions: the same tick machinery schedules their steps and tasks, workers pull their
+work, and nesting recurses naturally. A child MUST NOT inherit the parent's
+`OutputDestination` (the parent stages the gathered outputs after fan-in); it inherits the
+parent's routing/debug labels with `parent_task` overwritten per nesting level.
+
+**Durability.** All proxy Tasks and the StepInstance's `READY → DISPATCHED` transition MUST
+be persisted in a single transaction; child submissions are created afterwards,
+idempotently per proxy. A crash before the transaction leaves the step `READY` for a clean
+re-dispatch with no duplicates; a crash after it leaves `RUNNING` proxies whose missing
+children the poll phase MUST repair by recreating them from the proxy's persisted `Job` —
+never by re-running scatter combination, `valueFrom`, or `when` JavaScript. A restarted
+server therefore re-attaches to in-flight children rather than re-executing them.
+
+**Advancement and fan-in.** Phase 3 advances each `RUNNING` proxy from its child's state:
+child `COMPLETED` ⇒ proxy `SUCCESS` carrying the child's outputs; child `FAILED` **or
+`CANCELLED`** ⇒ proxy `FAILED` with the child's error in `Stderr`. A cancelled child MUST
+surface as a `FAILED` proxy, not `SKIPPED`: fan-in counts only `FAILED` as failure, and a
+`SKIPPED` proxy would let the parent complete with a null hole in the gathered array. The
+StepInstance then fans in through the ordinary `ScatterIndex` merge (§7.2). All proxy
+and Submission terminalizations on these paths MUST be guarded compare-and-set writes so
+a concurrent cancellation is never overwritten; StepInstance writes rely on the single
+scheduler goroutine, with cancel-side step writes touching only non-terminal rows and
+the reconciliation skip re-reading state before writing.
+
+**Cancellation.** Two cooperating mechanisms:
+
+1. *Synchronous handler fan-out.* The cancel endpoint walks the submission's subworkflow
+   proxies and cancels every non-terminal descendant child (any nesting depth) at
+   cancel-accept time, reporting the count as `children_cancelled`, so workers see the kill
+   on their next heartbeat even if the scheduler is slow or stopped. A proxy is retired
+   `SKIPPED` only once all of its children are verifiably terminal; a childless proxy
+   (mid-dispatch) MUST be left `RUNNING` so the scheduler's reconciliation stays armed for
+   a child created after the walk.
+2. *Per-tick scheduler reconciliation (backstop).* A `RUNNING` proxy whose own Submission
+   or StepInstance is terminal MUST cancel its child (if any), retire itself `SKIPPED`, and
+   conditionally `SKIP` its step. `CancelNonTerminalTasks` MUST exclude subworkflow proxies
+   so this path stays reachable; nested sub-workflows therefore cascade one nesting level
+   per tick with no explicit recursion.
+
+Under either path, a `SKIPPED` proxy in a step's task set yields a `SKIPPED` StepInstance
+(§7.2), never a `COMPLETED` one.
+
+**Deletion.** `DELETE /submissions/{id}` MUST be refused with `409 Conflict` while any
+descendant child submission is active: deleting the rows would delete the proxies — the
+scheduler's only handle for cascading a cancel to the children. Cancel first, let the
+cascade finish, then delete.
+
+**Failure.** Child-submission creation failure (e.g. a refused plaintext token, §13.5) is
+not retryable: the proxy goes `FAILED` with the reason in `Stderr` and the step fails
+outright.
 
 ---
 
@@ -271,6 +368,10 @@ Every backend MUST implement `Submit`, `Status`, `Cancel`, and `Logs`
 | `apptainer` | sync | Apptainer/Singularity container (`.sif`, `--nv`, binds). |
 | `worker` | async | queuing for a remote pull-worker (§9). |
 | `bvbrc` | async | BV-BRC JSON-RPC `start_app` + `query_tasks` polling ([ADR-0007](docs/adr/0007-generic-bvbrc-executor-over-operators.md)). |
+
+`subworkflow` is **not** a backend: it is a scheduler-internal `ExecutorType` marking
+sub-workflow proxy tasks (§7.4). It MUST NOT be registered in the executor registry, and
+the scheduler MUST NOT consult the registry for tasks carrying it.
 
 ### 8.2 Selection order (first match wins)
 

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -608,6 +608,11 @@ PUT /api/v1/submissions/{id}/cancel
 `children_cancelled` counts descendant sub-workflow submissions (scatter
 children, at any nesting depth) cancelled synchronously at cancel-accept time.
 
+Deletion is separate from cancellation: `DELETE /api/v1/submissions/{id}`
+permanently removes a submission and returns `409 Conflict` while any descendant
+child submission is still active — cancel first and wait for the cascade to
+finish. Deleting also requires an authenticated (non-anonymous) owner or admin.
+
 ---
 
 ## 9. Check System Health

--- a/docs/adr/0011-scatter-subworkflow-proxy-tasks.md
+++ b/docs/adr/0011-scatter-subworkflow-proxy-tasks.md
@@ -1,0 +1,120 @@
+# 0011. Run sub-workflow steps through proxy tasks paired with child submissions
+
+- **Status**: Accepted
+- **Date**: 2026-08-09
+- **Deciders**: GoWe core
+- **Related**: ADR-0003 (three-level state hierarchy), ADR-0004 (pull-based workers),
+  ADR-0006 (SQLite single-writer persistence); [`SPECIFICATION.md`](../../SPECIFICATION.md)
+  §7.2, §7.4, §8.1; issue #164; PRs #165, #167, #168, #169
+
+## Context
+
+The original sub-workflow implementation (`executeChildSubmission` +
+`waitForStepCompletion`) executed each scatter child **inline on the scheduler
+goroutine**, one at a time, driving the child's steps to completion in its own nested loop
+with no cancellation checks. Issue #164 documented the three user-visible defects:
+
+1. **No parallelism** — a scatter over a sub-workflow ran one child at a time regardless
+   of worker count.
+2. **Engine-wide head-of-line blocking** — while the inline loop ran, no other submission
+   was scheduled; an unrelated submission sat `PENDING, Tasks: 0` for the parent's entire
+   duration (observed: 1h+, workers idle).
+3. **Uncancellable** — `gowe cancel <parent>` marked the submission CANCELLED but the loop
+   kept creating and executing children (observed: 40+ children over 2h after cancel);
+   only a server restart stopped it.
+
+The root cause was shared: child execution lived in scheduler memory (an unpersisted
+`parentTask`), outside the three state machines the rest of the engine advances, so
+nothing could interleave with it, observe a cancel, or recover it after a restart.
+
+## Decision
+
+**Represent each sub-workflow execution as a persisted proxy Task paired 1:1 with a child
+Submission, and let the normal tick machinery do everything else.**
+
+- Dispatch creates one proxy Task per scatter combination (`ExecutorType: subworkflow`,
+  `ScatterIndex: i`, `Job` = the fully-resolved combination, `MaxRetries: 0`, state
+  RUNNING from birth — never QUEUED). A non-scatter sub-workflow is the N = 1 case
+  (`ScatterIndex` −1). All proxies plus the step's `READY → DISPATCHED` transition are
+  persisted in **one transaction**.
+- Each proxy pairs with a child Submission (`ParentTaskID` = proxy id), created
+  idempotently after the transaction. Children are ordinary submissions: the same
+  scheduler runs their steps, workers pull their tasks, nesting recurses naturally.
+- `pollInFlight` advances each RUNNING proxy from its child's state (child COMPLETED ⇒
+  proxy SUCCESS with the child's outputs; child FAILED or CANCELLED ⇒ proxy FAILED with
+  the child's error in `Stderr`), repairs a missing child from the proxy's persisted
+  `Job` (crash between transaction and child creation), and reconciles proxies whose own
+  submission or step went terminal. The parent fans in through the existing plain-scatter
+  `ScatterIndex` merge in `advanceSteps`.
+- Cancellation is a synchronous handler fan-out to all descendants (any depth, reported
+  as `children_cancelled`) plus the scheduler's per-tick reconciliation as backstop;
+  `CancelNonTerminalTasks` excludes subworkflow proxies so the backstop stays armed, and
+  nested cancels cascade one level per tick. Submission and task terminalizations are
+  compare-and-set writes (PR #165), and cancel-side step writes touch only non-terminal
+  rows, so the two paths race harmlessly.
+
+The 1:1 task↔child pairing is the crux: it reuses all three existing state machines,
+makes fan-in a verbatim copy of plain scatter, gives cancel fan-out a natural join key,
+and makes recovery per-task idempotent.
+
+### Alternatives considered
+
+- **StepInstance-level tracking without tasks** — store the child submission ids directly
+  on the StepInstance and advance it from their states. Rejected: it invents a fourth
+  bespoke state ledger next to the three the engine already has; fan-in, failure
+  aggregation, cancellation, and the heartbeat kill path all reason in Tasks, so each
+  would need a parallel implementation; and there is no per-combination row to serve as
+  the idempotency/join key for crash repair and cancel fan-out.
+- **Worker-pool inline execution** — keep the inline executor but run children on a pool
+  of goroutines inside the server. Rejected: it restores parallelism but keeps execution
+  state in memory, so a restart still orphans every in-flight child, cancellation still
+  needs bespoke signalling into each goroutine, and it duplicates the scheduler's own
+  dispatch/poll/advance machinery instead of reusing it.
+
+## Consequences
+
+**Positive**
+
+- **Durability.** The dispatch transaction plus idempotent per-proxy repair make every
+  crash window recoverable: before the transaction, the step re-dispatches cleanly; after
+  it, `pollInFlight` recreates missing children from `task.Job` without re-running scatter
+  combination or `valueFrom`/`when` JavaScript. A restarted server re-attaches to
+  in-flight children instead of re-executing them.
+- **Cancellation reaches every level.** Handler fan-out kills descendants at
+  cancel-accept time (workers see it on the next heartbeat); the per-tick reconciliation
+  catches anything created after the fan-out's snapshot. Live E2E (PR #167): cancel
+  cascaded to 14 running children in 0.6 s.
+- **Parallelism and no head-of-line blocking.** Children are limited only by worker
+  capacity; unrelated submissions dispatch mid-scatter (E2E: 36.2 s vs ~85 s serial for
+  6×10 s on 2 workers; 0.5 s dispatch latency for a submission arriving mid-scatter).
+
+**Negative / trade-offs**
+
+- **Listing flood.** Children are real submission rows, so a 64-shard scatter would bury
+  the submissions list. Addressed in PR #169: listings exclude children by default
+  (`parent_task_id` set) and take `include_children=true` to opt back in; children remain
+  individually reachable by id.
+- **One-tick latencies.** A proxy advances — and the parent step and submission finalize —
+  one tick after the child completes (phases 3→4→5 of the same tick); nested cancels
+  reconcile one nesting level per tick (the synchronous handler fan-out hides this for
+  the common cancel path).
+- A cancelled child surfaces as a FAILED parent step (with the cancellation noted in the
+  proxy's `Stderr`), not as a distinct state — the price of keeping fan-in identical to
+  plain scatter.
+- One `GetChildSubmissions` query per in-flight proxy per tick (N+1); acceptable at
+  current scales.
+
+**Neutral**
+
+- `subworkflow` is a scheduler-internal `ExecutorType`, never registered as an executor
+  backend (SPECIFICATION §8.1).
+- `DELETE /submissions/{id}` now refuses with 409 while descendant children are active,
+  since deleting the proxies would sever the cancel cascade.
+- **Upgrade note (pre-0.15 → 0.15).** The old code never persisted the step's DISPATCHED
+  state, so an in-flight scatter-over-subworkflow submission re-dispatches from scratch on
+  upgrade: duplicate children are created, and old orphan children run to completion with
+  their results discarded. Cancel such submissions before upgrading; dangling child rows
+  can be cleaned up with
+  `UPDATE submissions SET state='CANCELLED' WHERE state IN ('PENDING','RUNNING') AND
+  parent_task_id != '' AND parent_task_id NOT IN (SELECT id FROM tasks);`
+  See [`docs/upgrading.md`](../upgrading.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ recorded before or as they are made.
 | [0008](0008-dataset-affinity-and-staging-modes.md) | Route by dataset affinity; stage data by mode | Accepted |
 | [0009](0009-delegated-identity-and-optional-worker-keys.md) | Delegate identity to external providers; gate workers with optional shared keys | Accepted |
 | [0010](0010-scoped-worker-token-injection.md) | Scope automatic delegated-token injection to operator-trusted worker groups | Accepted |
+| [0011](0011-scatter-subworkflow-proxy-tasks.md) | Run sub-workflow steps through proxy tasks paired with child submissions | Accepted |
 
 ## Writing a new ADR
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,37 @@
+# Upgrading GoWe
+
+Version-specific operator guidance. Routine upgrades (stop server, replace binaries,
+restart) need no special steps — schema migrations run automatically at startup. Entries
+below cover the exceptions.
+
+## 0.14.x → 0.15.0 — scatter over sub-workflows becomes non-blocking
+
+0.15.0 replaces the inline serial sub-workflow executor with persisted proxy tasks paired
+1:1 with child submissions
+([ADR-0011](adr/0011-scatter-subworkflow-proxy-tasks.md), issue #164).
+
+**Before upgrading: cancel any in-flight scatter-over-subworkflow submissions.**
+
+Why: the pre-0.15 code never persisted the parent step's `DISPATCHED` state, so after the
+upgrade the new scheduler sees the step as `READY` and re-dispatches the whole scatter
+from scratch — creating a duplicate set of children — while the old-style children already
+in the database become orphans that run to completion with their results discarded.
+Submissions without sub-workflow steps are unaffected.
+
+If orphaned children are already present after an upgrade (old rows whose
+`parent_task_id` points at a task that was never persisted), either let them finish (their
+results are discarded) or clean them up:
+
+```sql
+UPDATE submissions SET state='CANCELLED'
+WHERE state IN ('PENDING','RUNNING')
+  AND parent_task_id != ''
+  AND parent_task_id NOT IN (SELECT id FROM tasks);
+```
+
+Also note two API behavior changes in 0.15.0:
+
+- `GET /api/v1/submissions` excludes child submissions by default; pass
+  `include_children=true` to list them (see [`API_GUIDE.md`](API_GUIDE.md) §7).
+- `DELETE /api/v1/submissions/{id}` returns `409 Conflict` while any descendant child
+  submission is active — cancel first and let the cascade finish.


### PR DESCRIPTION
## Summary

**PR 5 of 5 (final)** for the #164 plan — the docs catch up with the merged implementation (#165, #167, #168, #169).

- **SPECIFICATION.md draft-8**: normative §7.4 for sub-workflow execution (proxy tasks, child submissions, transactional dispatch/repair, cancellation semantics, delete 409); §8.1 executor carve-out; and a fix for the **long-standing §7.2 error** — scatter creates one StepInstance owning N indexed Tasks, not N StepInstances (also fixed in CLAUDE.md and README.md, where the sentence recurred verbatim; ADR-0003 repeats it but ADRs are immutable)
- **ADR-0011**: the proxy-task decision, rejected alternatives, consequences
- **docs/upgrading.md**: cancel in-flight scatter-over-subworkflow runs before upgrading (re-dispatch duplicates children); cleanup SQL for dangling `parent_task` rows; API behavior changes
- **API_GUIDE**: delete-409 documented (children_cancelled/include_children were already added by PRs 3–4)

Accuracy-reviewed against the merged code: the reviewer caught the spec overclaiming CAS on step writes (now correctly scoped to proxy/submission writes), an ADR latency miscount, and ExpressionTool inline-scatter needing explicit scoping — all fixed.

Part of #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg