### PR TITLE
fix(ui): typed Workspace client with session identity, seekable uploads, size cap

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,7 +50,7 @@ func main() {
 	// Scheduler options
 	schedulerPoll := flag.Duration("scheduler-poll", 2*time.Second, "Scheduler poll interval")
 	workspaceStaging := flag.String("workspace-staging", "", "Workspace staging mode: 'server' (pre/post-stage ws:// on server) or empty (passthrough to workers)")
-	wsStagingURL := flag.String("workspace-url", "", "BV-BRC Workspace service URL for server-side staging (default: production)")
+	wsStagingURL := flag.String("workspace-url", "", "BV-BRC Workspace service URL for server-side staging and the web UI workspace browser (default: production)")
 	preflightDeferral := flag.Int("preflight-deferral", 30, "Ticks to defer worker task dispatch when no capable worker exists (0=disable)")
 	stuckTaskThreshold := flag.Int("stuck-task-threshold", 30, "Consecutive zero-progress ticks before QUEUED tasks are flagged as stuck (0=disable)")
 	stuckTaskAction := flag.String("stuck-task-action", "warn", "Action for stuck tasks: 'warn' (log only) or 'fail' (also fail oldest task)")
@@ -69,7 +69,7 @@ func main() {
 
 	// File upload proxy options
 	uploadBackend := flag.String("upload-backend", "", "Enable file upload proxy with backend: shock, s3, local")
-	uploadMaxSize := flag.Int64("upload-max-size", 1<<30, "Maximum upload size in bytes (default: 1GB)")
+	uploadMaxSize := flag.Int64("upload-max-size", 1<<30, "Maximum upload size in bytes for the file proxy and web UI workspace uploads (default: 1GB)")
 
 	// Shock upload options
 	uploadShockHost := flag.String("upload-shock-host", "", "Shock server host for uploads (e.g., localhost:7445)")
@@ -204,9 +204,13 @@ func main() {
 	reg.Register(executor.NewWorkerExecutor(st, logger))
 
 	// Register BVBRCExecutor and create RPC callers if a token is available.
-	const workspaceURL = "https://p3.theseed.org/services/Workspace"
-
-	serverOpts := []server.Option{server.WithExecutorRegistry(reg)}
+	serverOpts := []server.Option{
+		server.WithExecutorRegistry(reg),
+		// The web UI browses and uploads to the Workspace as the logged-in
+		// user (session token), never as the server's service account.
+		server.WithWorkspaceURL(*wsStagingURL),
+		server.WithUIUploadMaxSize(*uploadMaxSize),
+	}
 
 	// Configure admin role assignment.
 	adminConfig := server.NewAdminConfig(st, "GOWE_ADMINS", *configFile)
@@ -328,11 +332,6 @@ func main() {
 			bvbrcCfg.Token = tok
 			defaultBVBRCCaller = bvbrc.NewHTTPRPCCaller(bvbrcCfg, logger)
 			serverOpts = append(serverOpts, server.WithBVBRCCaller(defaultBVBRCCaller))
-
-			// Workspace caller for workspace browsing.
-			wsCfg := bvbrc.ClientConfig{AppServiceURL: workspaceURL, Token: tok}
-			wsCaller := bvbrc.NewHTTPRPCCaller(wsCfg, logger)
-			serverOpts = append(serverOpts, server.WithWorkspaceCaller(wsCaller))
 
 			logger.Info("bvbrc service account ready", "username", tokenInfo.Username)
 		}

--- a/docs/tools/server.md
+++ b/docs/tools/server.md
@@ -31,7 +31,7 @@ gowe-server [flags]
 | `--config` | `""` | Path to server config file (for admins, worker keys) |
 | `--scheduler-poll` | `2s` | Scheduler poll interval |
 | `--workspace-staging` | `""` | Workspace staging mode: `server` (pre/post-stage `ws://` on server) or empty (passthrough to workers) |
-| `--workspace-url` | `""` | BV-BRC Workspace service URL for server-side staging (default: production) |
+| `--workspace-url` | `""` | BV-BRC Workspace service URL for server-side staging and the web UI workspace browser/uploads, which always run under the logged-in user's own token (default: production) |
 | `--log-level` | `info` | Log level: debug, info, warn, error |
 | `--log-format` | `text` | Log format: text, json |
 | `--debug` | `false` | Shorthand for `--log-level=debug` |
@@ -53,7 +53,7 @@ Environment variables:
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--upload-backend` | `""` | Enable file upload proxy: `shock`, `s3`, `local` |
-| `--upload-max-size` | `1073741824` (1 GB) | Maximum upload size in bytes |
+| `--upload-max-size` | `1073741824` (1 GB) | Maximum upload size in bytes, for the file proxy and for web UI workspace uploads (oversized bodies get 413) |
 | `--upload-local-dir` | `""` | Local directory for file uploads |
 | `--upload-download-dirs` | `""` | Comma-separated directories allowed for file download |
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,7 +29,8 @@ type Server struct {
 	scheduler        scheduler.Scheduler
 	registry         *executor.Registry      // optional; used by dry-run to check executor availability
 	bvbrcCaller      bvbrc.RPCCaller         // optional; AppService caller, nil when no BV-BRC token
-	workspaceCaller  bvbrc.RPCCaller         // optional; Workspace service caller
+	workspaceURL     string                  // optional; BV-BRC Workspace endpoint for the UI (empty = production)
+	uiUploadMaxSize  int64                   // optional; cap on UI workspace upload bodies (0 = ui default)
 	testApps         []map[string]any        // optional; static app list for testing without BV-BRC
 	ui               *ui.UI                  // UI handler for web interface
 	adminConfig      *AdminConfig            // optional; admin role configuration
@@ -56,10 +57,21 @@ func WithExecutorRegistry(reg *executor.Registry) Option {
 	}
 }
 
-// WithWorkspaceCaller sets the BV-BRC Workspace service caller.
-func WithWorkspaceCaller(caller bvbrc.RPCCaller) Option {
+// WithWorkspaceURL sets the BV-BRC Workspace service endpoint the web UI
+// uses for browsing and uploads. Every UI workspace call runs under the
+// logged-in user's own token; there is no server-side service-account
+// caller. Empty selects production.
+func WithWorkspaceURL(url string) Option {
 	return func(s *Server) {
-		s.workspaceCaller = caller
+		s.workspaceURL = url
+	}
+}
+
+// WithUIUploadMaxSize caps the request body of web UI workspace uploads, in
+// bytes. Zero keeps the UI's default (1 GB).
+func WithUIUploadMaxSize(n int64) Option {
+	return func(s *Server) {
+		s.uiUploadMaxSize = n
 	}
 }
 
@@ -118,12 +130,11 @@ func New(cfg config.ServerConfig, st store.Store, sched scheduler.Scheduler, log
 	s.ui = ui.New(st, logger, ui.Config{
 		SecureCookies:       cfg.SecureCookies || cfg.TLSEnabled(),
 		TrustForwardedProto: cfg.BehindProxy,
+		WorkspaceURL:        s.workspaceURL,
+		UploadMaxSize:       s.uiUploadMaxSize,
 	})
 	if s.bvbrcCaller != nil {
 		s.ui.WithBVBRCCaller(s.bvbrcCaller)
-	}
-	if s.workspaceCaller != nil {
-		s.ui.WithWorkspaceCaller(s.workspaceCaller)
 	}
 	if s.adminConfig != nil {
 		s.ui.WithAdminChecker(s.adminConfig)

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -4,20 +4,23 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
 	"log/slog"
-	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/me/gowe/internal/bvbrc"
 	"github.com/me/gowe/internal/store"
+	bvbrcpkg "github.com/me/gowe/pkg/bvbrc"
 	"github.com/me/gowe/pkg/model"
 )
 
@@ -28,13 +31,19 @@ type AdminChecker interface {
 
 // UI handles the web user interface.
 type UI struct {
-	store           store.Store
-	sessions        *SessionManager
-	logger          *slog.Logger
-	bvbrcCaller     bvbrc.RPCCaller // AppService caller
-	workspaceCaller bvbrc.RPCCaller // Workspace service caller
-	adminChecker    AdminChecker    // Admin role checker (nil = no admins)
-	startTime       time.Time
+	store        store.Store
+	sessions     *SessionManager
+	logger       *slog.Logger
+	bvbrcCaller  bvbrc.RPCCaller // AppService caller
+	adminChecker AdminChecker    // Admin role checker (nil = no admins)
+	startTime    time.Time
+
+	// workspaceURL is the BV-BRC Workspace JSON-RPC endpoint. Every
+	// workspace operation builds a per-request client against it with the
+	// session's token; see workspaceClient.
+	workspaceURL string
+	// uploadMaxSize caps the request body of a workspace upload.
+	uploadMaxSize int64
 
 	// Session cookie hardening.
 	secureCookies       bool // Always set the Secure attribute on session cookies
@@ -52,10 +61,28 @@ type Config struct {
 	// behind a trusted reverse proxy that sets this header, since a client can
 	// otherwise spoof it.
 	TrustForwardedProto bool
+	// WorkspaceURL is the BV-BRC Workspace service endpoint used by the
+	// workspace browser, the file picker and uploads. Empty selects
+	// production.
+	WorkspaceURL string
+	// UploadMaxSize is the largest workspace upload request body accepted,
+	// in bytes. Zero selects DefaultUploadMaxSize.
+	UploadMaxSize int64
 }
+
+// DefaultUploadMaxSize is the workspace upload cap when none is configured.
+const DefaultUploadMaxSize int64 = 1 << 30
 
 // New creates a new UI handler.
 func New(st store.Store, logger *slog.Logger, cfg Config) *UI {
+	workspaceURL := cfg.WorkspaceURL
+	if workspaceURL == "" {
+		workspaceURL = bvbrcpkg.DefaultWorkspaceURL
+	}
+	uploadMaxSize := cfg.UploadMaxSize
+	if uploadMaxSize <= 0 {
+		uploadMaxSize = DefaultUploadMaxSize
+	}
 	return &UI{
 		store:               st,
 		sessions:            NewSessionManager(st),
@@ -63,6 +90,8 @@ func New(st store.Store, logger *slog.Logger, cfg Config) *UI {
 		startTime:           time.Now(),
 		secureCookies:       cfg.SecureCookies,
 		trustForwardedProto: cfg.TrustForwardedProto,
+		workspaceURL:        workspaceURL,
+		uploadMaxSize:       uploadMaxSize,
 	}
 }
 
@@ -95,11 +124,6 @@ func (ui *UI) secureCookie(r *http.Request) bool {
 // WithBVBRCCaller sets the BV-BRC RPC caller for AppService operations.
 func (ui *UI) WithBVBRCCaller(caller bvbrc.RPCCaller) {
 	ui.bvbrcCaller = caller
-}
-
-// WithWorkspaceCaller sets the BV-BRC RPC caller for Workspace operations.
-func (ui *UI) WithWorkspaceCaller(caller bvbrc.RPCCaller) {
-	ui.workspaceCaller = caller
 }
 
 // WithAdminChecker sets the admin role checker.
@@ -1369,77 +1393,111 @@ func (ui *UI) HandleAdminLabelDelete(w http.ResponseWriter, r *http.Request) {
 
 // --- Workspace Handlers ---
 
-// getWorkspaceCaller returns a workspace caller, using the session token if no global caller is configured.
-func (ui *UI) getWorkspaceCaller(sess *model.Session) bvbrc.RPCCaller {
-	if ui.workspaceCaller != nil {
-		return ui.workspaceCaller
+// Workspace client settings for user-facing operations. Listings and the
+// JSON-RPC halves of an upload are short calls; the Shock PUT itself is
+// carried by the client's dedicated upload transport and bounded only by the
+// request context.
+const (
+	workspaceRPCTimeout    = 60 * time.Second
+	workspaceRPCRetries    = 3
+	workspaceUploadRetries = 3
+
+	// workspaceUploadMemory is the in-memory budget for parsing an upload
+	// form; parts beyond it spill to temporary files instead of RAM.
+	workspaceUploadMemory = 32 << 20
+)
+
+// errNoWorkspaceSession is returned when a workspace operation has no BV-BRC
+// token to act under.
+var errNoWorkspaceSession = errors.New("workspace access requires a BV-BRC login")
+
+// workspaceClient returns a typed Workspace client acting as the session's
+// user. Workspace operations always run under the SESSION token: the object
+// is created, PUT to Shock, and refreshed as the same identity, so ACLs on the
+// Workspace row and on the Shock node agree. There is deliberately no
+// service-account fallback — an object created by the service account inside
+// a user's home but written with the user's token is exactly the ACL mismatch
+// this replaced — so a session without a token cannot use the workspace.
+func (ui *UI) workspaceClient(sess *model.Session) (*bvbrcpkg.Client, error) {
+	if sess == nil || sess.Token == "" {
+		return nil, errNoWorkspaceSession
 	}
-	// Create a caller using the session token.
-	if sess != nil && sess.Token != "" {
-		cfg := bvbrc.ClientConfig{
-			AppServiceURL: "https://p3.theseed.org/services/Workspace",
-			Token:         sess.Token,
+	return bvbrcpkg.NewClient(bvbrcpkg.Config{
+		WorkspaceURL: ui.workspaceURL,
+		Token:        sess.Token,
+		Timeout:      workspaceRPCTimeout,
+		MaxRetries:   workspaceRPCRetries,
+		RetryDelay:   bvbrcpkg.DefaultRetryDelay,
+	}, ui.logger), nil
+}
+
+// workspaceHome is the default browsing root for a session.
+func workspaceHome(sess *model.Session) string {
+	return "/" + sess.Username + "/home"
+}
+
+// listWorkspaceDir lists one workspace directory and returns its entries. The
+// service keys its reply by the path it was given; tolerate a trailing slash
+// on either side.
+func listWorkspaceDir(ctx context.Context, client *bvbrcpkg.Client, dir string) ([]bvbrcpkg.WorkspaceObject, error) {
+	result, err := client.WorkspaceLs(ctx, bvbrcpkg.WorkspaceLsInput{Paths: []string{dir}})
+	if err != nil {
+		return nil, err
+	}
+
+	if items, ok := result[dir]; ok {
+		return items, nil
+	}
+	trimmed := strings.TrimSuffix(dir, "/")
+	if items, ok := result[trimmed]; ok {
+		return items, nil
+	}
+	if items, ok := result[trimmed+"/"]; ok {
+		return items, nil
+	}
+	if len(result) == 0 {
+		// The service answers with an empty map for a directory it knows
+		// but has nothing to report for; that is an empty listing.
+		return []bvbrcpkg.WorkspaceObject{}, nil
+	}
+	if len(result) == 1 {
+		// Single-path request: whatever key the service used is our listing.
+		for _, items := range result {
+			return items, nil
 		}
-		return bvbrc.NewHTTPRPCCaller(cfg, ui.logger)
 	}
-	return nil
+	return nil, fmt.Errorf("workspace listing for path %q not found in response", dir)
+}
+
+// writeJSONError writes a JSON error body the UI's JavaScript understands.
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
 // HandleWorkspaceAPI returns workspace listing as JSON (for file picker modal).
 func (ui *UI) HandleWorkspaceAPI(w http.ResponseWriter, r *http.Request) {
 	sess := SessionFromContext(r.Context())
 
-	caller := ui.getWorkspaceCaller(sess)
-	if caller == nil {
-		http.Error(w, `{"error": "Workspace not configured - please log in"}`, http.StatusServiceUnavailable)
-		return
-	}
-
-	path := r.URL.Query().Get("path")
-	if path == "" {
-		path = "/" + sess.Username + "/home"
-	}
-
-	result, err := caller.Call(r.Context(), "Workspace.ls", []any{
-		map[string]any{"paths": []string{path}},
-	})
+	client, err := ui.workspaceClient(sess)
 	if err != nil {
-		ui.logger.Error("workspace API ls failed", "path", path, "error", err)
-		http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
+		writeJSONError(w, http.StatusUnauthorized, err.Error())
 		return
 	}
 
-	// Parse workspace response.
-	var outer []map[string]json.RawMessage
-	if err := json.Unmarshal(result, &outer); err != nil || len(outer) == 0 {
-		http.Error(w, `{"error": "Failed to parse workspace response"}`, http.StatusInternalServerError)
+	wsPath := r.URL.Query().Get("path")
+	if wsPath == "" {
+		wsPath = workspaceHome(sess)
+	}
+
+	items, err := listWorkspaceDir(r.Context(), client, wsPath)
+	if err != nil {
+		ui.logger.Error("workspace API ls failed", "path", wsPath, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	var items [][]any
-	// Select the listing corresponding to the requested path.
-	var listing json.RawMessage
-	if v, ok := outer[0][path]; ok {
-		listing = v
-	} else {
-		trimmed := strings.TrimSuffix(path, "/")
-		if trimmed != path {
-			if v, ok := outer[0][trimmed]; ok {
-				listing = v
-			}
-		}
-	}
-
-	if listing == nil {
-		http.Error(w, fmt.Sprintf(`{"error": "Workspace listing for path %q not found in response"}`, path), http.StatusInternalServerError)
-		return
-	}
-
-	if err := json.Unmarshal(listing, &items); err != nil {
-		http.Error(w, `{"error": "Failed to parse workspace listing"}`, http.StatusInternalServerError)
-		return
-	}
-	// Convert to structured response.
 	type wsItem struct {
 		Path     string `json:"path"`
 		Name     string `json:"name"`
@@ -1452,174 +1510,126 @@ func (ui *UI) HandleWorkspaceAPI(w http.ResponseWriter, r *http.Request) {
 		Path  string   `json:"path"`
 		Items []wsItem `json:"items"`
 	}{
-		Path:  path,
+		Path:  wsPath,
 		Items: make([]wsItem, 0, len(items)),
 	}
 
-	for _, item := range items {
-		if len(item) < 2 {
-			continue
-		}
-		itemPath, ok := item[0].(string)
-		if !ok {
-			continue
-		}
-		itemType, ok := item[1].(string)
-		if !ok {
-			continue
-		}
-		var itemSize int64
-		if len(item) > 6 {
-			if size, ok := item[6].(float64); ok {
-				itemSize = int64(size)
-			}
-		}
-
-		// Extract name from path.
-		// The workspace API may return full paths or just names.
-		// Ensure we have a full path.
-		name := itemPath
-		fullPath := itemPath
-		if strings.Contains(itemPath, "/") {
-			// Already a full path - extract name from it
-			parts := strings.Split(strings.TrimSuffix(itemPath, "/"), "/")
-			name = parts[len(parts)-1]
-		} else {
-			// Just a name - construct full path from current directory
-			fullPath = strings.TrimSuffix(path, "/") + "/" + itemPath
-		}
-
-		isFolder := itemType == "folder" || itemType == "modelfolder"
-
+	for _, obj := range items {
 		response.Items = append(response.Items, wsItem{
-			Path:     fullPath,
-			Name:     name,
-			Type:     itemType,
-			Size:     itemSize,
-			IsFolder: isFolder,
+			Path:     obj.Path,
+			Name:     obj.Name,
+			Type:     string(obj.Type),
+			Size:     obj.Size,
+			IsFolder: isWorkspaceFolder(obj.Type),
 		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// isWorkspaceFolder reports whether an object type is browsed as a directory.
+func isWorkspaceFolder(t bvbrcpkg.WorkspaceObjectType) bool {
+	return t == bvbrcpkg.WorkspaceTypeFolder || t == "modelfolder"
+}
+
+// workspaceObjectTypeFor picks the Workspace object type from a file name.
+func workspaceObjectTypeFor(filename string) bvbrcpkg.WorkspaceObjectType {
+	lower := strings.ToLower(filename)
+	switch {
+	case strings.HasSuffix(lower, ".fasta") || strings.HasSuffix(lower, ".fa") || strings.HasSuffix(lower, ".fna"):
+		return "contigs"
+	case strings.HasSuffix(lower, ".fastq") || strings.HasSuffix(lower, ".fq"):
+		return "reads"
+	case strings.HasSuffix(lower, ".fastq.gz") || strings.HasSuffix(lower, ".fq.gz"):
+		return "reads"
+	case strings.HasSuffix(lower, ".gff") || strings.HasSuffix(lower, ".gff3"):
+		return "gff"
+	case strings.HasSuffix(lower, ".gbk") || strings.HasSuffix(lower, ".genbank"):
+		return "genbank"
+	case strings.HasSuffix(lower, ".csv"):
+		return "csv"
+	case strings.HasSuffix(lower, ".tsv") || strings.HasSuffix(lower, ".txt"):
+		return "txt"
+	}
+	return bvbrcpkg.WorkspaceTypeUnspecified
 }
 
 // HandleWorkspaceUpload handles file upload to BV-BRC workspace.
+//
+// The upload form is parsed with a bounded memory budget — larger parts spill
+// to a temporary file — and the part is streamed to the workspace under the
+// session's token with an exact Content-Length. Every attempt rewinds the part
+// and starts afresh, because WorkspaceUploadReader verifies what the service
+// stored and cleans up after itself on failure.
 func (ui *UI) HandleWorkspaceUpload(w http.ResponseWriter, r *http.Request) {
 	sess := SessionFromContext(r.Context())
 
-	caller := ui.getWorkspaceCaller(sess)
-	if caller == nil {
-		http.Error(w, `{"error": "Workspace not configured - please log in"}`, http.StatusServiceUnavailable)
+	client, err := ui.workspaceClient(sess)
+	if err != nil {
+		writeJSONError(w, http.StatusUnauthorized, err.Error())
 		return
 	}
 
-	// Parse multipart form (max 100MB).
-	if err := r.ParseMultipartForm(100 << 20); err != nil {
-		http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusBadRequest)
+	// Cap the whole request body; the cap surfaces as *http.MaxBytesError
+	// from the form parser.
+	r.Body = http.MaxBytesReader(w, r.Body, ui.uploadMaxSize)
+	if err := r.ParseMultipartForm(workspaceUploadMemory); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeJSONError(w, http.StatusRequestEntityTooLarge,
+				fmt.Sprintf("upload exceeds the %d byte limit", ui.uploadMaxSize))
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+	if r.MultipartForm != nil {
+		defer r.MultipartForm.RemoveAll()
 	}
 
 	file, header, err := r.FormFile("file")
 	if err != nil {
-		http.Error(w, `{"error": "No file provided"}`, http.StatusBadRequest)
+		writeJSONError(w, http.StatusBadRequest, "No file provided")
 		return
 	}
 	defer file.Close()
 
-	// Get destination folder.
-	destFolder := r.FormValue("folder")
-	if destFolder == "" {
-		destFolder = "/" + sess.Username + "/home"
+	// Browsers send a bare name, but never trust it: the object name must not
+	// carry directory components.
+	filename := path.Base(strings.ReplaceAll(header.Filename, "\\", "/"))
+	switch filename {
+	case "", ".", "..", "/":
+		writeJSONError(w, http.StatusBadRequest, "Invalid file name")
+		return
 	}
-
-	// Read file content.
-	data, err := io.ReadAll(file)
-	if err != nil {
-		http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
+	if strings.ContainsFunc(filename, unicode.IsControl) {
+		writeJSONError(w, http.StatusBadRequest, "Invalid file name: control characters are not allowed")
 		return
 	}
 
-	filename := header.Filename
-	destPath := strings.TrimSuffix(destFolder, "/") + "/" + filename
-
-	// Determine object type based on extension.
-	objType := "unspecified"
-	lower := strings.ToLower(filename)
-	switch {
-	case strings.HasSuffix(lower, ".fasta") || strings.HasSuffix(lower, ".fa") || strings.HasSuffix(lower, ".fna"):
-		objType = "contigs"
-	case strings.HasSuffix(lower, ".fastq") || strings.HasSuffix(lower, ".fq"):
-		objType = "reads"
-	case strings.HasSuffix(lower, ".fastq.gz") || strings.HasSuffix(lower, ".fq.gz"):
-		objType = "reads"
-	case strings.HasSuffix(lower, ".gff") || strings.HasSuffix(lower, ".gff3"):
-		objType = "gff"
-	case strings.HasSuffix(lower, ".gbk") || strings.HasSuffix(lower, ".genbank"):
-		objType = "genbank"
-	case strings.HasSuffix(lower, ".csv"):
-		objType = "csv"
-	case strings.HasSuffix(lower, ".tsv") || strings.HasSuffix(lower, ".txt"):
-		objType = "txt"
+	destFolder := r.FormValue("folder")
+	if destFolder == "" {
+		destFolder = workspaceHome(sess)
 	}
+	destPath := strings.TrimSuffix(destFolder, "/") + "/" + filename
+	objType := workspaceObjectTypeFor(filename)
 
 	ui.logger.Info("uploading file to workspace",
 		"filename", filename,
 		"destPath", destPath,
-		"size", len(data),
+		"size", header.Size,
 		"type", objType,
+		"user", sess.Username,
 	)
 
-	// Every upload goes through Shock, whatever its size. The inline branch this
-	// replaced handed Workspace.create a []byte in a JSON string slot, which
-	// encoding/json base64-encodes — and inline content is UTF-8-only anyway, so
-	// there is no size below which routing bytes through JSON is correct
-	// (issues #172, #171).
-	//
-	// Step 1: create the destination as an upload node.
-	result, err := caller.Call(r.Context(), "Workspace.create", []any{
-		map[string]any{
-			"objects": [][]any{
-				{destPath, objType, nil, nil},
-			},
-			"createUploadNodes": true,
-			"overwrite":         true,
-		},
-	})
+	obj, err := uploadWorkspaceFile(r.Context(), client, destPath, filename, file, header.Size, objType)
 	if err != nil {
-		ui.logger.Error("workspace create upload node failed", "path", destPath, "error", err)
-		http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
+		ui.logger.Error("workspace upload failed", "path", destPath, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	// Step 2: pull the Shock URL out of the returned ObjectMeta tuple. Per
-	// Workspace.spec it is slot [11] — slot [10] is the global permission string.
-	var createResp [][][]any
-	if err := json.Unmarshal(result, &createResp); err != nil {
-		ui.logger.Error("workspace parse upload node failed", "error", err)
-		http.Error(w, `{"error": "Failed to parse upload node response"}`, http.StatusInternalServerError)
-		return
-	}
-
-	if len(createResp) == 0 || len(createResp[0]) == 0 || len(createResp[0][0]) < 12 {
-		http.Error(w, `{"error": "Invalid upload node response"}`, http.StatusInternalServerError)
-		return
-	}
-
-	shockURL, ok := createResp[0][0][11].(string)
-	if !ok || shockURL == "" {
-		http.Error(w, `{"error": "No Shock upload URL in response"}`, http.StatusInternalServerError)
-		return
-	}
-
-	// Step 3: PUT the raw bytes to the Shock node.
-	if err := ui.uploadToShock(r.Context(), shockURL, filename, data, sess.Token); err != nil {
-		ui.logger.Error("shock upload failed", "error", err)
-		http.Error(w, fmt.Sprintf(`{"error": %q}`, err.Error()), http.StatusInternalServerError)
-		return
-	}
-
-	// Return success with the workspace path.
 	response := struct {
 		Path string `json:"path"`
 		Name string `json:"name"`
@@ -1628,119 +1638,92 @@ func (ui *UI) HandleWorkspaceUpload(w http.ResponseWriter, r *http.Request) {
 	}{
 		Path: destPath,
 		Name: filename,
-		Type: objType,
-		Size: int64(len(data)),
+		Type: string(objType),
+		Size: obj.Size,
+	}
+	if obj.Path != "" {
+		response.Path = obj.Path
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
-// uploadToShock uploads file data to a Shock node.
-func (ui *UI) uploadToShock(ctx context.Context, shockURL, filename string, data []byte, token string) error {
-	// Create multipart form.
-	var buf bytes.Buffer
-	writer := multipart.NewWriter(&buf)
+// uploadWorkspaceFile streams file into the workspace object at wsPath,
+// rewinding the reader for every attempt.
+func uploadWorkspaceFile(ctx context.Context, client *bvbrcpkg.Client, wsPath, filename string, file io.ReadSeeker, size int64, objType bvbrcpkg.WorkspaceObjectType) (*bvbrcpkg.WorkspaceObject, error) {
+	var lastErr error
+	for attempt := 0; attempt < workspaceUploadRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(attempt) * time.Second):
+			}
+		}
 
-	part, err := writer.CreateFormFile("upload", filename)
-	if err != nil {
-		return err
-	}
-	if _, err = part.Write(data); err != nil {
-		return err
-	}
-	if err = writer.Close(); err != nil {
-		return err
-	}
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("rewinding upload: %w", err)
+		}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, shockURL, &buf)
-	if err != nil {
-		return err
+		obj, err := client.WorkspaceUploadReader(ctx, wsPath, filename, file, size, objType)
+		if err == nil {
+			return obj, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil || permanentUploadError(err) {
+			return nil, err
+		}
 	}
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	// Shock wants the OAuth scheme, as scripts/ws-create.pl sends it. (The
-	// Workspace JSON-RPC endpoint accepts a bare token; Shock is not the same
-	// service.)
-	if !strings.HasPrefix(token, "OAuth ") {
-		token = "OAuth " + token
-	}
-	req.Header.Set("Authorization", token)
+	return nil, fmt.Errorf("after %d attempts: %w", workspaceUploadRetries, lastErr)
+}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
+// permanentUploadError reports whether an upload failure is deterministic —
+// an auth/permission refusal or a coded service error the client library
+// itself would not retry — so another attempt cannot help. The gate is
+// deliberately narrow: WorkspaceUploadReader wraps its verification failures
+// (size and md5 mismatches, a bad Shock reply) in a code-less Error, and
+// those must still be retried.
+func permanentUploadError(err error) bool {
+	if bvbrcpkg.IsAuthError(err) {
+		return true
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("shock upload failed (HTTP %d): %s", resp.StatusCode, body)
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if be, ok := e.(*bvbrcpkg.Error); ok && be.Code != 0 && !bvbrcpkg.IsRetryable(be) {
+			return true
+		}
 	}
-
-	return nil
+	return false
 }
 
 // HandleWorkspace renders the workspace browser.
 func (ui *UI) HandleWorkspace(w http.ResponseWriter, r *http.Request) {
 	sess := SessionFromContext(r.Context())
 
-	caller := ui.getWorkspaceCaller(sess)
-	if caller == nil {
-		ui.renderError(w, "BV-BRC Workspace not configured - please log in", nil)
+	client, err := ui.workspaceClient(sess)
+	if err != nil {
+		// The browser page needs a BV-BRC login; send the user there.
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
 		return
 	}
 
-	path := r.URL.Query().Get("path")
-	if path == "" {
-		path = "/" + sess.Username + "/home"
+	wsPath := r.URL.Query().Get("path")
+	if wsPath == "" {
+		wsPath = workspaceHome(sess)
 	}
 
-	// Call workspace list using the Workspace service.
-	ui.logger.Debug("workspace ls request", "path", path)
-	result, err := caller.Call(r.Context(), "Workspace.ls", []any{
-		map[string]any{"paths": []string{path}},
-	})
+	ui.logger.Debug("workspace ls request", "path", wsPath)
+	items, err := listWorkspaceDir(r.Context(), client, wsPath)
 	if err != nil {
-		ui.logger.Error("workspace ls failed", "path", path, "error", err)
+		ui.logger.Error("workspace ls failed", "path", wsPath, "error", err)
 		ui.renderError(w, "Failed to list workspace", err)
 		return
-	}
-
-	ui.logger.Debug("workspace ls response", "raw", string(result))
-
-	// Response format: [{"/path": [[item], [item], ...]}]
-	var outer []map[string]json.RawMessage
-	if err := json.Unmarshal(result, &outer); err != nil || len(outer) == 0 {
-		ui.logger.Error("workspace parse failed", "error", err, "response", string(result))
-		ui.renderError(w, "Failed to parse workspace response", err)
-		return
-	}
-
-	// Extract items for the requested path.
-	var items [][]any
-	var foundKey string
-	for key := range outer[0] {
-		foundKey = key
-		break
-	}
-	ui.logger.Debug("workspace response keys", "requestedPath", path, "foundKey", foundKey)
-
-	if listing, ok := outer[0][path]; ok {
-		json.Unmarshal(listing, &items)
-	} else if listing, ok := outer[0][strings.TrimSuffix(path, "/")]; ok {
-		json.Unmarshal(listing, &items)
-	} else if len(outer[0]) > 0 {
-		// Use whatever key is in the response
-		for _, listing := range outer[0] {
-			json.Unmarshal(listing, &items)
-			break
-		}
 	}
 
 	data := map[string]any{
 		"Title":   "Workspace - GoWe",
 		"Session": sess,
-		"Path":    path,
+		"Path":    wsPath,
 		"Items":   items,
 	}
 	ui.render(w, "workspace/browser", data)

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -2261,19 +2261,14 @@ var templates = map[string]string{
     <div class="bg-white shadow overflow-hidden sm:rounded-lg">
         <ul class="divide-y divide-gray-200">
             {{range .Items}}
-            {{if gt (len .) 0}}
-            {{$name := index . 0}}
-            {{$type := index . 1}}
-            {{$parent := index . 2}}
-            {{$fullPath := printf "%s%s" $parent $name}}
             <li>
-                {{if eq $type "folder"}}
-                <a href="/workspace?path={{urlquery $fullPath}}" class="block hover:bg-gray-50 px-4 py-4">
+                {{if eq .Type "folder"}}
+                <a href="/workspace?path={{urlquery .Path}}" class="block hover:bg-gray-50 px-4 py-4">
                     <div class="flex items-center">
                         <svg class="h-5 w-5 text-yellow-400 mr-3" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
                         </svg>
-                        <span class="text-sm font-medium text-gray-900">{{$name}}</span>
+                        <span class="text-sm font-medium text-gray-900">{{.Name}}</span>
                     </div>
                 </a>
                 {{else}}
@@ -2282,13 +2277,12 @@ var templates = map[string]string{
                         <svg class="h-5 w-5 text-gray-400 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
                         </svg>
-                        <span class="text-sm text-gray-900">{{$name}}</span>
-                        <span class="ml-2 text-xs text-gray-500">{{$type}}</span>
+                        <span class="text-sm text-gray-900">{{.Name}}</span>
+                        <span class="ml-2 text-xs text-gray-500">{{.Type}}</span>
                     </div>
                 </div>
                 {{end}}
             </li>
-            {{end}}
             {{else}}
             <li class="px-4 py-8 text-center text-gray-500">
                 Empty directory

--- a/internal/ui/workspace_test.go
+++ b/internal/ui/workspace_test.go
@@ -1,0 +1,496 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/me/gowe/pkg/bvbrc/bvbrctest"
+	"github.com/me/gowe/pkg/model"
+)
+
+const (
+	testWSUser  = "tester@bvbrc"
+	testWSToken = "un=tester@bvbrc|tokenid=session-token-123|sig=abc"
+)
+
+// newWorkspaceUI builds a UI whose workspace calls go to the fake service.
+func newWorkspaceUI(t *testing.T, fake *bvbrctest.Server) *UI {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return New(nil, logger, Config{WorkspaceURL: fake.WorkspaceURL()})
+}
+
+// withSession injects a session into the request the way AuthMiddleware does.
+func withSession(r *http.Request, sess *model.Session) *http.Request {
+	if sess == nil {
+		return r
+	}
+	return r.WithContext(context.WithValue(r.Context(), sessionContextKey, sess))
+}
+
+func testSession() *model.Session {
+	return &model.Session{ID: "sess-1", UserID: testWSUser, Username: testWSUser, Role: "user", Token: testWSToken}
+}
+
+// uploadRequest builds a multipart POST like the file picker's upload form.
+func uploadRequest(t *testing.T, folder, filename string, content []byte) *http.Request {
+	t.Helper()
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	if folder != "" {
+		if err := mw.WriteField("folder", folder); err != nil {
+			t.Fatal(err)
+		}
+	}
+	part, err := mw.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/workspace/upload", &body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	return req
+}
+
+// allBytes is a payload covering every byte value, including 0x80-0xFF, which
+// the old inline-JSON path used to mangle.
+func allBytes(repeat int) []byte {
+	out := make([]byte, 0, 256*repeat)
+	for i := 0; i < repeat; i++ {
+		for b := 0; b < 256; b++ {
+			out = append(out, byte(b))
+		}
+	}
+	return out
+}
+
+func decodeJSON(t *testing.T, rec *httptest.ResponseRecorder, into any) {
+	t.Helper()
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json (body %q)", ct, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), into); err != nil {
+		t.Fatalf("decoding response %q: %v", rec.Body.String(), err)
+	}
+}
+
+func TestHandleWorkspaceUpload_RoundTrip(t *testing.T) {
+	fake := bvbrctest.New(t)
+	u := newWorkspaceUI(t, fake)
+
+	payload := allBytes(12) // 3 KiB, every byte value
+	folder := "/" + testWSUser + "/home/inputs"
+	req := withSession(uploadRequest(t, folder, "reads.fq.gz", payload), testSession())
+	rec := httptest.NewRecorder()
+
+	u.HandleWorkspaceUpload(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Path string `json:"path"`
+		Name string `json:"name"`
+		Type string `json:"type"`
+		Size int64  `json:"size"`
+	}
+	decodeJSON(t, rec, &resp)
+
+	wantPath := folder + "/reads.fq.gz"
+	if resp.Path != wantPath {
+		t.Errorf("path = %q, want %q", resp.Path, wantPath)
+	}
+	if resp.Name != "reads.fq.gz" {
+		t.Errorf("name = %q, want reads.fq.gz", resp.Name)
+	}
+	if resp.Type != "reads" {
+		t.Errorf("type = %q, want reads", resp.Type)
+	}
+	if resp.Size != int64(len(payload)) {
+		t.Errorf("size = %d, want %d", resp.Size, len(payload))
+	}
+
+	// Bytes stored exactly as sent.
+	if got := fake.Bytes(wantPath); !bytes.Equal(got, payload) {
+		t.Errorf("stored %d bytes, want %d byte-exact", len(got), len(payload))
+	}
+	if obj := fake.Object(wantPath); obj == nil || obj.Size != int64(len(payload)) {
+		t.Errorf("workspace object = %+v, want recorded size %d", obj, len(payload))
+	}
+
+	// The PUT was made as the session user, with the OAuth scheme, with a
+	// filename and an exact Content-Length.
+	put, ok := fake.LastPut()
+	if !ok {
+		t.Fatal("no Shock PUT recorded")
+	}
+	if put.Authorization != "OAuth "+testWSToken {
+		t.Errorf("Authorization = %q, want the session token under the OAuth scheme", put.Authorization)
+	}
+	if put.FormField != "upload" {
+		t.Errorf("form field = %q, want upload", put.FormField)
+	}
+	if put.Filename != "reads.fq.gz" {
+		t.Errorf("filename = %q, want reads.fq.gz", put.Filename)
+	}
+	if put.ContentLength <= 0 || put.ContentLength != put.RawLength {
+		t.Errorf("Content-Length = %d, raw body = %d; want an exact declared length", put.ContentLength, put.RawLength)
+	}
+	if len(put.TransferEncoding) != 0 {
+		t.Errorf("Transfer-Encoding = %v, want none", put.TransferEncoding)
+	}
+	if calls := fake.CallsTo("Workspace.update_auto_meta"); len(calls) != 1 {
+		t.Errorf("update_auto_meta calls = %d, want 1", len(calls))
+	}
+}
+
+func TestHandleWorkspaceUpload_RequiresSession(t *testing.T) {
+	tests := []struct {
+		name string
+		sess *model.Session
+	}{
+		{name: "no session", sess: nil},
+		{name: "session without token", sess: &model.Session{ID: "s", Username: testWSUser}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := bvbrctest.New(t)
+			u := newWorkspaceUI(t, fake)
+
+			req := withSession(uploadRequest(t, "", "a.txt", []byte("hello")), tt.sess)
+			rec := httptest.NewRecorder()
+			u.HandleWorkspaceUpload(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401 (body %s)", rec.Code, rec.Body.String())
+			}
+			var resp map[string]string
+			decodeJSON(t, rec, &resp)
+			if resp["error"] == "" {
+				t.Error("expected a JSON error message")
+			}
+			if n := len(fake.Calls()); n != 0 {
+				t.Errorf("fake received %d calls without a session, want 0", n)
+			}
+			if _, ok := fake.LastPut(); ok {
+				t.Error("a Shock PUT was made without a session")
+			}
+		})
+	}
+}
+
+func TestHandleWorkspaceUpload_RetriesAfterShockFailure(t *testing.T) {
+	fake := bvbrctest.New(t)
+	u := newWorkspaceUI(t, fake)
+
+	// The first PUT fails; the retry must rewind the part and go through the
+	// whole create → PUT → update_auto_meta protocol again on a fresh node.
+	failed := false
+	fake.ShockReply = func(put bvbrctest.ShockPut) (int, string) {
+		if !failed {
+			failed = true
+			return http.StatusInternalServerError, `{"status":500,"error":["disk full"],"data":null}`
+		}
+		return 0, ""
+	}
+
+	payload := allBytes(4)
+	folder := "/" + testWSUser + "/home"
+	req := withSession(uploadRequest(t, folder, "blob.bin", payload), testSession())
+	rec := httptest.NewRecorder()
+	u.HandleWorkspaceUpload(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	puts := fake.Puts()
+	if len(puts) != 2 {
+		t.Fatalf("Shock PUTs = %d, want 2 (one failure, one success)", len(puts))
+	}
+	if puts[0].NodeID == puts[1].NodeID {
+		t.Error("retry reused the same Shock node; every attempt must re-create the object")
+	}
+	for i, p := range puts {
+		if !bytes.Equal(p.Body, payload) {
+			t.Errorf("PUT %d carried %d bytes, want the full %d-byte payload (rewind failed?)", i, len(p.Body), len(payload))
+		}
+	}
+	if got := fake.Bytes(folder + "/blob.bin"); !bytes.Equal(got, payload) {
+		t.Errorf("stored %d bytes, want %d byte-exact", len(got), len(payload))
+	}
+}
+
+func TestHandleWorkspaceUpload_EmptyFile(t *testing.T) {
+	fake := bvbrctest.New(t)
+	u := newWorkspaceUI(t, fake)
+
+	folder := "/" + testWSUser + "/home"
+	req := withSession(uploadRequest(t, folder, "empty.txt", nil), testSession())
+	rec := httptest.NewRecorder()
+	u.HandleWorkspaceUpload(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if _, ok := fake.LastPut(); ok {
+		t.Error("an empty file must be stored inline, not PUT to Shock")
+	}
+	obj := fake.Object(folder + "/empty.txt")
+	if obj == nil || obj.NodeID != "" || obj.Size != 0 {
+		t.Errorf("object = %+v, want an inline 0-byte object", obj)
+	}
+}
+
+func seedListing(fake *bvbrctest.Server) {
+	home := "/" + testWSUser + "/home"
+	fake.Put(bvbrctest.Object{Path: home + "/sub", Type: "folder"})
+	fake.Put(bvbrctest.Object{Path: home + "/reads.fq", Type: "reads", Size: 42})
+	fake.Put(bvbrctest.Object{Path: home + "/sub/nested.txt", Type: "txt", Size: 7}) // not a direct child
+}
+
+func TestHandleWorkspaceAPI_FullPaths(t *testing.T) {
+	fake := bvbrctest.New(t)
+	seedListing(fake)
+	u := newWorkspaceUI(t, fake)
+	home := "/" + testWSUser + "/home"
+
+	type item struct {
+		Path     string `json:"path"`
+		Name     string `json:"name"`
+		Type     string `json:"type"`
+		Size     int64  `json:"size"`
+		IsFolder bool   `json:"isFolder"`
+	}
+	var resp struct {
+		Path  string `json:"path"`
+		Items []item `json:"items"`
+	}
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "explicit path", query: "?path=" + home},
+		{name: "default path is the user's home", query: ""},
+		{name: "trailing slash", query: "?path=" + home + "/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := withSession(httptest.NewRequest(http.MethodGet, "/api/workspace/ls"+tc.query, nil), testSession())
+			rec := httptest.NewRecorder()
+			u.HandleWorkspaceAPI(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+			}
+			resp.Items = nil
+			decodeJSON(t, rec, &resp)
+
+			if strings.TrimSuffix(resp.Path, "/") != home {
+				t.Errorf("path = %q, want %q", resp.Path, home)
+			}
+			byName := map[string]item{}
+			for _, it := range resp.Items {
+				byName[it.Name] = it
+			}
+			if len(byName) != 2 {
+				t.Fatalf("items = %+v, want exactly sub and reads.fq", resp.Items)
+			}
+			if sub := byName["sub"]; sub.Path != home+"/sub" || !sub.IsFolder || sub.Type != "folder" {
+				t.Errorf("sub = %+v, want full path %s/sub and isFolder", sub, home)
+			}
+			if f := byName["reads.fq"]; f.Path != home+"/reads.fq" || f.IsFolder || f.Size != 42 || f.Type != "reads" {
+				t.Errorf("reads.fq = %+v, want full path %s/reads.fq, size 42", f, home)
+			}
+		})
+	}
+}
+
+func TestHandleWorkspaceAPI_RequiresSession(t *testing.T) {
+	fake := bvbrctest.New(t)
+	u := newWorkspaceUI(t, fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/workspace/ls", nil)
+	rec := httptest.NewRecorder()
+	u.HandleWorkspaceAPI(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if n := len(fake.Calls()); n != 0 {
+		t.Errorf("fake received %d calls without a session, want 0", n)
+	}
+}
+
+func TestHandleWorkspace_RendersTypedPaths(t *testing.T) {
+	fake := bvbrctest.New(t)
+	seedListing(fake)
+	u := newWorkspaceUI(t, fake)
+	home := "/" + testWSUser + "/home"
+
+	req := withSession(httptest.NewRequest(http.MethodGet, "/workspace?path="+home, nil), testSession())
+	rec := httptest.NewRecorder()
+	u.HandleWorkspace(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+
+	// The folder link carries the object's full path, composed by the client
+	// from the directory and name slots — no guessing in the template.
+	if want := `href="/workspace?path=%2Ftester%40bvbrc%2Fhome%2Fsub"`; !strings.Contains(body, want) {
+		t.Errorf("folder link %s missing from page:\n%s", want, body)
+	}
+	if !strings.Contains(body, ">sub<") {
+		t.Error("folder name not rendered")
+	}
+	if !strings.Contains(body, ">reads.fq<") || !strings.Contains(body, ">reads<") {
+		t.Error("file name/type not rendered")
+	}
+	if strings.Contains(body, "nested.txt") {
+		t.Error("a nested object leaked into the parent listing")
+	}
+	if strings.Contains(body, "Empty directory") {
+		t.Error("non-empty listing rendered as empty")
+	}
+}
+
+func TestHandleWorkspace_RequiresSession(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		sess *model.Session
+	}{
+		{name: "no session", sess: nil},
+		{name: "session without token", sess: &model.Session{ID: "s", Username: testWSUser}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := bvbrctest.New(t)
+			u := newWorkspaceUI(t, fake)
+
+			rec := httptest.NewRecorder()
+			u.HandleWorkspace(rec, withSession(httptest.NewRequest(http.MethodGet, "/workspace", nil), tt.sess))
+
+			if rec.Code != http.StatusSeeOther {
+				t.Fatalf("status = %d, want 303 redirect to login", rec.Code)
+			}
+			if loc := rec.Header().Get("Location"); loc != "/login" {
+				t.Errorf("Location = %q, want /login", loc)
+			}
+			if n := len(fake.Calls()); n != 0 {
+				t.Errorf("fake received %d calls without a session, want 0", n)
+			}
+		})
+	}
+}
+
+func TestHandleWorkspaceUpload_TooLarge(t *testing.T) {
+	fake := bvbrctest.New(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	u := New(nil, logger, Config{WorkspaceURL: fake.WorkspaceURL(), UploadMaxSize: 1024})
+
+	req := withSession(uploadRequest(t, "/"+testWSUser+"/home", "big.bin", allBytes(16)), testSession()) // 4 KiB
+	rec := httptest.NewRecorder()
+	u.HandleWorkspaceUpload(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413 (body %s)", rec.Code, rec.Body.String())
+	}
+	var resp map[string]string
+	decodeJSON(t, rec, &resp)
+	if resp["error"] == "" {
+		t.Error("expected a JSON error message")
+	}
+	if n := len(fake.Calls()); n != 0 {
+		t.Errorf("fake received %d calls for an oversized upload, want 0", n)
+	}
+}
+
+func TestHandleWorkspaceUpload_RejectsControlCharacters(t *testing.T) {
+	fake := bvbrctest.New(t)
+	u := newWorkspaceUI(t, fake)
+
+	req := withSession(uploadRequest(t, "/"+testWSUser+"/home", "evil\x01name.txt", []byte("x")), testSession())
+	rec := httptest.NewRecorder()
+	u.HandleWorkspaceUpload(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body %s)", rec.Code, rec.Body.String())
+	}
+	if n := len(fake.Calls()); n != 0 {
+		t.Errorf("fake received %d calls for a rejected name, want 0", n)
+	}
+}
+
+func TestHandleWorkspaceUpload_NoRetryOnPermissionError(t *testing.T) {
+	fake := bvbrctest.New(t)
+	u := newWorkspaceUI(t, fake)
+	fake.RPCError = func(method string, _ json.RawMessage) (int, string) {
+		if method == "Workspace.create" {
+			return -32401, "User tester@bvbrc does not have permission to write to /other@bvbrc/home"
+		}
+		return 0, ""
+	}
+
+	req := withSession(uploadRequest(t, "/other@bvbrc/home", "a.txt", []byte("hello")), testSession())
+	rec := httptest.NewRecorder()
+	u.HandleWorkspaceUpload(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (body %s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "permission") {
+		t.Errorf("error body %q does not surface the service's message", rec.Body.String())
+	}
+	if n := len(fake.CallsTo("Workspace.create")); n != 1 {
+		t.Errorf("Workspace.create calls = %d, want exactly 1 (no retry on a permission error)", n)
+	}
+	if _, ok := fake.LastPut(); ok {
+		t.Error("a Shock PUT was made despite the create failing")
+	}
+}
+
+func TestHandleWorkspaceAPI_EmptyDirectory(t *testing.T) {
+	fake := bvbrctest.New(t)
+	u := newWorkspaceUI(t, fake)
+	fake.LsReply = func([]string) (map[string][][]any, bool) {
+		return map[string][][]any{}, true
+	}
+	home := "/" + testWSUser + "/home"
+
+	req := withSession(httptest.NewRequest(http.MethodGet, "/api/workspace/ls?path="+home+"/empty", nil), testSession())
+	rec := httptest.NewRecorder()
+	u.HandleWorkspaceAPI(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for an empty listing (body %s)", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Path  string `json:"path"`
+		Items []any  `json:"items"`
+	}
+	decodeJSON(t, rec, &resp)
+	if resp.Items == nil || len(resp.Items) != 0 {
+		t.Errorf("items = %v, want an empty (non-null) list", resp.Items)
+	}
+
+	// The browser page renders it as an empty directory rather than an error.
+	rec = httptest.NewRecorder()
+	u.HandleWorkspace(rec, withSession(httptest.NewRequest(http.MethodGet, "/workspace?path="+home+"/empty", nil), testSession()))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Empty directory") {
+		t.Errorf("browser page status = %d, want 200 with 'Empty directory'", rec.Code)
+	}
+}

--- a/pkg/bvbrc/bvbrctest/server.go
+++ b/pkg/bvbrc/bvbrctest/server.go
@@ -114,6 +114,16 @@ type Server struct {
 	// the client treats as retryable.
 	Intercept func(method string, params json.RawMessage) (status int, body string)
 
+	// RPCError, when set, is consulted after Intercept and before the method
+	// is dispatched; a non-zero code makes the fake answer with that JSON-RPC
+	// error (for example -32401 for a permission failure) instead.
+	RPCError func(method string, params json.RawMessage) (code int, message string)
+
+	// LsReply, when set, replaces the Workspace.ls result for the requested
+	// paths whenever it returns ok — for instance an empty map, which the real
+	// service can emit for a directory it knows but has nothing to list.
+	LsReply func(paths []string) (result map[string][][]any, ok bool)
+
 	// HoldShockBody, when set and returning a non-nil channel for a node,
 	// makes the Shock PUT handler accept the request headers and then never
 	// read the body: it blocks until the channel is closed, stores nothing,
@@ -264,11 +274,15 @@ func writeResult(w http.ResponseWriter, result any) {
 }
 
 func writeError(w http.ResponseWriter, msg string) {
+	writeErrorCode(w, -32603, msg)
+}
+
+func writeErrorCode(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusInternalServerError)
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"id": "1", "version": "1.1",
-		"error": rpcError{Name: "JSONRPCError", Code: -32603, Message: msg},
+		"error": rpcError{Name: "JSONRPCError", Code: code, Message: msg},
 	})
 }
 
@@ -295,6 +309,13 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/plain")
 			w.WriteHeader(status)
 			_, _ = io.WriteString(w, body)
+			return
+		}
+	}
+
+	if s.RPCError != nil {
+		if code, msg := s.RPCError(req.Method, params); code != 0 {
+			writeErrorCode(w, code, msg)
 			return
 		}
 	}
@@ -421,6 +442,13 @@ func (s *Server) rpcLs(w http.ResponseWriter, raw json.RawMessage) {
 	if err := json.Unmarshal(raw, &p); err != nil {
 		writeError(w, "bad params: "+err.Error())
 		return
+	}
+
+	if s.LsReply != nil {
+		if result, ok := s.LsReply(p.Paths); ok {
+			writeResult(w, result)
+			return
+		}
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

**PR B′-ui of #175** (follow-up to #174). The UI's workspace code was the last hand-rolled Workspace/Shock path and carried a fresh bug from #174: the server's **global service-account caller took precedence over the session token**, so an upload created the object as the service account (owned by it, inside the user's home) but PUT to Shock with the user's token — an ACL mismatch.

## Changes

- `WithWorkspaceCaller` and the service-account path are **removed**; every user-facing workspace op builds a per-request typed `pkg/bvbrc` client with the **session token** (login always mints one). No token → 401 (API) / 303 to `/login` (page).
- Upload: `ParseMultipartForm(32 MiB)` (larger parts spill to disk, not RAM) + `header.Size` + the `multipart.File` ReadSeeker → `WorkspaceUploadReader` with exact `Content-Length`, `Seek(0,0)` per retry, no retry on deterministic failures (auth/permission), control characters in filenames rejected, and a real **upload cap** via the existing `--upload-max-size` (→ 413).
- Listing: typed `WorkspaceLs`, full paths composed by the client (no slash-guessing), empty directory tolerated, templates consume typed fields.
- `--workspace-url` now feeds both the scheduler stager and the UI.
- **First-ever tests for these handlers** (12): byte-exact round-trip incl. 0x80–0xFF, PUT authorized with the *session* token, filename present, exact Content-Length/no chunked TE, retry rewinds and uses a fresh node, 0-byte inline, 413 cap, 401s, permission error → single attempt, typed paths in API and page.

Reviewed adversarially (mutation-verified: swapping the PUT to a non-session token and dropping the retry rewind each fail exactly one targeted test); should-fixes included. Verified the scheduler stager wiring survived the caller removal.

Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg