### PR TITLE
fix(staging): upload stage-out bytes through Shock — JSON-inline content corrupts every binary file (#172, #171)

### DIFF
--- a/docs/BVBRC-API.md
+++ b/docs/BVBRC-API.md
@@ -796,7 +796,7 @@ Each object spec is an array:
 }
 ```
 
-**Example - Upload a small file**:
+**Example - inline text content** (⚠️ text only):
 
 ```json
 {
@@ -818,9 +818,15 @@ Each object spec is an array:
 }
 ```
 
-#### `Workspace.create` (for upload nodes - large files)
+> **Never send file bytes through this field.** The content slot is a JSON string, so any
+> byte that is not valid UTF-8 is replaced with U+FFFD by every conforming JSON encoder —
+> three bytes replacing one — and the object is stored corrupted, with no error anywhere.
+> Text survives, binaries do not, so the damage is silent (issue #172). Upload **all**
+> file content through Shock, as below and as `scripts/ws-create.pl` does.
 
-For large files, create an upload node first, then upload to Shock:
+#### `Workspace.create` (for upload nodes — the binary-safe upload path)
+
+Create an upload node first, then PUT the bytes to Shock:
 
 ```json
 {
@@ -841,37 +847,49 @@ For large files, create an upload node first, then upload to Shock:
 }
 ```
 
-**Response** includes a Shock node URL for upload:
+**Response** carries the full Shock node URL in ObjectMeta slot `[11]`:
 
 ```json
 {
     "result": [[
         [
-            "/user@patricbrc.org/home/large_file.fastq.gz",
+            "large_file.fastq.gz",
             "reads",
-            "user@patricbrc.org",
+            "/user@patricbrc.org/home/",
             "2026-02-09T10:00:00Z",
             "uuid-here",
             "user@patricbrc.org",
-            12345,
+            0,
             {},
             {},
-            "shock",
-            "shock-node-id-here"
+            "o",
+            "n",
+            "https://<shock-host>/services/shock_api/node/<shock-node-id>"
         ]
     ]]
 }
 ```
 
-Then upload the file to Shock:
+Slot `[11]` is already a complete URL — use it verbatim rather than rebuilding one from a
+node id, and do not read slot `[10]`, which is the global permission letter (issue #171).
+
+Then PUT the file to that URL, exactly as `scripts/ws-create.pl` does:
 
 ```
-PUT https://p3.theseed.org/services/shock_api/node/<shock-node-id>
-Authorization: <token>
+PUT <slot [11] URL>
+Authorization: OAuth <token>
 Content-Type: multipart/form-data
 
-[file data]
+--boundary
+Content-Disposition: form-data; name="upload"; filename="large_file.fastq.gz"
+
+[raw file bytes]
+--boundary--
 ```
+
+The multipart field name must be `upload`, the method must be `PUT`, and the
+`Authorization` header uses the `OAuth` scheme (unlike the JSON-RPC endpoint, which accepts
+a bare token).
 
 #### `Workspace.get`
 
@@ -900,28 +918,45 @@ Retrieve workspace objects.
 
 **Response format**:
 
-Each object is returned as a tuple array:
+`Workspace.get` returns a list of `[ObjectMeta, ObjectData]` **pairs** — the metadata
+tuple and the object's content, not the metadata tuple alone. Unwrap the pair first,
+then parse its element `[0]` with the ObjectMeta layout below.
+
+`ObjectMeta` is the tuple defined by the Workspace module's own `Workspace.spec`:
 
 ```
-[path, type, owner, creation_time, id, owner_id, size, user_metadata, auto_metadata, shock_ref, shock_node]
+[ObjectName, ObjectType, FullObjectPath, creation_time, ObjectID, object_owner,
+ ObjectSize, UserMetadata, AutoMetadata, user_permission, global_permission,
+ shockurl, error]
 ```
 
 Index mapping:
 
 | Index | Field | Type | Description |
 |-------|-------|------|-------------|
-| 0 | path | string | Full workspace path |
-| 1 | type | string | Object type |
-| 2 | owner | string | Object owner |
+| 0 | ObjectName | string | Object name, without directory prefix |
+| 1 | ObjectType | string | Object type |
+| 2 | FullObjectPath | string | Containing directory, with a trailing `/` |
 | 3 | creation_time | string | ISO 8601 creation timestamp |
-| 4 | id | string | Object UUID |
-| 5 | owner_id | string | Owner identifier |
-| 6 | size | integer | File size in bytes |
-| 7 | user_metadata | object | User-defined metadata |
-| 8 | auto_metadata | object | Auto-generated metadata |
-| 9 | shock_ref | string | Shock reference type ("shock" or "inline") |
-| 10 | shock_node | string | Shock node ID (if applicable) |
-| 11 | data | string | File content (if not metadata_only and inline) |
+| 4 | ObjectID | string | Object UUID |
+| 5 | object_owner | string | Owner username |
+| 6 | ObjectSize | integer | File size in bytes (or child count for a directory) |
+| 7 | UserMetadata | object | User-defined metadata |
+| 8 | AutoMetadata | object | Auto-generated metadata |
+| 9 | user_permission | string | Calling user's permission: `o`, `w`, `r`, `n` |
+| 10 | global_permission | string | Workspace's global permission |
+| 11 | shockurl | string | Full URL of the backing Shock node, if any |
+| 12 | error | string | Per-object error, if any |
+
+Two things this table used to get wrong, and they cost real data (issues #171, #172):
+
+- **The full path is `[2] + [0]`**, not `[0]`. Slot `[2]` is the containing directory
+  with a trailing slash; the service's own clients concatenate the two.
+- **The Shock URL is slot `[11]`**, not `[10]`. Slots `[9]` and `[10]` are permission
+  letters, so code that PUT file bytes to `[10]` was addressing a permission string.
+
+The service's implementation (`_generate_object_meta`) emits the **first 12 slots** and
+omits the trailing `error`, so parsers must tolerate a 12-element tuple.
 
 #### `Workspace.ls`
 
@@ -1345,9 +1380,6 @@ type WorkspaceObject struct {
     // ID is the unique object identifier (UUID).
     ID string `json:"id"`
 
-    // OwnerID is the owner's identifier.
-    OwnerID string `json:"owner_id"`
-
     // Size is the file size in bytes.
     Size int64 `json:"size"`
 
@@ -1357,13 +1389,20 @@ type WorkspaceObject struct {
     // AutoMetadata contains system-generated metadata.
     AutoMetadata map[string]string `json:"auto_metadata"`
 
-    // ShockRef indicates storage type ("shock" for Shock-stored, "inline" for small files).
-    ShockRef string `json:"shock_ref,omitempty"`
+    // UserPermission is the calling user's permission on the owning workspace.
+    UserPermission string `json:"user_permission,omitempty"`
 
-    // ShockNodeID is the Shock node identifier for large files.
-    ShockNodeID string `json:"shock_node_id,omitempty"`
+    // GlobalPermission is the owning workspace's global permission.
+    GlobalPermission string `json:"global_permission,omitempty"`
 
-    // Data contains inline file content (for small files retrieved with metadata_only=false).
+    // ShockURL is the full URL of the backing Shock node, if any. This is the
+    // URL that file bytes are PUT to when uploading.
+    ShockURL string `json:"shock_url,omitempty"`
+
+    // Error is set when the service reported a per-object error.
+    Error string `json:"error,omitempty"`
+
+    // Data holds the ObjectData half of a Workspace.get [meta, data] pair.
     Data string `json:"data,omitempty"`
 }
 
@@ -1378,11 +1417,11 @@ type WorkspacePermission struct {
 
 // WorkspaceObjectMeta is the tuple representation returned by workspace API calls.
 // The API returns arrays of arrays, not named objects.
-// Index mapping:
-//   [0] = path, [1] = type, [2] = owner, [3] = creation_time, [4] = id,
-//   [5] = owner_id, [6] = size, [7] = user_meta, [8] = auto_meta,
-//   [9] = shock_ref, [10] = shock_node
-type WorkspaceObjectMeta [11]interface{}
+// Index mapping (Workspace.spec ObjectMeta; the service emits the first 12):
+//   [0] = name, [1] = type, [2] = directory path, [3] = creation_time,
+//   [4] = id, [5] = owner, [6] = size, [7] = user_meta, [8] = auto_meta,
+//   [9] = user_permission, [10] = global_permission, [11] = shockurl, [12] = error
+type WorkspaceObjectMeta [13]interface{}
 ```
 
 ### Client Configuration Types
@@ -1955,35 +1994,15 @@ func main() {
 
 ```go
 // UploadFile uploads a file to the BV-BRC workspace.
-// For small files (< 10MB), inline upload is used.
-// For large files, Shock upload is used.
+// All content goes through Shock, whatever its size: Workspace.create's inline
+// content slot is a JSON string and mangles every non-UTF-8 byte (issue #172).
 func (c *Client) UploadFile(localPath, wsPath, objType string) error {
     data, err := os.ReadFile(localPath)
     if err != nil {
         return fmt.Errorf("reading file: %w", err)
     }
 
-    const maxInlineSize = 10 * 1024 * 1024 // 10 MB
-
-    if len(data) < maxInlineSize {
-        // Inline upload for small files
-        resp, err := c.CallWorkspace(
-            "Workspace.create",
-            map[string]interface{}{
-                "objects": [][]interface{}{
-                    {wsPath, objType, map[string]string{}, string(data)},
-                },
-                "overwrite": true,
-            },
-        )
-        if err != nil {
-            return fmt.Errorf("workspace create: %w", err)
-        }
-        _ = resp
-        return nil
-    }
-
-    // Large file: create upload node, then upload to Shock
+    // Create the destination as an upload node.
     resp, err := c.CallWorkspace(
         "Workspace.create",
         map[string]interface{}{
@@ -1991,29 +2010,29 @@ func (c *Client) UploadFile(localPath, wsPath, objType string) error {
                 {wsPath, objType, map[string]string{}, nil},
             },
             "createUploadNodes": true,
+            "overwrite":         true,
         },
     )
     if err != nil {
         return fmt.Errorf("creating upload node: %w", err)
     }
 
-    // Parse response to get Shock node ID
+    // Parse the response for the Shock URL: ObjectMeta slot [11].
     var results [][][]interface{}
     if err := json.Unmarshal(resp.Result, &results); err != nil {
         return fmt.Errorf("parsing upload node response: %w", err)
     }
 
-    if len(results) == 0 || len(results[0]) == 0 || len(results[0][0]) < 11 {
+    if len(results) == 0 || len(results[0]) == 0 || len(results[0][0]) < 12 {
         return fmt.Errorf("unexpected upload node response format")
     }
 
-    shockNodeID, ok := results[0][0][10].(string)
-    if !ok || shockNodeID == "" {
-        return fmt.Errorf("no Shock node ID in response")
+    shockURL, ok := results[0][0][11].(string)
+    if !ok || shockURL == "" {
+        return fmt.Errorf("no Shock upload URL in response")
     }
 
-    // Upload to Shock
-    shockURL := fmt.Sprintf("%s/node/%s", c.config.ShockURL, shockNodeID)
+    // Slot [11] is a complete URL; PUT the bytes to it.
     return c.uploadToShock(shockURL, localPath, data)
 }
 
@@ -2361,6 +2380,7 @@ The Data API supports Resource Query Language (RQL) for querying. Common operato
 | "Token expired" | Token past expiry date | Obtain new token |
 | "Workspace path not found" | Invalid workspace path | Verify path format: `/user@patricbrc.org/...` |
 | Upload fails | File too large for inline | Use Shock upload (createUploadNodes) |
+| Stored file larger than the original, checksum mismatch | File bytes were sent through `Workspace.create`'s inline JSON content slot, which replaces every non-UTF-8 byte with U+FFFD | Upload through Shock (`createUploadNodes`); the stored copy is unrecoverable and must be re-uploaded |
 
 ### Debugging Tips
 

--- a/docs/BVBRC-Workspace-Deep-Dive.md
+++ b/docs/BVBRC-Workspace-Deep-Dive.md
@@ -97,8 +97,9 @@ server-side staging phases in [`internal/scheduler/workspace.go`](../internal/sc
   downloads `ws://` inputs to local `file://` (via `WorkspaceGetDownloadURL` + HTTP GET with
   OAuth) and rewrites the input locations so a container step can read them.
 - **Phase 5.5 post-stage** — `poststageWorkspaceOutputs` (`scheduler/workspace.go:106–198`)
-  uploads local `file://` outputs back to `ws://` (via `ensureDir` + `WorkspaceUpload`) and
-  writes a `_gowe_outputs.json` manifest.
+  uploads local `file://` outputs back to `ws://` (via `ensureDir` + `WorkspaceUploadFile`,
+  which creates the object as a Shock upload node and PUTs the raw bytes to it) and writes a
+  `_gowe_outputs.json` manifest.
 
 Enabled with `--workspace-staging server --workspace-url <url>` (`cmd/server/main.go:41–42`).
 
@@ -109,8 +110,17 @@ The stager itself is complete — `StageIn` (`workspace.go:83`), `StageOut` (`wo
 ### Client surface
 
 [`pkg/bvbrc/workspace.go`](../pkg/bvbrc/workspace.go) implements `WorkspaceLs`, `Get`,
-`Create`, `CreateFolder`, `Upload`, `Delete`, `Copy`, `Move`, `SetPermissions`,
-`ListPermissions`, and `GetDownloadURL`. [`pkg/bvbrc/appservice.go`](../pkg/bvbrc/appservice.go)
+`Create`, `CreateFolder`, `UploadFile`, `Delete`, `Copy`, `Move`, `SetPermissions`,
+`ListPermissions`, and `GetDownloadURL`.
+
+`WorkspaceUploadFile` is the **only** upload entry point, and it always goes through Shock:
+`Workspace.create` with `createUploadNodes` and `overwrite`, then a multipart `PUT` of the
+raw bytes to the Shock URL in `ObjectMeta[11]`, with `Authorization: OAuth <token>` — the
+protocol `scripts/ws-create.pl` implements. The inline `Content` field of `Workspace.create`
+is reserved for folders and upload-node placeholders (`null`); routing file bytes through it
+corrupted every binary output, because it is a JSON string and `encoding/json` replaces every
+byte that is not valid UTF-8 with U+FFFD. That was issue #172; there is a regression test
+pinning it in `pkg/bvbrc/workspace_test.go`. [`pkg/bvbrc/appservice.go`](../pkg/bvbrc/appservice.go)
 implements `enumerate_apps`, `query_app_description`, `start_app`, `query_tasks`,
 `query_task_details`, `kill_task`, `query_app_log`, and more.
 
@@ -145,7 +155,7 @@ Beyond the verification gap, these edges only surface against real infrastructur
 | Edge | Detail | Location |
 |------|--------|----------|
 | **Wildcard globs unresolved (fallback)** | When an app does not populate `output_files` **and** an output is a wildcard (`*.fasta`), the glob fallback deliberately skips it — resolving it would require a `WorkspaceLs` of the result folder, which the fallback does not do. The primary `output_files` path is unaffected. | `bvbrc.go:316` |
-| **Whole-file-in-memory staging** | `StageOut` does `os.ReadFile` and uploads the entire content as a string — memory-bound for multi-GB genomics files. | `workspace.go:156` |
+| **Whole-file-in-memory staging** | `StageOut` does `os.ReadFile` and buffers the multipart body in memory — memory-bound for multi-GB genomics files. Streaming with a computed `Content-Length` is the fix, but Shock is not verified to accept a chunked body, so it needs a live service to land. | `workspace.go:156` |
 | **No recursive directory download** | `StageIn` is single-file; a `ws://` `Directory` output that a local step needs is not recursively listed and downloaded. | `workspace.go:83` |
 | **No submit-time schema validation** | `query_app_description` exists but is not called; bad params fail at BV-BRC, not pre-flight. | `bvbrc.go:95` |
 

--- a/internal/cli/submit.go
+++ b/internal/cli/submit.go
@@ -287,7 +287,7 @@ func uploadFileToWorkspace(ctx context.Context, ws *bvbrcpkg.Client, fileObj map
 	wsPath := destFolder + "/" + basename
 	fmt.Fprintf(os.Stderr, "  Uploading %s → ws://%s\n", basename, wsPath)
 
-	_, err = ws.WorkspaceUpload(ctx, wsPath, string(data), bvbrcpkg.WorkspaceTypeUnspecified)
+	_, err = ws.WorkspaceUploadFile(ctx, wsPath, data, bvbrcpkg.WorkspaceTypeUnspecified)
 	if err != nil {
 		return nil, fmt.Errorf("workspace upload %s: %w", basename, err)
 	}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1570,70 +1570,53 @@ func (ui *UI) HandleWorkspaceUpload(w http.ResponseWriter, r *http.Request) {
 		"type", objType,
 	)
 
-	// For small files (< 10MB), use inline upload.
-	// For larger files, we'd need to use Shock upload (createUploadNodes).
-	const inlineLimit = 10 * 1024 * 1024 // 10MB
-
-	if len(data) < inlineLimit {
-		// Inline upload.
-		result, err := caller.Call(r.Context(), "Workspace.create", []any{
-			map[string]any{
-				"objects": [][]any{
-					{destPath, objType, nil, data},
-				},
-				"overwrite": true,
+	// Every upload goes through Shock, whatever its size. The inline branch this
+	// replaced handed Workspace.create a []byte in a JSON string slot, which
+	// encoding/json base64-encodes — and inline content is UTF-8-only anyway, so
+	// there is no size below which routing bytes through JSON is correct
+	// (issues #172, #171).
+	//
+	// Step 1: create the destination as an upload node.
+	result, err := caller.Call(r.Context(), "Workspace.create", []any{
+		map[string]any{
+			"objects": [][]any{
+				{destPath, objType, nil, nil},
 			},
-		})
-		if err != nil {
-			ui.logger.Error("workspace upload failed", "path", destPath, "error", err)
-			http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
-			return
-		}
-		ui.logger.Debug("workspace upload response", "result", string(result))
-	} else {
-		// Large file - need Shock upload.
-		// First, create an upload node.
-		result, err := caller.Call(r.Context(), "Workspace.create", []any{
-			map[string]any{
-				"objects": [][]any{
-					{destPath, objType, nil, nil},
-				},
-				"createUploadNodes": true,
-				"overwrite":         true,
-			},
-		})
-		if err != nil {
-			ui.logger.Error("workspace create upload node failed", "path", destPath, "error", err)
-			http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
-			return
-		}
+			"createUploadNodes": true,
+			"overwrite":         true,
+		},
+	})
+	if err != nil {
+		ui.logger.Error("workspace create upload node failed", "path", destPath, "error", err)
+		http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
 
-		// Parse response to get Shock node ID.
-		var createResp [][][]any
-		if err := json.Unmarshal(result, &createResp); err != nil {
-			ui.logger.Error("workspace parse upload node failed", "error", err)
-			http.Error(w, `{"error": "Failed to parse upload node response"}`, http.StatusInternalServerError)
-			return
-		}
+	// Step 2: pull the Shock URL out of the returned ObjectMeta tuple. Per
+	// Workspace.spec it is slot [11] — slot [10] is the global permission string.
+	var createResp [][][]any
+	if err := json.Unmarshal(result, &createResp); err != nil {
+		ui.logger.Error("workspace parse upload node failed", "error", err)
+		http.Error(w, `{"error": "Failed to parse upload node response"}`, http.StatusInternalServerError)
+		return
+	}
 
-		if len(createResp) == 0 || len(createResp[0]) == 0 || len(createResp[0][0]) < 11 {
-			http.Error(w, `{"error": "Invalid upload node response"}`, http.StatusInternalServerError)
-			return
-		}
+	if len(createResp) == 0 || len(createResp[0]) == 0 || len(createResp[0][0]) < 12 {
+		http.Error(w, `{"error": "Invalid upload node response"}`, http.StatusInternalServerError)
+		return
+	}
 
-		shockNodeID, ok := createResp[0][0][10].(string)
-		if !ok || shockNodeID == "" {
-			http.Error(w, `{"error": "No Shock node ID in response"}`, http.StatusInternalServerError)
-			return
-		}
+	shockURL, ok := createResp[0][0][11].(string)
+	if !ok || shockURL == "" {
+		http.Error(w, `{"error": "No Shock upload URL in response"}`, http.StatusInternalServerError)
+		return
+	}
 
-		// Upload to Shock.
-		shockURL := "https://p3.theseed.org/services/shock_api/node/" + shockNodeID
-		if err := ui.uploadToShock(r.Context(), shockURL, filename, data, sess.Token); err != nil {
-			ui.logger.Error("shock upload failed", "url", shockURL, "error", err)
-			http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
-			return
-		}
+	// Step 3: PUT the raw bytes to the Shock node.
+	if err := ui.uploadToShock(r.Context(), shockURL, filename, data, sess.Token); err != nil {
+		ui.logger.Error("shock upload failed", "error", err)
+		http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
+		return
 	}
 
 	// Return success with the workspace path.
@@ -1675,6 +1658,12 @@ func (ui *UI) uploadToShock(ctx context.Context, shockURL, filename string, data
 		return err
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
+	// Shock wants the OAuth scheme, as scripts/ws-create.pl sends it. (The
+	// Workspace JSON-RPC endpoint accepts a bare token; Shock is not the same
+	// service.)
+	if !strings.HasPrefix(token, "OAuth ") {
+		token = "OAuth " + token
+	}
 	req.Header.Set("Authorization", token)
 
 	resp, err := http.DefaultClient.Do(req)

--- a/mcp-servers/python/src/bvbrc_mcp/client.py
+++ b/mcp-servers/python/src/bvbrc_mcp/client.py
@@ -48,7 +48,11 @@ class WorkspaceObject:
     size: int
     user_metadata: dict[str, str]
     auto_metadata: dict[str, str]
-    shock_ref: str | None = None
+    name: str = ""
+    user_permission: str | None = None
+    global_permission: str | None = None
+    shock_url: str | None = None
+    error: str | None = None
     data: str | None = None
 
 
@@ -210,7 +214,7 @@ class BVBRCClient:
         result = self._call_workspace("Workspace.get", [params])
         if not result or not result[0]:
             return []
-        return [_parse_workspace_object(t) for t in result[0]]
+        return [_parse_workspace_get_entry(e) for e in result[0]]
 
     def workspace_create(
         self,
@@ -322,16 +326,57 @@ def _load_token() -> str:
 
 
 def _parse_workspace_object(tuple_data: list[Any]) -> WorkspaceObject:
-    """Parse workspace object tuple."""
+    """Parse a Workspace ObjectMeta tuple.
+
+    Layout per the Workspace module's own ``Workspace.spec``::
+
+        [ObjectName, ObjectType, FullObjectPath, creation_time, ObjectID,
+         object_owner, ObjectSize, UserMetadata, AutoMetadata, user_permission,
+         global_permission, shockurl, error]
+
+    The spec declares 13 slots; ``WorkspaceImpl.pm``'s ``_generate_object_meta``
+    emits the first 12. Note that ``shockurl`` is slot 11 — slots 9 and 10 are
+    permission letters (issue #171) — and that the object's full path is slot 2
+    (the containing directory, trailing slash) joined with slot 0.
+    """
+
+    def slot(i: int) -> Any:
+        return tuple_data[i] if len(tuple_data) > i else None
+
+    name = str(slot(0)) if slot(0) else ""
+    directory = str(slot(2)) if slot(2) else ""
+    if directory and name:
+        path = directory + name if directory.endswith("/") else f"{directory}/{name}"
+    else:
+        path = directory or name
+
     return WorkspaceObject(
-        path=str(tuple_data[0]) if len(tuple_data) > 0 else "",
-        type=str(tuple_data[1]) if len(tuple_data) > 1 else "",
-        owner=str(tuple_data[2]) if len(tuple_data) > 2 else "",
-        creation_time=str(tuple_data[3]) if len(tuple_data) > 3 else "",
-        id=str(tuple_data[4]) if len(tuple_data) > 4 else "",
-        size=int(tuple_data[6]) if len(tuple_data) > 6 and tuple_data[6] else 0,
-        user_metadata=tuple_data[7] if len(tuple_data) > 7 else {},
-        auto_metadata=tuple_data[8] if len(tuple_data) > 8 else {},
-        shock_ref=str(tuple_data[9]) if len(tuple_data) > 9 and tuple_data[9] else None,
-        data=str(tuple_data[11]) if len(tuple_data) > 11 and tuple_data[11] else None,
+        path=path,
+        name=name,
+        type=str(slot(1)) if slot(1) else "",
+        owner=str(slot(5)) if slot(5) else "",
+        creation_time=str(slot(3)) if slot(3) else "",
+        id=str(slot(4)) if slot(4) else "",
+        size=int(slot(6)) if slot(6) else 0,
+        user_metadata=slot(7) or {},
+        auto_metadata=slot(8) or {},
+        user_permission=str(slot(9)) if slot(9) else None,
+        global_permission=str(slot(10)) if slot(10) else None,
+        shock_url=str(slot(11)) if slot(11) else None,
+        error=str(slot(12)) if slot(12) else None,
     )
+
+
+def _parse_workspace_get_entry(entry: list[Any]) -> WorkspaceObject:
+    """Parse one ``[ObjectMeta, ObjectData]`` pair returned by ``Workspace.get``.
+
+    ``Workspace.spec`` declares ``get(...) returns (list<tuple<ObjectMeta,ObjectData>>)``
+    — each entry is a pair, not the metadata tuple itself (issue #171). A bare
+    metadata tuple is still accepted.
+    """
+    if entry and isinstance(entry[0], list):
+        obj = _parse_workspace_object(entry[0])
+        if len(entry) > 1 and entry[1]:
+            obj.data = str(entry[1])
+        return obj
+    return _parse_workspace_object(entry)

--- a/mcp-servers/python/src/bvbrc_mcp/server.py
+++ b/mcp-servers/python/src/bvbrc_mcp/server.py
@@ -59,7 +59,11 @@ TOOLS = [
     ),
     Tool(
         name="workspace_upload",
-        description="Upload file content to the BV-BRC workspace",
+        description=(
+            "Upload TEXT content to the BV-BRC workspace. The content travels in a "
+            "JSON string, so it must be valid UTF-8; binary files uploaded this way "
+            "are silently corrupted (issue #172) and must go through Shock instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {

--- a/pkg/bvbrc/types.go
+++ b/pkg/bvbrc/types.go
@@ -148,9 +148,26 @@ const (
 )
 
 // WorkspaceObject represents a file or folder in the BV-BRC workspace.
+//
+// It is decoded from the service's ObjectMeta tuple. The authoritative layout is
+// the ObjectMeta typedef in the Workspace module's Workspace.spec (13 slots;
+// _generate_object_meta in WorkspaceImpl.pm emits the first 12, omitting the
+// trailing error slot):
+//
+//	0 ObjectName          6 ObjectSize         12 error
+//	1 ObjectType          7 UserMetadata
+//	2 FullObjectPath      8 AutoMetadata
+//	3 creation_time       9 user_permission
+//	4 ObjectID           10 global_permission
+//	5 object_owner       11 shockurl
 type WorkspaceObject struct {
-	// Path is the full workspace path.
+	// Path is the full workspace path: the directory in slot [2] joined with the
+	// name in slot [0], the way the service's own clients compose it
+	// (FileListing.pm, WorkspaceClientExt.pm).
 	Path string `json:"path"`
+
+	// Name is the object's own name, without the directory prefix.
+	Name string `json:"name"`
 
 	// Type is the object type.
 	Type WorkspaceObjectType `json:"type"`
@@ -164,9 +181,6 @@ type WorkspaceObject struct {
 	// ID is the unique object identifier (UUID).
 	ID string `json:"id"`
 
-	// OwnerID is the owner's identifier.
-	OwnerID string `json:"owner_id"`
-
 	// Size is the file size in bytes.
 	Size int64 `json:"size"`
 
@@ -176,13 +190,23 @@ type WorkspaceObject struct {
 	// AutoMetadata contains system-generated metadata.
 	AutoMetadata map[string]string `json:"auto_metadata"`
 
-	// ShockRef indicates storage type ("shock" or "inline").
-	ShockRef string `json:"shock_ref,omitempty"`
+	// UserPermission is the calling user's permission on the owning workspace
+	// ("o", "w", "r" or "n").
+	UserPermission string `json:"user_permission,omitempty"`
 
-	// ShockNodeID is the Shock node identifier for large files.
-	ShockNodeID string `json:"shock_node_id,omitempty"`
+	// GlobalPermission is the owning workspace's global permission.
+	GlobalPermission string `json:"global_permission,omitempty"`
 
-	// Data contains inline file content (for small files).
+	// ShockURL is the full URL of the backing Shock node. It is set when the
+	// object is Shock-backed, and in particular when the object was just created
+	// as an upload node — that is the URL file bytes must be PUT to.
+	ShockURL string `json:"shock_url,omitempty"`
+
+	// Error is set when the service reported a per-object error.
+	Error string `json:"error,omitempty"`
+
+	// Data holds the object content returned alongside the metadata by
+	// Workspace.get, which yields [ObjectMeta, ObjectData] pairs.
 	Data string `json:"data,omitempty"`
 }
 

--- a/pkg/bvbrc/workspace.go
+++ b/pkg/bvbrc/workspace.go
@@ -1,9 +1,15 @@
 package bvbrc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"path"
+	"strings"
 	"time"
 )
 
@@ -91,7 +97,9 @@ func (c *Client) WorkspaceGet(ctx context.Context, input WorkspaceGetInput) ([]W
 		return nil, err
 	}
 
-	// Result is [[[obj_tuple], ...]]
+	// Workspace.spec: get(...) returns (list<tuple<ObjectMeta,ObjectData>>).
+	// Wrapped in the JSON-RPC result array, that is [[[meta, data], ...]] — each
+	// entry is a two-element pair, *not* the metadata tuple itself (issue #171).
 	var rawResult [][][]any
 	if err := json.Unmarshal(resp.Result, &rawResult); err != nil {
 		return nil, WrapError("WorkspaceGet", fmt.Errorf("unmarshaling result: %w", err))
@@ -102,8 +110,8 @@ func (c *Client) WorkspaceGet(ctx context.Context, input WorkspaceGetInput) ([]W
 	}
 
 	objects := make([]WorkspaceObject, 0, len(rawResult[0]))
-	for _, tuple := range rawResult[0] {
-		obj, err := parseWorkspaceObjectTuple(tuple)
+	for _, entry := range rawResult[0] {
+		obj, err := parseWorkspaceGetEntry(entry)
 		if err != nil {
 			continue
 		}
@@ -111,6 +119,33 @@ func (c *Client) WorkspaceGet(ctx context.Context, input WorkspaceGetInput) ([]W
 	}
 
 	return objects, nil
+}
+
+// parseWorkspaceGetEntry parses one [ObjectMeta, ObjectData] pair as returned by
+// Workspace.get. The data half is optional: metadata_only requests and older
+// deployments may return a bare metadata tuple, which is accepted as well.
+func parseWorkspaceGetEntry(entry []any) (WorkspaceObject, error) {
+	if len(entry) == 0 {
+		return WorkspaceObject{}, fmt.Errorf("empty get entry")
+	}
+
+	meta, ok := entry[0].([]any)
+	if !ok {
+		// Not a [meta, data] pair — treat the entry itself as the metadata tuple.
+		return parseWorkspaceObjectTuple(entry)
+	}
+
+	obj, err := parseWorkspaceObjectTuple(meta)
+	if err != nil {
+		return obj, err
+	}
+	if len(entry) > 1 {
+		if s, ok := entry[1].(string); ok {
+			obj.Data = s
+		}
+	}
+
+	return obj, nil
 }
 
 // WorkspaceCreateInput contains parameters for creating workspace objects.
@@ -188,14 +223,91 @@ func (c *Client) WorkspaceCreateFolder(ctx context.Context, path string) (*Works
 	})
 }
 
-// WorkspaceUpload uploads content to the workspace.
-func (c *Client) WorkspaceUpload(ctx context.Context, path, content string, objType WorkspaceObjectType) (*WorkspaceObject, error) {
-	return c.WorkspaceCreate(ctx, WorkspaceCreateInput{
-		Path:      path,
-		Type:      objType,
-		Content:   &content,
-		Overwrite: true,
+// WorkspaceUploadFile uploads file bytes to the workspace, binary-safe.
+//
+// It follows the service's own upload protocol, the one implemented by
+// scripts/ws-create.pl --useshock and used by the BV-BRC clients:
+//
+//  1. Workspace.create the destination with createUploadNodes set, which
+//     allocates a Shock node and returns its URL in ObjectMeta slot [11];
+//  2. PUT the raw bytes to that URL as multipart form field "upload", with
+//     an "Authorization: OAuth <token>" header.
+//
+// Do not be tempted back to Workspace.create's inline Content field: it is a
+// JSON string, and encoding/json replaces every byte that is not valid UTF-8
+// with U+FFFD (3 bytes for 1), silently destroying every binary file that goes
+// through it. That was issue #172.
+func (c *Client) WorkspaceUploadFile(ctx context.Context, wsPath string, data []byte, objType WorkspaceObjectType) (*WorkspaceObject, error) {
+	obj, err := c.WorkspaceCreate(ctx, WorkspaceCreateInput{
+		Path:              wsPath,
+		Type:              objType,
+		Overwrite:         true,
+		CreateUploadNodes: true,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	if obj.ShockURL == "" {
+		// Never fall back to the inline path: for a binary payload that would
+		// silently store corrupt bytes. Fail loudly instead.
+		return nil, NewError("WorkspaceUploadFile",
+			fmt.Sprintf("no Shock upload URL returned for %s (ObjectMeta slot 11 empty)", wsPath))
+	}
+
+	if err := c.shockUpload(ctx, obj.ShockURL, path.Base(wsPath), data); err != nil {
+		return nil, WrapError("WorkspaceUploadFile", err)
+	}
+
+	return obj, nil
+}
+
+// shockUpload PUTs data to a Shock node URL as multipart form field "upload".
+// Mirrors scripts/ws-create.pl: a multipart/form-data body sent with the PUT
+// method and an "OAuth <token>" Authorization header.
+func (c *Client) shockUpload(ctx context.Context, shockURL, filename string, data []byte) error {
+	if filename == "" {
+		filename = "upload"
+	}
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("upload", filename)
+	if err != nil {
+		return fmt.Errorf("building multipart body: %w", err)
+	}
+	if _, err := part.Write(data); err != nil {
+		return fmt.Errorf("building multipart body: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("building multipart body: %w", err)
+	}
+
+	// bytes.Reader gives the request a known Content-Length; Shock is not
+	// verified to accept a chunked body.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, shockURL, bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		return fmt.Errorf("creating Shock request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if c.config.Token != "" {
+		req.Header.Set("Authorization", "OAuth "+c.config.Token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("Shock upload request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return &HTTPError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+	// Drain so the connection can be reused.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+
+	return nil
 }
 
 // WorkspaceDeleteInput contains parameters for deleting workspace objects.
@@ -423,8 +535,20 @@ func (c *Client) WorkspaceGetDownloadURL(ctx context.Context, paths []string) (m
 	return result, nil
 }
 
-// parseWorkspaceObjectTuple parses a workspace object tuple into a WorkspaceObject.
-// Tuple format: [path, type, owner, creation_time, id, owner_id, size, user_meta, auto_meta, shock_ref, shock_node, ?data]
+// parseWorkspaceObjectTuple parses a Workspace ObjectMeta tuple into a WorkspaceObject.
+//
+// The layout is the ObjectMeta typedef in the Workspace module's Workspace.spec:
+//
+//	[ObjectName, ObjectType, FullObjectPath, creation_time, ObjectID, object_owner,
+//	 ObjectSize, UserMetadata, AutoMetadata, user_permission, global_permission,
+//	 shockurl, error]
+//
+// The spec declares 13 slots but WorkspaceImpl.pm's _generate_object_meta returns
+// the first 12 (no error slot), so every slot past 8 is optional here.
+//
+// Note in particular that shockurl is slot [11], not [10]: [9] and [10] are the
+// user and global permission strings ("o", "w", "r", "n"). Reading [10] as a Shock
+// reference yields a permission letter — see issue #171.
 func parseWorkspaceObjectTuple(tuple []any) (WorkspaceObject, error) {
 	obj := WorkspaceObject{}
 
@@ -432,19 +556,21 @@ func parseWorkspaceObjectTuple(tuple []any) (WorkspaceObject, error) {
 		return obj, fmt.Errorf("tuple too short: %d elements", len(tuple))
 	}
 
-	// Index 0: path
+	// Index 0: ObjectName
 	if s, ok := tuple[0].(string); ok {
-		obj.Path = s
+		obj.Name = s
 	}
 
-	// Index 1: type
+	// Index 1: ObjectType
 	if s, ok := tuple[1].(string); ok {
 		obj.Type = WorkspaceObjectType(s)
 	}
 
-	// Index 2: owner
+	// Index 2: FullObjectPath — emitted as the containing directory with a
+	// trailing slash; the service's own clients form the object path as
+	// tuple[2] . tuple[0] (FileListing.pm, WorkspaceClientExt.pm).
 	if s, ok := tuple[2].(string); ok {
-		obj.Owner = s
+		obj.Path = joinWorkspacePath(s, obj.Name)
 	}
 
 	// Index 3: creation_time
@@ -454,17 +580,17 @@ func parseWorkspaceObjectTuple(tuple []any) (WorkspaceObject, error) {
 		}
 	}
 
-	// Index 4: id
+	// Index 4: ObjectID
 	if s, ok := tuple[4].(string); ok {
 		obj.ID = s
 	}
 
-	// Index 5: owner_id
+	// Index 5: object_owner
 	if s, ok := tuple[5].(string); ok {
-		obj.OwnerID = s
+		obj.Owner = s
 	}
 
-	// Index 6: size
+	// Index 6: ObjectSize
 	switch v := tuple[6].(type) {
 	case float64:
 		obj.Size = int64(v)
@@ -474,7 +600,7 @@ func parseWorkspaceObjectTuple(tuple []any) (WorkspaceObject, error) {
 		obj.Size = int64(v)
 	}
 
-	// Index 7: user_metadata
+	// Index 7: UserMetadata
 	if m, ok := tuple[7].(map[string]any); ok {
 		obj.UserMetadata = make(map[string]string)
 		for k, v := range m {
@@ -484,7 +610,7 @@ func parseWorkspaceObjectTuple(tuple []any) (WorkspaceObject, error) {
 		}
 	}
 
-	// Index 8: auto_metadata
+	// Index 8: AutoMetadata
 	if m, ok := tuple[8].(map[string]any); ok {
 		obj.AutoMetadata = make(map[string]string)
 		for k, v := range m {
@@ -494,26 +620,49 @@ func parseWorkspaceObjectTuple(tuple []any) (WorkspaceObject, error) {
 		}
 	}
 
-	// Index 9: shock_ref (if present)
+	// Index 9: user_permission
 	if len(tuple) > 9 {
 		if s, ok := tuple[9].(string); ok {
-			obj.ShockRef = s
+			obj.UserPermission = s
 		}
 	}
 
-	// Index 10: shock_node (if present)
+	// Index 10: global_permission
 	if len(tuple) > 10 {
 		if s, ok := tuple[10].(string); ok {
-			obj.ShockNodeID = s
+			obj.GlobalPermission = s
 		}
 	}
 
-	// Index 11: data (if present and not metadata_only)
+	// Index 11: shockurl
 	if len(tuple) > 11 {
 		if s, ok := tuple[11].(string); ok {
-			obj.Data = s
+			obj.ShockURL = s
+		}
+	}
+
+	// Index 12: error
+	if len(tuple) > 12 {
+		if s, ok := tuple[12].(string); ok {
+			obj.Error = s
 		}
 	}
 
 	return obj, nil
+}
+
+// joinWorkspacePath joins the directory slot of an ObjectMeta tuple with the
+// object name. The service emits the directory with a trailing slash; tolerate
+// its absence.
+func joinWorkspacePath(dir, name string) string {
+	switch {
+	case name == "":
+		return dir
+	case dir == "":
+		return name
+	case strings.HasSuffix(dir, "/"):
+		return dir + name
+	default:
+		return dir + "/" + name
+	}
 }

--- a/pkg/bvbrc/workspace_test.go
+++ b/pkg/bvbrc/workspace_test.go
@@ -1,0 +1,491 @@
+package bvbrc
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeWorkspace is an httptest-backed stand-in for the Workspace JSON-RPC
+// endpoint plus the Shock node endpoint it hands out. It records exactly what
+// each side received so tests can assert on the wire protocol, not just on the
+// happy path.
+type fakeWorkspace struct {
+	t   *testing.T
+	srv *httptest.Server
+
+	mu sync.Mutex
+
+	// CreateCalls holds the decoded "objects" entry of every Workspace.create.
+	CreateCalls []createCall
+
+	// ShockPuts holds the body of every multipart PUT, keyed by node id.
+	ShockPuts map[string][]byte
+	// ShockMeta records the request shape of the last Shock upload.
+	ShockMeta shockRequest
+
+	nextNode int
+}
+
+type createCall struct {
+	Path              string
+	Type              string
+	Content           any
+	CreateUploadNodes bool
+	Overwrite         bool
+}
+
+type shockRequest struct {
+	Method        string
+	Authorization string
+	FormField     string
+	Filename      string
+	ContentLength int64
+}
+
+func newFakeWorkspace(t *testing.T) *fakeWorkspace {
+	t.Helper()
+	f := &fakeWorkspace{t: t, ShockPuts: map[string][]byte{}}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeWorkspace) URL() string { return f.srv.URL + "/services/Workspace" }
+
+func (f *fakeWorkspace) handle(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/shock_api/node/") {
+		f.handleShock(w, r)
+		return
+	}
+	f.handleRPC(w, r)
+}
+
+func (f *fakeWorkspace) handleRPC(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Method string            `json:"method"`
+		Params []json.RawMessage `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.Method != "Workspace.create" {
+		http.Error(w, "unexpected method "+req.Method, http.StatusNotImplemented)
+		return
+	}
+
+	var params struct {
+		Objects           [][]any `json:"objects"`
+		CreateUploadNodes bool    `json:"createUploadNodes"`
+		Overwrite         bool    `json:"overwrite"`
+	}
+	if len(req.Params) == 0 {
+		http.Error(w, "no params", http.StatusBadRequest)
+		return
+	}
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(params.Objects) == 0 || len(params.Objects[0]) < 2 {
+		http.Error(w, "no objects", http.StatusBadRequest)
+		return
+	}
+
+	spec := params.Objects[0]
+	call := createCall{
+		CreateUploadNodes: params.CreateUploadNodes,
+		Overwrite:         params.Overwrite,
+	}
+	call.Path, _ = spec[0].(string)
+	call.Type, _ = spec[1].(string)
+	if len(spec) > 3 {
+		call.Content = spec[3]
+	}
+
+	f.mu.Lock()
+	f.CreateCalls = append(f.CreateCalls, call)
+	shockURL := ""
+	if params.CreateUploadNodes {
+		f.nextNode++
+		shockURL = f.srv.URL + "/shock_api/node/" + nodeID(f.nextNode)
+	}
+	f.mu.Unlock()
+
+	// A 12-slot ObjectMeta, shaped exactly like WorkspaceImpl.pm's
+	// _generate_object_meta: it stops at shockurl and omits the error slot.
+	dir, name := splitLast(call.Path)
+	meta := []any{
+		name,                            // 0 ObjectName
+		call.Type,                       // 1 ObjectType
+		dir,                             // 2 FullObjectPath (directory, trailing /)
+		"2026-08-20T12:00:00Z",          // 3 creation_time
+		"11111111-2222-3333-4444-5555",  // 4 ObjectID
+		"someuser@bvbrc",                // 5 object_owner
+		0,                               // 6 ObjectSize
+		map[string]any{},                // 7 UserMetadata
+		map[string]any{"is_folder": ""}, // 8 AutoMetadata
+		"o",                             // 9 user_permission
+		"n",                             // 10 global_permission
+		shockURL,                        // 11 shockurl
+	}
+
+	writeRPCResult(w, [][]any{meta})
+}
+
+func (f *fakeWorkspace) handleShock(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/shock_api/node/")
+
+	rec := shockRequest{
+		Method:        r.Method,
+		Authorization: r.Header.Get("Authorization"),
+		ContentLength: r.ContentLength,
+	}
+
+	_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		http.Error(w, "bad content type: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	mr := multipart.NewReader(r.Body, params["boundary"])
+	part, err := mr.NextPart()
+	if err != nil {
+		http.Error(w, "no multipart part: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	rec.FormField = part.FormName()
+	rec.Filename = part.FileName()
+	body, err := io.ReadAll(part)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	f.mu.Lock()
+	f.ShockPuts[id] = body
+	f.ShockMeta = rec
+	f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":200,"data":{"id":"` + id + `"}}`))
+}
+
+// LastShockUpload returns the bytes of the most recent Shock PUT.
+func (f *fakeWorkspace) LastShockUpload() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ShockPuts[nodeID(f.nextNode)]
+}
+
+func writeRPCResult(w http.ResponseWriter, result any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":      "1",
+		"version": "1.1",
+		"result":  []any{result},
+	})
+}
+
+func nodeID(n int) string {
+	return "node-" + string(rune('a'+n-1))
+}
+
+func splitLast(p string) (dir, name string) {
+	i := strings.LastIndex(p, "/")
+	if i < 0 {
+		return "", p
+	}
+	return p[:i+1], p[i+1:]
+}
+
+// allBytesPayload returns a payload containing every byte value 0x00–0xFF.
+func allBytesPayload() []byte {
+	b := make([]byte, 256)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return b
+}
+
+func testClient(f *fakeWorkspace, token string) *Client {
+	return NewClient(Config{
+		WorkspaceURL: f.URL(),
+		Token:        token,
+		Timeout:      10 * time.Second,
+	}, nil)
+}
+
+func TestWorkspaceUploadFile_BinaryRoundTrip(t *testing.T) {
+	f := newFakeWorkspace(t)
+	c := testClient(f, "un=tester|sig=deadbeef")
+
+	payload := allBytesPayload()
+	want := sha256.Sum256(payload)
+
+	obj, err := c.WorkspaceUploadFile(context.Background(),
+		"/tester@bvbrc/home/out/vectors.f32", payload, WorkspaceTypeUnspecified)
+	if err != nil {
+		t.Fatalf("WorkspaceUploadFile: %v", err)
+	}
+	if obj.Path != "/tester@bvbrc/home/out/vectors.f32" {
+		t.Errorf("object path = %q, want the full destination path", obj.Path)
+	}
+
+	got := sha256.Sum256(f.LastShockUpload())
+	if got != want {
+		t.Fatalf("sha256 mismatch: stored %x, uploaded %x (%d bytes stored, %d sent)",
+			got, want, len(f.LastShockUpload()), len(payload))
+	}
+}
+
+func TestWorkspaceUploadFile_ProtocolShape(t *testing.T) {
+	f := newFakeWorkspace(t)
+	c := testClient(f, "un=tester|sig=deadbeef")
+
+	if _, err := c.WorkspaceUploadFile(context.Background(),
+		"/tester@bvbrc/home/out/chunks.jsonl.gz", allBytesPayload(), WorkspaceTypeUnspecified); err != nil {
+		t.Fatalf("WorkspaceUploadFile: %v", err)
+	}
+
+	if len(f.CreateCalls) != 1 {
+		t.Fatalf("Workspace.create calls = %d, want 1", len(f.CreateCalls))
+	}
+	create := f.CreateCalls[0]
+	if !create.CreateUploadNodes {
+		t.Error("Workspace.create did not set createUploadNodes")
+	}
+	if !create.Overwrite {
+		t.Error("Workspace.create did not preserve overwrite semantics")
+	}
+	if create.Content != nil {
+		t.Errorf("Workspace.create carried inline content %v, want null — bytes must go via Shock", create.Content)
+	}
+
+	// ws-create.pl: PUT, multipart field "upload", Authorization: OAuth <token>.
+	if f.ShockMeta.Method != http.MethodPut {
+		t.Errorf("Shock method = %s, want PUT", f.ShockMeta.Method)
+	}
+	if f.ShockMeta.FormField != "upload" {
+		t.Errorf("Shock multipart field = %q, want \"upload\"", f.ShockMeta.FormField)
+	}
+	if f.ShockMeta.Filename != "chunks.jsonl.gz" {
+		t.Errorf("Shock filename = %q, want the object basename", f.ShockMeta.Filename)
+	}
+	if f.ShockMeta.Authorization != "OAuth un=tester|sig=deadbeef" {
+		t.Errorf("Shock Authorization = %q, want \"OAuth <token>\"", f.ShockMeta.Authorization)
+	}
+	if f.ShockMeta.ContentLength <= 0 {
+		t.Error("Shock request had no Content-Length; a chunked body is not verified to work")
+	}
+}
+
+// TestWorkspaceUploadFile_NoShockURLIsAnError pins the decision that an absent
+// Shock URL fails loudly rather than silently falling back to the inline path,
+// which would corrupt binary content.
+func TestWorkspaceUploadFile_NoShockURLIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		meta := []any{
+			"f.bin", "unspecified", "/tester@bvbrc/home/", "2026-08-20T12:00:00Z",
+			"id", "tester@bvbrc", 0, map[string]any{}, map[string]any{}, "o", "n", "",
+		}
+		writeRPCResult(w, [][]any{meta})
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{WorkspaceURL: srv.URL, Token: "t", Timeout: 5 * time.Second}, nil)
+	_, err := c.WorkspaceUploadFile(context.Background(), "/tester@bvbrc/home/f.bin", []byte{0xff}, WorkspaceTypeUnspecified)
+	if err == nil {
+		t.Fatal("expected an error when the create response carries no Shock URL")
+	}
+	if !strings.Contains(err.Error(), "slot 11") {
+		t.Errorf("error = %v, want it to name the empty ObjectMeta slot", err)
+	}
+}
+
+// TestJSONInlineContentCorruptsBinary is the regression pin for #172: it drives
+// the *old* inline path — file bytes handed to encoding/json as a string — and
+// asserts the exact corruption the issue documented.
+func TestJSONInlineContentCorruptsBinary(t *testing.T) {
+	gzipish := append([]byte{0x1f, 0x8b, 0x08, 0x00}, allBytesPayload()...)
+
+	tests := []struct {
+		name        string
+		payload     []byte
+		wantCorrupt bool
+	}{
+		{name: "every byte 0x00-0xFF", payload: allBytesPayload(), wantCorrupt: true},
+		{name: "gzip magic + binary", payload: gzipish, wantCorrupt: true},
+		{name: "float32 blob", payload: []byte{0x00, 0x00, 0x80, 0x3f, 0xcd, 0xcc, 0x4c, 0xbe}, wantCorrupt: true},
+		// Text is unaffected, which is why the corruption went unnoticed: the
+		// JSON manifests round-tripped byte-exact while every binary sibling did not.
+		{name: "ascii json manifest", payload: []byte(`{"files":[{"name":"a.txt","size":3}]}`), wantCorrupt: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFakeWorkspace(t)
+			c := testClient(f, "un=tester")
+
+			// This is precisely what the removed WorkspaceUpload did.
+			content := string(tt.payload)
+			if _, err := c.WorkspaceCreate(context.Background(), WorkspaceCreateInput{
+				Path:      "/tester@bvbrc/home/out/blob",
+				Type:      WorkspaceTypeUnspecified,
+				Content:   &content,
+				Overwrite: true,
+			}); err != nil {
+				t.Fatalf("WorkspaceCreate: %v", err)
+			}
+
+			received, ok := f.CreateCalls[0].Content.(string)
+			if !ok {
+				t.Fatalf("server received content of type %T, want string", f.CreateCalls[0].Content)
+			}
+			got := []byte(received)
+
+			if !tt.wantCorrupt {
+				if sha256.Sum256(got) != sha256.Sum256(tt.payload) {
+					t.Fatalf("text payload was altered in transit: %q vs %q", got, tt.payload)
+				}
+				return
+			}
+
+			if sha256.Sum256(got) == sha256.Sum256(tt.payload) {
+				t.Fatal("inline JSON round-trip preserved binary bytes; the regression pin is no longer meaningful")
+			}
+			replacements := strings.Count(received, "�")
+			if replacements == 0 {
+				t.Fatal("expected U+FFFD replacement characters in the round-tripped content")
+			}
+			// The issue's arithmetic: each invalid byte becomes a 3-byte U+FFFD,
+			// so the stored size grows by exactly 2 bytes per replacement —
+			// 105738 − 2×24261 = 57216 for the reported gzip.
+			if grew := len(got) - len(tt.payload); grew != 2*replacements {
+				t.Errorf("size grew by %d bytes for %d replacements, want %d",
+					grew, replacements, 2*replacements)
+			}
+		})
+	}
+}
+
+func TestParseWorkspaceObjectTuple_SpecLayout(t *testing.T) {
+	// Shaped like WorkspaceImpl.pm's _generate_object_meta: 12 slots, the
+	// directory in [2] with a trailing slash, permissions in [9]/[10], the Shock
+	// URL in [11].
+	tuple := []any{
+		"vectors.f32",
+		"unspecified",
+		"/tester@bvbrc/home/out/",
+		"2026-08-20T12:00:00Z",
+		"1a2b3c4d-0000-1111-2222-333344445555",
+		"tester@bvbrc",
+		float64(3948608),
+		map[string]any{"run": "42"},
+		map[string]any{"is_folder": "0"},
+		"o",
+		"n",
+		"https://example.invalid/services/shock_api/node/abc-123",
+	}
+
+	obj, err := parseWorkspaceObjectTuple(tuple)
+	if err != nil {
+		t.Fatalf("parseWorkspaceObjectTuple: %v", err)
+	}
+
+	if obj.Name != "vectors.f32" {
+		t.Errorf("Name = %q, want slot [0]", obj.Name)
+	}
+	if obj.Path != "/tester@bvbrc/home/out/vectors.f32" {
+		t.Errorf("Path = %q, want slot [2] joined with slot [0]", obj.Path)
+	}
+	if obj.Type != WorkspaceTypeUnspecified {
+		t.Errorf("Type = %q, want slot [1]", obj.Type)
+	}
+	if obj.Owner != "tester@bvbrc" {
+		t.Errorf("Owner = %q, want slot [5] — not the path in slot [2]", obj.Owner)
+	}
+	if obj.Size != 3948608 {
+		t.Errorf("Size = %d, want slot [6]", obj.Size)
+	}
+	if obj.UserMetadata["run"] != "42" {
+		t.Errorf("UserMetadata = %v, want slot [7]", obj.UserMetadata)
+	}
+	if obj.UserPermission != "o" || obj.GlobalPermission != "n" {
+		t.Errorf("permissions = %q/%q, want slots [9]/[10]", obj.UserPermission, obj.GlobalPermission)
+	}
+	if obj.ShockURL != "https://example.invalid/services/shock_api/node/abc-123" {
+		t.Errorf("ShockURL = %q, want slot [11] — slot [10] is the global permission", obj.ShockURL)
+	}
+	if obj.CreationTime.IsZero() {
+		t.Error("CreationTime not parsed from slot [3]")
+	}
+	if obj.Error != "" {
+		t.Errorf("Error = %q, want empty for a 12-slot tuple", obj.Error)
+	}
+}
+
+func TestParseWorkspaceObjectTuple_ThirteenSlotsCarryError(t *testing.T) {
+	tuple := []any{
+		"x", "unspecified", "/tester@bvbrc/home/", "2026-08-20T12:00:00Z",
+		"id", "tester@bvbrc", float64(0), map[string]any{}, map[string]any{},
+		"o", "n", "", "permission denied",
+	}
+	obj, err := parseWorkspaceObjectTuple(tuple)
+	if err != nil {
+		t.Fatalf("parseWorkspaceObjectTuple: %v", err)
+	}
+	if obj.Error != "permission denied" {
+		t.Errorf("Error = %q, want slot [12]", obj.Error)
+	}
+}
+
+func TestParseWorkspaceGetEntry_MetaDataPair(t *testing.T) {
+	// Workspace.spec: get(...) returns list<tuple<ObjectMeta,ObjectData>>.
+	meta := []any{
+		"manifest.json", "json", "/tester@bvbrc/home/out/", "2026-08-20T12:00:00Z",
+		"id-1", "tester@bvbrc", float64(1006), map[string]any{}, map[string]any{},
+		"o", "n", "",
+	}
+	entry := []any{meta, `{"files":[]}`}
+
+	obj, err := parseWorkspaceGetEntry(entry)
+	if err != nil {
+		t.Fatalf("parseWorkspaceGetEntry: %v", err)
+	}
+	if obj.Path != "/tester@bvbrc/home/out/manifest.json" {
+		t.Errorf("Path = %q, want the path from the meta half of the pair", obj.Path)
+	}
+	if obj.Data != `{"files":[]}` {
+		t.Errorf("Data = %q, want the ObjectData half of the pair", obj.Data)
+	}
+	if obj.Type != WorkspaceTypeJSON {
+		t.Errorf("Type = %q; the meta half was not parsed as ObjectMeta", obj.Type)
+	}
+}
+
+func TestParseWorkspaceGetEntry_BareMetaTuple(t *testing.T) {
+	// Defensive: a bare metadata tuple (no data half) must still parse.
+	meta := []any{
+		"manifest.json", "json", "/tester@bvbrc/home/out/", "2026-08-20T12:00:00Z",
+		"id-1", "tester@bvbrc", float64(1006), map[string]any{}, map[string]any{},
+		"o", "n", "",
+	}
+	obj, err := parseWorkspaceGetEntry(meta)
+	if err != nil {
+		t.Fatalf("parseWorkspaceGetEntry: %v", err)
+	}
+	if obj.Path != "/tester@bvbrc/home/out/manifest.json" {
+		t.Errorf("Path = %q", obj.Path)
+	}
+}

--- a/pkg/staging/workspace.go
+++ b/pkg/staging/workspace.go
@@ -169,7 +169,7 @@ func (s *WorkspaceStager) StageOut(ctx context.Context, srcPath string, taskID s
 			}
 		}
 
-		err := s.upload(ctx, destPath, string(data), token)
+		err := s.upload(ctx, destPath, data, token)
 		if err == nil {
 			return "ws://" + destPath, nil
 		}
@@ -269,7 +269,7 @@ func (s *WorkspaceStager) UploadContent(ctx context.Context, destPath string, co
 			}
 		}
 
-		err := s.upload(ctx, destPath, content, token)
+		err := s.upload(ctx, destPath, []byte(content), token)
 		if err == nil {
 			return "ws://" + destPath, nil
 		}
@@ -282,7 +282,13 @@ func (s *WorkspaceStager) UploadContent(ctx context.Context, destPath string, co
 }
 
 // upload creates/overwrites a file in the workspace.
-func (s *WorkspaceStager) upload(ctx context.Context, wsPath string, content string, token string) error {
+//
+// The bytes travel through Shock (Workspace.create with createUploadNodes, then a
+// multipart PUT to the returned node URL), never through Workspace.create's inline
+// JSON string field — that field runs the content through encoding/json, which
+// replaces every byte that is not valid UTF-8 with U+FFFD and silently corrupts
+// every binary output. See issue #172 and bvbrc.Client.WorkspaceUploadFile.
+func (s *WorkspaceStager) upload(ctx context.Context, wsPath string, data []byte, token string) error {
 	bvbrcCfg := bvbrc.Config{
 		WorkspaceURL: s.config.WorkspaceURL,
 		Token:        token,
@@ -290,7 +296,7 @@ func (s *WorkspaceStager) upload(ctx context.Context, wsPath string, content str
 	}
 	wsClient := bvbrc.NewClient(bvbrcCfg, s.logger)
 
-	_, err := wsClient.WorkspaceUpload(ctx, wsPath, content, bvbrc.WorkspaceTypeUnspecified)
+	_, err := wsClient.WorkspaceUploadFile(ctx, wsPath, data, bvbrc.WorkspaceTypeUnspecified)
 	if err != nil {
 		return fmt.Errorf("upload to %s: %w", wsPath, err)
 	}

--- a/pkg/staging/workspace_stageout_test.go
+++ b/pkg/staging/workspace_stageout_test.go
@@ -1,0 +1,243 @@
+package staging
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeWorkspaceService stands in for the Workspace JSON-RPC endpoint and the
+// Shock node it hands out, so the whole stage-out path can be exercised over
+// HTTP without touching a live service.
+type fakeWorkspaceService struct {
+	srv *httptest.Server
+
+	mu sync.Mutex
+	// Uploaded maps workspace destination path -> bytes received by Shock.
+	Uploaded map[string][]byte
+	// InlineContent maps destination path -> content sent inline via
+	// Workspace.create (should stay empty for file stage-out).
+	InlineContent map[string]string
+	// Auth records the Authorization header of the last Shock PUT.
+	Auth string
+	// Method records the HTTP method of the last Shock PUT.
+	Method string
+	// FormField records the multipart field name of the last Shock PUT.
+	FormField string
+
+	nodes map[string]string // node id -> destination path
+	seq   int
+}
+
+func newFakeWorkspaceService(t *testing.T) *fakeWorkspaceService {
+	t.Helper()
+	f := &fakeWorkspaceService{
+		Uploaded:      map[string][]byte{},
+		InlineContent: map[string]string{},
+		nodes:         map[string]string{},
+	}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeWorkspaceService) handle(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/shock_api/node/") {
+		f.handleShock(w, r)
+		return
+	}
+
+	var req struct {
+		Method string            `json:"method"`
+		Params []json.RawMessage `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Method != "Workspace.create" || len(req.Params) == 0 {
+		http.Error(w, "unexpected call "+req.Method, http.StatusNotImplemented)
+		return
+	}
+
+	var params struct {
+		Objects           [][]any `json:"objects"`
+		CreateUploadNodes bool    `json:"createUploadNodes"`
+	}
+	if err := json.Unmarshal(req.Params[0], &params); err != nil || len(params.Objects) == 0 {
+		http.Error(w, "bad params", http.StatusBadRequest)
+		return
+	}
+
+	spec := params.Objects[0]
+	destPath, _ := spec[0].(string)
+	objType, _ := spec[1].(string)
+
+	f.mu.Lock()
+	if len(spec) > 3 {
+		if s, ok := spec[3].(string); ok && s != "" {
+			f.InlineContent[destPath] = s
+		}
+	}
+	shockURL := ""
+	if params.CreateUploadNodes {
+		f.seq++
+		id := "node-" + destPath
+		f.nodes[id] = destPath
+		shockURL = f.srv.URL + "/shock_api/node/" + id
+	}
+	f.mu.Unlock()
+
+	dir, name := destPath, ""
+	if i := strings.LastIndex(destPath, "/"); i >= 0 {
+		dir, name = destPath[:i+1], destPath[i+1:]
+	}
+
+	// 12-slot ObjectMeta, as WorkspaceImpl.pm's _generate_object_meta emits it.
+	meta := []any{
+		name, objType, dir, "2026-08-20T12:00:00Z",
+		"uuid-1", "tester@bvbrc", 0,
+		map[string]any{}, map[string]any{},
+		"o", "n", shockURL,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id": "1", "version": "1.1",
+		"result": []any{[][]any{meta}},
+	})
+}
+
+func (f *fakeWorkspaceService) handleShock(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/shock_api/node/")
+
+	_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	part, err := multipart.NewReader(r.Body, params["boundary"]).NextPart()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	body, err := io.ReadAll(part)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	f.mu.Lock()
+	f.Uploaded[f.nodes[id]] = body
+	f.Auth = r.Header.Get("Authorization")
+	f.Method = r.Method
+	f.FormField = part.FormName()
+	f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":200}`))
+}
+
+func (f *fakeWorkspaceService) bytesAt(path string) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.Uploaded[path]
+}
+
+// TestWorkspaceStageOut_BinaryRoundTrip is the fix for #172: a stage-out of a
+// payload containing every byte value must land byte-for-byte identical.
+func TestWorkspaceStageOut_BinaryRoundTrip(t *testing.T) {
+	payload := make([]byte, 0, 4096)
+	for rep := 0; rep < 16; rep++ {
+		for i := 0; i < 256; i++ {
+			payload = append(payload, byte(i))
+		}
+	}
+	want := sha256.Sum256(payload)
+
+	src := filepath.Join(t.TempDir(), "chunks.jsonl.gz")
+	if err := os.WriteFile(src, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := newFakeWorkspaceService(t)
+	stager := NewWorkspaceStager(WorkspaceConfig{
+		WorkspaceURL: f.srv.URL + "/services/Workspace",
+		Token:        "un=tester|sig=abc",
+	}, nil)
+
+	loc, err := stager.StageOut(context.Background(), src, "task-1", StageOptions{
+		Metadata: map[string]string{"destination": "/tester@bvbrc/home/results/1"},
+	})
+	if err != nil {
+		t.Fatalf("StageOut: %v", err)
+	}
+
+	const dest = "/tester@bvbrc/home/results/1/chunks.jsonl.gz"
+	if loc != "ws://"+dest {
+		t.Errorf("StageOut location = %q, want %q", loc, "ws://"+dest)
+	}
+
+	stored := f.bytesAt(dest)
+	if got := sha256.Sum256(stored); got != want {
+		t.Fatalf("sha256 mismatch: stored %d bytes (%x), staged out %d bytes (%x)",
+			len(stored), got, len(payload), want)
+	}
+
+	if len(f.InlineContent) != 0 {
+		t.Errorf("file bytes were sent inline via Workspace.create for %v; they must go through Shock",
+			mapKeys(f.InlineContent))
+	}
+	if f.Method != http.MethodPut {
+		t.Errorf("Shock method = %s, want PUT", f.Method)
+	}
+	if f.FormField != "upload" {
+		t.Errorf("Shock multipart field = %q, want \"upload\"", f.FormField)
+	}
+	if f.Auth != "OAuth un=tester|sig=abc" {
+		t.Errorf("Shock Authorization = %q, want \"OAuth <token>\"", f.Auth)
+	}
+}
+
+// TestWorkspaceUploadContent_GoesThroughShock covers the manifest path
+// (_gowe_outputs.json), which is text but is routed identically so no caller is
+// left on the JSON-inline path.
+func TestWorkspaceUploadContent_GoesThroughShock(t *testing.T) {
+	f := newFakeWorkspaceService(t)
+	stager := NewWorkspaceStager(WorkspaceConfig{
+		WorkspaceURL: f.srv.URL + "/services/Workspace",
+		Token:        "un=tester",
+	}, nil)
+
+	const dest = "/tester@bvbrc/home/results/1/_gowe_outputs.json"
+	content := `{"outputs":{"out":"ws:///tester@bvbrc/home/results/1/a.bin"}}`
+
+	if _, err := stager.UploadContent(context.Background(), dest, content, StageOptions{}); err != nil {
+		t.Fatalf("UploadContent: %v", err)
+	}
+
+	if got := string(f.bytesAt(dest)); got != content {
+		t.Errorf("stored content = %q, want %q", got, content)
+	}
+	if len(f.InlineContent) != 0 {
+		t.Errorf("content was sent inline via Workspace.create for %v", mapKeys(f.InlineContent))
+	}
+}
+
+func mapKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Fixes #172. Fixes #171 — the two are entangled: the #172 fix PUTs bytes to the Shock URL carried in the Workspace `ObjectMeta` tuple, and GoWe was reading that URL from the wrong slot.

## The mechanism

`pkg/staging/workspace.go` `StageOut` read the output file into a `[]byte`, converted it to a Go string, and passed it down to `Workspace.create`'s inline `Content` field:

```go
data, err := os.ReadFile(srcPath)                    // []byte
err := s.upload(ctx, destPath, string(data), token)  // -> Go string -> JSON string field
```

`Content` is marshalled by `encoding/json`, which replaces **every byte that is not valid UTF-8 with U+FFFD** — 3 bytes replacing 1. Every non-text output the engine post-staged to a Workspace was stored corrupted, and unrecoverably so: the original bytes are gone from the stored copy.

It was silent by construction. The engine records the *pre-upload* size and reports `output_state=delivered`, and text outputs (JSON manifests) round-trip byte-exact, so nothing ever looked wrong until a downstream project's per-file sha256 manifest turned it into a loud failure.

### The byte arithmetic from #172

One submission, four outputs:

| file | engine-recorded size | stored in Workspace | integrity |
|---|---|---|---|
| `manifest.json` | 1006 | 1006 | ok (UTF-8) |
| `receipt.json` | 23852 | 23852 | ok (UTF-8) |
| `chunks.jsonl.gz` | 57216 | **105738** | sha256 mismatch |
| `vectors.f32` | 3948608 | **6827272** | sha256 mismatch |

It closes exactly, because each replacement adds precisely 2 bytes:

- `105738 − 2×24261 = 57216` — 24,261 bytes replaced
- `6827272 − 2×1439332 = 3948608` — 1,439,332 bytes replaced

## The fix

Stage-out now uses the service's own upload protocol — the one `scripts/ws-create.pl --useshock` implements and the BV-BRC clients use:

1. `Workspace.create` for the destination with `createUploadNodes` set (existing `overwrite` semantics preserved), which allocates a Shock node and returns its URL in the object tuple;
2. `PUT` the raw bytes to that URL as multipart form field `upload`, with `Authorization: OAuth <token>`.

The inline JSON path is **not** kept as a small-file shortcut. There is no size below which routing bytes through a JSON string is correct, and text files are equally correct through Shock — so `WorkspaceUpload` is gone entirely, replaced by `WorkspaceUploadFile`, and every caller is migrated. Nothing is left that can put file bytes back into the JSON field.

An empty Shock URL in the create response is a **hard error**, never a silent fallback to inline: silent corruption is the bug being fixed.

## The ObjectMeta index correction (#171)

GoWe read the Shock URL from slot `[10]`. That slot is the **global permission letter** (`"n"`, `"o"`). PUTting file bytes to a permission string is what the #172 fix would have done had #171 not been fixed with it.

Primary sources, all in the Workspace service module's own tree:

- **`Workspace.spec`**, the `ObjectMeta` typedef — a 13-slot tuple: `[ObjectName, ObjectType, FullObjectPath, creation_time, ObjectID, object_owner, ObjectSize, UserMetadata, AutoMetadata, user_permission, global_permission, shockurl, error]`. **`shockurl` is index 11**; the doc comment above the typedef names each slot.
- **`scripts/ws-create.pl:56-61`** — the service's own upload path reads `my $shock_url = $item->[11];`, then sends `Content => [upload => [$filename]]` as `multipart/form-data` with `Authorization => "OAuth " . $token->token`, with the method forced to `PUT`.
- **`lib/Bio/P3/Workspace/WorkspaceImpl.pm`**, `_generate_object_meta` — builds the tuple in that order, and **emits only 12 slots**, omitting the trailing `error`. Parsers must therefore tolerate a 12-element tuple; the POD in the same file repeats `11: (shockurl) a string`.
- **`lib/Bio/P3/Workspace/ScriptHelpers.pm:56-57`** — destructures the same order into named variables.
- **`lib/Bio/P3/Workspace/FileListing.pm:36`** and **`WorkspaceClientExt.pm:66`** — both compose an object's full path as `$res->[2] . $res->[0]`, i.e. **the path is slot [2] (the containing directory, with a trailing slash) joined with the name in slot [0]** — not slot [0] alone, which is what GoWe used.

The line that settles the Shock slot is `ws-create.pl:56`:

```perl
my $shock_url = $item->[11];
```

Also from #171: `Workspace.spec` declares `get(...) returns (list<tuple<ObjectMeta,ObjectData>>)`, so each `Workspace.get` entry is a `[meta, data]` **pair**, not the metadata tuple itself. `WorkspaceGet` now unpacks the pair (and still accepts a bare metadata tuple defensively).

### Corrected layout as implemented

| slot | field | was parsed as |
|---|---|---|
| 0 | `ObjectName` | path |
| 1 | `ObjectType` | type ✓ |
| 2 | `FullObjectPath` (directory, trailing `/`) | owner |
| 3 | `creation_time` | ✓ |
| 4 | `ObjectID` | ✓ |
| 5 | `object_owner` | owner_id |
| 6 | `ObjectSize` | ✓ |
| 7 | `UserMetadata` | ✓ |
| 8 | `AutoMetadata` | ✓ |
| 9 | `user_permission` | shock_ref |
| 10 | `global_permission` | **shock_node** ← the bug |
| 11 | `shockurl` | data |
| 12 | `error` | — |

## What changed

- **`pkg/bvbrc/workspace.go`** — `WorkspaceUpload` (inline) removed; `WorkspaceUploadFile` added (create-upload-node + multipart Shock PUT). `parseWorkspaceObjectTuple` rewritten to the spec layout. `parseWorkspaceGetEntry` added for `[meta, data]`.
- **`pkg/bvbrc/types.go`** — `WorkspaceObject`: `Path` is now the composed full path, `Name` added; `ShockRef`/`ShockNodeID`/`OwnerID` replaced by `ShockURL`, `UserPermission`, `GlobalPermission`, `Error`. No consumer outside the client read the old fields.
- **`pkg/staging/workspace.go`** — `StageOut` and `UploadContent` (the `_gowe_outputs.json` manifest) both route through Shock.
- **`internal/cli/submit.go`** — input upload migrated.
- **`internal/ui/handlers.go`** — the workspace upload handler had *two* defects: its `<10 MB` branch handed `Workspace.create` a raw `[]byte`, which `encoding/json` base64-encodes into the object; its `≥10 MB` branch read slot `[10]` and rebuilt a URL against a hardcoded Shock host. Both branches are replaced by the single Shock path using slot `[11]` verbatim. Its `uploadToShock` sent a bare token where Shock expects the `OAuth` scheme — corrected, flagged below as unverified.
- **`docs/BVBRC-API.md`** — the `ObjectMeta` table, the `Workspace.get` response format, the create/upload examples, the Go example (which recommended the inline branch), and the troubleshooting table.
- **`docs/BVBRC-Workspace-Deep-Dive.md`** — the Role-B post-stage description and the whole-file-in-memory edge.
- **`mcp-servers/python/src/bvbrc_mcp/client.py`** — the same tuple layout fix and `[meta, data]` unpacking (the other half of #171). Its `workspace_upload` MCP tool takes `content` as a JSON string argument, so it is inherently text-only; its description now says so rather than pretending to handle files.

## Testing

No live Workspace or Shock service was contacted, and no token was read. Everything runs against an `httptest` server that serves both the Workspace JSON-RPC endpoint and the Shock node it hands out, returning a 12-slot `ObjectMeta` shaped exactly like `_generate_object_meta`'s output.

- **`TestWorkspaceStageOut_BinaryRoundTrip`** — a real temp file of 4,096 bytes cycling every value 0x00–0xFF is staged out through the full `StageOut` path; **sha256 of what Shock received equals sha256 of what was written**. Verified to *fail* against the pre-fix inline path.
- **`TestWorkspaceUploadFile_BinaryRoundTrip`** — same assertion one layer down, over all 256 byte values.
- **`TestWorkspaceUploadFile_ProtocolShape`** — asserts the wire contract against `ws-create.pl`: `createUploadNodes` set, `overwrite` preserved, create carries **null** content, method is `PUT`, multipart field is `upload`, filename is the object basename, header is `Authorization: OAuth <token>`, and the request has a `Content-Length` (a chunked body is not verified to work against real Shock).
- **`TestJSONInlineContentCorruptsBinary`** — the regression pin. A table test drives the **old** inline path against the same server for four payloads (all 256 byte values; gzip magic + binary; a float32 blob; an ASCII manifest). For the binary rows it asserts the sha256 differs, U+FFFD is present, and **`len(stored) − len(sent) == 2 × count(U+FFFD)`** — the issue's arithmetic. The ASCII row asserts the text case is untouched, which is exactly why this went unnoticed for so long.
- **`TestWorkspaceUploadFile_NoShockURLIsAnError`** — pins the no-silent-fallback decision.
- **`TestParseWorkspaceObjectTuple_SpecLayout`**, **`_ThirteenSlotsCarryError`**, **`TestParseWorkspaceGetEntry_MetaDataPair`**, **`_BareMetaTuple`** — the tuple layout, the 12-vs-13-slot tolerance, and the `[meta, data]` unpacking.

`go build ./...`, `go vet ./...`, `gofmt -l .` and `go test ./...` are all clean (Go 1.23 toolchain; `-buildvcs=false` locally, an environment artefact only). The Python MCP client was syntax-checked; it has no test suite in this repo.

## ⚠️ The deployed engine must be rebuilt

**This fix does nothing until the server binary is rebuilt and redeployed.** The running engine was built from an older checkout; merging this PR does not change its behaviour. Rebuilding and restarting is a separate operator step, deliberately not performed here.

Note also that **already-staged binary outputs cannot be repaired** — the original bytes are not present in the stored copies. Anything staged out before the rebuilt binary is running has to be regenerated or re-uploaded from source.

## Not verified without a live service

- That real Shock accepts the multipart `PUT` exactly as constructed. The shape matches `ws-create.pl` byte-for-byte in method, field name and auth scheme, and matches the client whose uploads were confirmed byte-exact in #172's control experiment — but only a live upload proves it.
- The UI's `Authorization` header change (bare token → `OAuth <token>`). The bare-token form is a suspected latent bug on a code path that was already broken for a different reason; the OAuth scheme is what the service's own script sends.
- Whether `Workspace.get` ever returns a bare metadata tuple in some deployment. The defensive branch accepting one costs nothing and is tested.
- A storage-semantics shift for **text** stage-out, now that it also goes through Shock. `_retrieve_object_data` in `WorkspaceImpl.pm` returns the Shock node URL (after granting an ACL) as the `data` half of a `Workspace.get` result for Shock-backed objects, rather than inline content. GoWe's own read path is unaffected — `StageIn` uses `get_download_url` + HTTP GET, and no Go code calls `Workspace.get` — but an external consumer that read `_gowe_outputs.json` out of `Workspace.get`'s inline data would now receive a URL instead. Routing everything through Shock is the deliberate choice here; this is the one visible consequence.
- Streaming uploads. `StageOut` still buffers the whole file in memory — a pre-existing, documented edge, deliberately left unchanged: streaming means a chunked body, and Shock's acceptance of one cannot be verified here. Worth a follow-up with a computed `Content-Length`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FARymRfh5r8PFdy2BwtfLp
