### PR TITLE
feat(server,cli): admin output verification and re-delivery

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,6 +51,7 @@ func main() {
 	schedulerPoll := flag.Duration("scheduler-poll", 2*time.Second, "Scheduler poll interval")
 	workspaceStaging := flag.String("workspace-staging", "", "Workspace staging mode: 'server' (pre/post-stage ws:// on server) or empty (passthrough to workers)")
 	wsStagingURL := flag.String("workspace-url", "", "BV-BRC Workspace service URL for server-side staging and the web UI workspace browser (default: production)")
+	redeliverSourceDirs := flag.String("redeliver-source-dirs", "", "Comma-separated directories the admin re-delivery endpoint may read staged originals from (e.g. the shared stage-out dir); empty refuses local re-upload")
 	preflightDeferral := flag.Int("preflight-deferral", 30, "Ticks to defer worker task dispatch when no capable worker exists (0=disable)")
 	stuckTaskThreshold := flag.Int("stuck-task-threshold", 30, "Consecutive zero-progress ticks before QUEUED tasks are flagged as stuck (0=disable)")
 	stuckTaskAction := flag.String("stuck-task-action", "warn", "Action for stuck tasks: 'warn' (log only) or 'fail' (also fail oldest task)")
@@ -362,14 +363,23 @@ func main() {
 	}
 	sched := scheduler.NewLoop(st, reg, schedCfg, logger)
 
-	// Configure server-side workspace staging if requested.
+	// One Workspace stager serves both the scheduler (server-side pre/post
+	// staging, only in "server" mode) and the admin output verification /
+	// re-delivery endpoints (always: they act with each submission's stored
+	// token, so verifying a single submission works in any staging mode).
+	wsStager := staging.NewWorkspaceStager(staging.WorkspaceConfig{
+		WorkspaceURL: *wsStagingURL,
+		Timeout:      5 * time.Minute,
+		MaxRetries:   3,
+	}, logger)
+	serverOpts = append(serverOpts, server.WithWorkspaceStager(wsStager))
+	if *redeliverSourceDirs != "" {
+		dirs := strings.Split(*redeliverSourceDirs, ",")
+		serverOpts = append(serverOpts, server.WithRedeliverSourceDirs(dirs))
+		logger.Info("admin re-delivery source directories", "dirs", dirs)
+	}
 	if *workspaceStaging == "server" {
-		wsCfg := staging.WorkspaceConfig{
-			WorkspaceURL: *wsStagingURL,
-			Timeout:      5 * time.Minute,
-			MaxRetries:   3,
-		}
-		sched.SetWorkspaceStager(staging.NewWorkspaceStager(wsCfg, logger))
+		sched.SetWorkspaceStager(wsStager)
 		logger.Info("server-side workspace staging enabled")
 	}
 

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -648,6 +648,177 @@ No auth required:
 
 ---
 
+## 10. Admin: Verify and Re-deliver Workspace Outputs
+
+Both endpoints require the **admin** role (`401` unauthenticated, `403` for a
+non-admin) and a server with BV-BRC Workspace staging available
+(`503 workspace staging not configured` otherwise). They act on behalf of the
+submission's owner using the token stored with the submission — the admin's
+own token is never used, because it has no write permission in another user's
+workspace home. A missing or expired stored token yields `409 Conflict` with an
+explanatory message; the owner must re-submit.
+
+Only submissions whose delivery already ran to an outcome are accepted:
+`output_state` must be `delivered` or `upload_failed` (`409` for anything else,
+including `uploading` while the scheduler is still delivering), and the
+submission must be terminal.
+
+Every output `File` of the submission **and of its descendant sub-workflow
+child submissions** is examined, at any nesting depth (arrays, records,
+`Directory` listings). `secondaryFiles` are not examined — the scheduler's
+stage-out never delivers them on their own, so they are neither expected in
+the workspace nor reported.
+
+### Verify outputs (read-only)
+
+```
+POST /api/v1/admin/submissions/{id}/verify-outputs
+```
+
+Downloads each `ws://` output through `Workspace.get_download_url` and streams
+it through SHA-1, comparing the result to the `checksum` (`sha1$<hex>`) and
+`size` the worker recorded **before** upload. The workspace's own `ObjectSize`
+is never trusted. Outputs that still carry a `file://` location on a submission
+with an output destination are reported as *not delivered*. Nothing is written.
+
+```json
+{
+  "data": {
+    "submission_id": "sub_abc",
+    "state": "COMPLETED",
+    "output_state": "delivered",
+    "submissions": ["sub_abc", "sub_child1"],
+    "files": [
+      {
+        "submission_id": "sub_abc",
+        "location": "ws:///user@bvbrc/home/results/chunks.jsonl.gz",
+        "expected_checksum": "sha1$3f786850e387550fdab836ed7e6dc881de23001b",
+        "actual_checksum":   "sha1$89e6c98d92887913cadf06b2adb97f26cde4849b",
+        "expected_size": 1048576,
+        "actual_size": 1572864,
+        "ok": false,
+        "error": "checksum mismatch"
+      }
+    ],
+    "summary": { "total": 1, "ok": 0, "mismatched": 1, "errors": 0 }
+  }
+}
+```
+
+`summary.mismatched` counts files that downloaded but differ; `summary.errors`
+counts files that could not be compared (missing object, no recorded checksum,
+not delivered, download failure) — see each file's `error`. A `total` of `0`
+means no deliverable output was found at all (for example a submission with
+no `File` outputs); such a submission is never marked delivered by re-delivery.
+
+Optional fields (`expected_checksum`, `actual_checksum`, `error`, `action`,
+`source`, `dry_run`, `updated`, `state_restored`, `manifest_uploaded`,
+`manifest_error`, and the extra summary counters) are omitted when empty.
+
+Each verification download waits at most 5 minutes for response headers and
+1 hour end to end.
+
+### Re-deliver outputs
+
+```
+POST /api/v1/admin/submissions/{id}/redeliver
+POST /api/v1/admin/submissions/{id}/redeliver?dry_run=true
+```
+
+Runs the verification above, then for every file that does **not** verify:
+
+1. locates the local original by **checksum + size** among the output `File`
+   objects recorded on the submission's tasks (and its children's tasks) —
+   `file://<stage-out-dir>/<task-id>/<name>`; basenames are not used because
+   scatter shards share them;
+2. admits the candidate only if it resolves (symlinks followed) under one of
+   the server's `--redeliver-source-dirs`, is a regular file, and has the
+   recorded size — FIFOs, devices, directories and wrong-size files are
+   skipped without being opened; with no `--redeliver-source-dirs` configured
+   local recovery is refused and reported per file;
+3. checks the original's SHA-1 against the recorded checksum;
+4. re-uploads it through the verified streaming Shock path to the **same**
+   workspace path (overwrite) — or, for a never-uploaded `file://` output,
+   under the submission's output destination. The target path must lie inside
+   the submission's output destination;
+5. downloads and re-verifies it, rewriting the output's `location` if it
+   changed.
+
+Only when **every** file verifies is `output_state` set to `delivered`; a
+submission the scheduler had marked `FAILED` with error code
+`OUTPUT_STAGING_FAILED` is then restored to `COMPLETED` (`state_restored:
+true`). Whenever the submission row is written, the output manifest
+`_gowe_outputs.json` in the destination is rewritten to match
+(`manifest_uploaded: true`, or `manifest_error` if that non-fatal step failed).
+Nothing is ever deleted.
+
+Writes are compare-and-set against the `state`/`output_state` the request
+loaded: if the submission changed meanwhile the response is `409 … changed
+concurrently` and nothing is written. Only one re-delivery per submission runs
+at a time (`409 re-delivery in progress`); the lock is in-memory, the row is
+never marked `uploading`.
+
+The response has the same shape as verification plus per-file `action` and
+`source`, and extra summary counters:
+
+| `action`            | Meaning |
+|---------------------|---------|
+| `verified`          | already matched; nothing done |
+| `reuploaded`        | re-uploaded from `source` and re-verified OK |
+| `would_reupload`    | dry run: original found at `source`, nothing changed |
+| `original_missing`  | no admissible local file with that checksum+size (the `error` lists why each candidate was rejected) |
+| `failed`            | not recoverable or the attempt failed — no recorded checksum, basename of the original differs from the workspace object, target path outside the destination, upload error, or the re-verification after upload did not match (`error` begins with `re-verify after upload`) |
+
+```json
+{
+  "data": {
+    "submission_id": "sub_abc",
+    "state": "COMPLETED",
+    "output_state": "delivered",
+    "updated": true,
+    "state_restored": true,
+    "manifest_uploaded": true,
+    "submissions": ["sub_abc"],
+    "files": [
+      {
+        "submission_id": "sub_abc",
+        "location": "ws:///user@bvbrc/home/results/chunks.jsonl.gz",
+        "expected_checksum": "sha1$3f78…",
+        "actual_checksum":   "sha1$3f78…",
+        "expected_size": 1048576,
+        "actual_size": 1048576,
+        "ok": true,
+        "action": "reuploaded",
+        "source": "/shared/stage-out/task_7f3a/chunks.jsonl.gz"
+      }
+    ],
+    "summary": { "total": 1, "ok": 1, "mismatched": 0, "errors": 0, "reuploaded": 1 }
+  }
+}
+```
+
+### Finding affected submissions
+
+`GET /api/v1/submissions/` accepts `output_state=<state>[,<state>...]`
+(lowercase: `delivered`, `upload_failed`, `skipped`, `uploading`), combinable
+with `date_start=YYYY-MM-DD`; children are excluded by default.
+
+### CLI
+
+```bash
+gowe admin verify-outputs sub_abc                       # one submission
+gowe admin verify-outputs --all --since 2026-06-01      # every delivered/upload_failed submission
+gowe admin verify-outputs --all --output-state delivered --json
+gowe admin redeliver sub_abc --dry-run                  # plan only
+gowe admin redeliver sub_abc                            # repair
+```
+
+The commands exit non-zero when any output fails verification or re-delivery.
+The server is started with `--redeliver-source-dirs /path/to/stage-out` to
+allow re-uploads from the shared stage-out directory.
+
+---
+
 ## Complete MCP Server Example
 
 Here's a minimal MCP tool that submits a job and polls for completion. This shows the typical flow an MCP server would implement:

--- a/docs/tools/server.md
+++ b/docs/tools/server.md
@@ -32,6 +32,7 @@ gowe-server [flags]
 | `--scheduler-poll` | `2s` | Scheduler poll interval |
 | `--workspace-staging` | `""` | Workspace staging mode: `server` (pre/post-stage `ws://` on server) or empty (passthrough to workers) |
 | `--workspace-url` | `""` | BV-BRC Workspace service URL for server-side staging and the web UI workspace browser/uploads, which always run under the logged-in user's own token (default: production) |
+| `--redeliver-source-dirs` | `""` | Comma-separated directories the admin re-delivery endpoint may read staged originals from (typically the shared stage-out directory; symlinks resolved). Empty refuses local re-upload |
 | `--log-level` | `info` | Log level: debug, info, warn, error |
 | `--log-format` | `text` | Log format: text, json |
 | `--debug` | `false` | Shorthand for `--log-level=debug` |
@@ -935,6 +936,38 @@ Permanently revoke (delete) a key. Use this for a compromised worker — other w
 curl -X DELETE http://localhost:8080/api/v1/admin/worker-keys/wk_1f2e... \
   -H "Authorization: $ADMIN_TOKEN"
 ```
+
+#### `POST /api/v1/admin/submissions/{id}/verify-outputs`
+
+Download every `ws://` output of a delivered (or `upload_failed`) submission,
+including sub-workflow children, and compare it to the SHA-1 checksum and size
+the worker recorded before upload. Read-only; acts with the submission's stored
+token. Answers `503` when Workspace staging is not available and `409` when the
+submission is not `delivered`/`upload_failed`, not terminal, or its stored
+token is missing or expired.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/admin/submissions/sub_abc/verify-outputs \
+  -H "Authorization: $ADMIN_TOKEN"
+```
+
+#### `POST /api/v1/admin/submissions/{id}/redeliver`
+
+Re-upload every output that fails verification from its local original,
+matched by checksum+size among the submission's task outputs and read only
+from under `--redeliver-source-dirs`; then re-verify, rewrite the output
+manifest, and mark the submission `delivered` (restoring `COMPLETED` for an
+`OUTPUT_STAGING_FAILED` failure) once every output verifies. `?dry_run=true`
+reports the plan without changing anything. One re-delivery per submission at
+a time (`409`); writes are compare-and-set (`409` on a concurrent change).
+
+```bash
+curl -X POST "http://localhost:8080/api/v1/admin/submissions/sub_abc/redeliver?dry_run=true" \
+  -H "Authorization: $ADMIN_TOKEN"
+```
+
+Request/response details: [API_GUIDE.md §10](../API_GUIDE.md#10-admin-verify-and-re-deliver-workspace-outputs).
+CLI: `gowe admin verify-outputs`, `gowe admin redeliver`.
 
 ## Graceful Shutdown
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1,0 +1,325 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// outputFileRow mirrors the per-file entry of the admin output endpoints.
+type outputFileRow struct {
+	SubmissionID     string `json:"submission_id"`
+	Location         string `json:"location"`
+	ExpectedChecksum string `json:"expected_checksum"`
+	ActualChecksum   string `json:"actual_checksum"`
+	ExpectedSize     int64  `json:"expected_size"`
+	ActualSize       int64  `json:"actual_size"`
+	OK               bool   `json:"ok"`
+	Error            string `json:"error"`
+	Action           string `json:"action"`
+	Source           string `json:"source"`
+}
+
+// outputReportBody mirrors the response of verify-outputs and redeliver.
+type outputReportBody struct {
+	SubmissionID  string          `json:"submission_id"`
+	State         string          `json:"state"`
+	OutputState   string          `json:"output_state"`
+	DryRun        bool            `json:"dry_run"`
+	Submissions   []string        `json:"submissions"`
+	Files         []outputFileRow `json:"files"`
+	Updated       bool            `json:"updated"`
+	StateRestored bool            `json:"state_restored"`
+	Summary       struct {
+		Total           int `json:"total"`
+		OK              int `json:"ok"`
+		Mismatched      int `json:"mismatched"`
+		Errors          int `json:"errors"`
+		Reuploaded      int `json:"reuploaded"`
+		WouldReupload   int `json:"would_reupload"`
+		OriginalMissing int `json:"original_missing"`
+		Failed          int `json:"failed"`
+	} `json:"summary"`
+}
+
+func newAdminCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Administrative operations (admin role required)",
+	}
+	cmd.AddCommand(
+		newAdminVerifyOutputsCmd(),
+		newAdminRedeliverCmd(),
+	)
+	return cmd
+}
+
+// validateAdminVerifyArgs enforces "exactly one submission ID, or --all".
+func validateAdminVerifyArgs(args []string, all bool) error {
+	switch {
+	case all && len(args) > 0:
+		return errors.New("--all cannot be combined with a submission ID")
+	case !all && len(args) != 1:
+		return errors.New("requires exactly one submission ID (or --all)")
+	}
+	return nil
+}
+
+func newAdminVerifyOutputsCmd() *cobra.Command {
+	var (
+		all         bool
+		outputState string
+		since       string
+		asJSON      bool
+	)
+	cmd := &cobra.Command{
+		Use:   "verify-outputs [submission_id]",
+		Short: "Verify delivered workspace outputs against their recorded checksums",
+		Long: `Downloads every ws:// output of a submission (including sub-workflow
+children) and compares it to the checksum and size the worker recorded before
+upload. Read-only. With --all, every submission whose output_state matches
+--output-state (default: delivered,upload_failed) is verified in turn.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateAdminVerifyArgs(args, all); err != nil {
+				return err
+			}
+
+			var ids []string
+			if all {
+				var err error
+				ids, err = listSubmissionIDs(outputState, since)
+				if err != nil {
+					return err
+				}
+				if len(ids) == 0 {
+					fmt.Println("No submissions match the filter.")
+					return nil
+				}
+			} else {
+				ids = args
+			}
+
+			var reports []outputReportBody
+			exitErr := false
+			for _, id := range ids {
+				report, err := postOutputReport("/api/v1/admin/submissions/" + id + "/verify-outputs")
+				if err != nil {
+					exitErr = true
+					if asJSON {
+						reports = append(reports, outputReportBody{SubmissionID: id, Files: []outputFileRow{{SubmissionID: id, Error: err.Error()}}})
+					} else {
+						fmt.Fprintf(os.Stderr, "%s: %v\n", id, err)
+					}
+					continue
+				}
+				if report.Summary.OK != report.Summary.Total {
+					exitErr = true
+				}
+				reports = append(reports, *report)
+			}
+
+			if asJSON {
+				return printJSON(reports)
+			}
+			printOutputReports(reports, false)
+			if exitErr {
+				return errors.New("one or more outputs failed verification")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "Verify every submission matching --output-state/--since")
+	cmd.Flags().StringVar(&outputState, "output-state", "delivered,upload_failed", "Comma-separated output states to select with --all")
+	cmd.Flags().StringVar(&since, "since", "", "Only submissions created on/after this date (YYYY-MM-DD) with --all")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Print the raw JSON reports")
+	return cmd
+}
+
+func newAdminRedeliverCmd() *cobra.Command {
+	var (
+		dryRun bool
+		asJSON bool
+	)
+	cmd := &cobra.Command{
+		Use:   "redeliver <submission_id>",
+		Short: "Re-upload outputs that fail verification from their local originals",
+		Long: `Verifies every output of the submission (including sub-workflow children),
+locates the local original of each failing file by checksum and size in the
+task outputs, re-uploads it to the same workspace path using the submission's
+stored token, re-verifies it, and marks the submission delivered once every
+output verifies. Nothing is ever deleted. Use --dry-run to see what would be
+re-uploaded without changing anything.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "/api/v1/admin/submissions/" + args[0] + "/redeliver"
+			if dryRun {
+				path += "?dry_run=true"
+			}
+			report, err := postOutputReport(path)
+			if err != nil {
+				return fmt.Errorf("redeliver %s: %w", args[0], err)
+			}
+			if asJSON {
+				return printJSON(report)
+			}
+			printOutputReports([]outputReportBody{*report}, true)
+			if report.Summary.OK != report.Summary.Total {
+				return errors.New("one or more outputs could not be re-delivered")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report what would be re-uploaded without uploading or updating anything")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Print the raw JSON report")
+	return cmd
+}
+
+// listSubmissionIDs pages through /submissions with the output_state filter
+// and returns every matching root submission ID.
+func listSubmissionIDs(outputState, since string) ([]string, error) {
+	var ids []string
+	const pageSize = 100
+	for offset := 0; ; offset += pageSize {
+		q := url.Values{}
+		q.Set("limit", fmt.Sprint(pageSize))
+		q.Set("offset", fmt.Sprint(offset))
+		if outputState != "" {
+			q.Set("output_state", outputState)
+		}
+		if since != "" {
+			q.Set("date_start", since)
+		}
+		resp, err := client.Get("/api/v1/submissions/?" + q.Encode())
+		if err != nil {
+			return nil, fmt.Errorf("list submissions: %w", err)
+		}
+		var page []struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(resp.Data, &page); err != nil {
+			return nil, fmt.Errorf("parse submissions: %w", err)
+		}
+		for _, s := range page {
+			ids = append(ids, s.ID)
+		}
+		if resp.Pagination == nil || !resp.Pagination.HasMore || len(page) == 0 {
+			break
+		}
+	}
+	return ids, nil
+}
+
+// adminRequestTimeout bounds one verify/redeliver call. The server downloads
+// (and may re-upload) every output before answering, so this is deliberately
+// generous; it only exists so a dead connection cannot hang the CLI forever.
+const adminRequestTimeout = 4 * time.Hour
+
+func postOutputReport(path string) (*outputReportBody, error) {
+	if client.HTTPClient.Timeout == 0 {
+		client.HTTPClient.Timeout = adminRequestTimeout
+	}
+	resp, err := client.Post(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var report outputReportBody
+	if err := json.Unmarshal(resp.Data, &report); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &report, nil
+}
+
+func printJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// printOutputReports renders one compact table across all reports, followed
+// by a per-submission summary line.
+func printOutputReports(reports []outputReportBody, withAction bool) {
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if withAction {
+		fmt.Fprintln(tw, "SUBMISSION\tLOCATION\tEXPECTED\tACTUAL\tOK\tACTION\tERROR")
+	} else {
+		fmt.Fprintln(tw, "SUBMISSION\tLOCATION\tEXPECTED\tACTUAL\tOK\tERROR")
+	}
+	for _, r := range reports {
+		for _, f := range r.Files {
+			ok := "no"
+			if f.OK {
+				ok = "yes"
+			}
+			if withAction {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					f.SubmissionID, f.Location, shortChecksum(f.ExpectedChecksum), shortChecksum(f.ActualChecksum), ok, f.Action, f.Error)
+			} else {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					f.SubmissionID, f.Location, shortChecksum(f.ExpectedChecksum), shortChecksum(f.ActualChecksum), ok, f.Error)
+			}
+		}
+	}
+	tw.Flush()
+
+	fmt.Println()
+	for _, r := range reports {
+		if r.SubmissionID == "" {
+			continue
+		}
+		s := r.Summary
+		line := fmt.Sprintf("%s: %d/%d ok", r.SubmissionID, s.OK, s.Total)
+		if s.Mismatched > 0 {
+			line += fmt.Sprintf(", %d mismatched", s.Mismatched)
+		}
+		if s.Errors > 0 {
+			line += fmt.Sprintf(", %d errors", s.Errors)
+		}
+		if withAction {
+			if s.Reuploaded > 0 {
+				line += fmt.Sprintf(", %d re-uploaded", s.Reuploaded)
+			}
+			if s.WouldReupload > 0 {
+				line += fmt.Sprintf(", %d would re-upload", s.WouldReupload)
+			}
+			if s.OriginalMissing > 0 {
+				line += fmt.Sprintf(", %d original missing", s.OriginalMissing)
+			}
+			if s.Failed > 0 {
+				line += fmt.Sprintf(", %d failed", s.Failed)
+			}
+			if r.DryRun {
+				line += " (dry run)"
+			}
+		}
+		if r.OutputState != "" || r.State != "" {
+			line += fmt.Sprintf(" [state=%s output_state=%s]", r.State, r.OutputState)
+		}
+		if r.StateRestored {
+			line += " state restored to COMPLETED"
+		}
+		if len(r.Submissions) > 1 {
+			line += fmt.Sprintf(" (%d submissions incl. children)", len(r.Submissions))
+		}
+		fmt.Println(line)
+	}
+}
+
+// shortChecksum abbreviates "sha1$<40 hex>" to "sha1$<12 hex>" for the table.
+func shortChecksum(sum string) string {
+	if sum == "" {
+		return "-"
+	}
+	algo, hexPart, ok := strings.Cut(sum, "$")
+	if !ok || len(hexPart) <= 12 {
+		return sum
+	}
+	return algo + "$" + hexPart[:12]
+}

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestValidateAdminVerifyArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		all     bool
+		wantErr string
+	}{
+		{"single id", []string{"sub_1"}, false, ""},
+		{"all only", nil, true, ""},
+		{"no id no all", nil, false, "requires exactly one submission ID"},
+		{"two ids", []string{"sub_1", "sub_2"}, false, "requires exactly one submission ID"},
+		{"all with id", []string{"sub_1"}, true, "--all cannot be combined"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAdminVerifyArgs(tt.args, tt.all)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestAdminCommands_ArgParsing drives the cobra tree: argument errors must
+// surface before any HTTP request is made.
+func TestAdminCommands_ArgParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"verify without target", []string{"admin", "verify-outputs"}, "requires exactly one submission ID"},
+		{"verify all with id", []string{"admin", "verify-outputs", "--all", "sub_1"}, "--all cannot be combined"},
+		{"redeliver without id", []string{"admin", "redeliver"}, "accepts 1 arg"},
+		{"redeliver two ids", []string{"admin", "redeliver", "a", "b"}, "accepts 1 arg"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := NewRootCmd()
+			var out bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&out)
+			// Point at a closed port so an accidental request fails fast
+			// instead of hanging; arg validation must fire before it anyway.
+			root.SetArgs(append([]string{"--server", "http://127.0.0.1:1"}, tt.args...))
+			err := root.Execute()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestShortChecksum(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", "-"},
+		{"sha1$0123456789abcdef0123456789abcdef01234567", "sha1$0123456789ab"},
+		{"sha1$abc", "sha1$abc"},
+		{"nodollar", "nodollar"},
+	}
+	for _, tt := range tests {
+		if got := shortChecksum(tt.in); got != tt.want {
+			t.Errorf("shortChecksum(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -58,6 +58,7 @@ func NewRootCmd() *cobra.Command {
 		newAppsCmd(),
 		newRunCmd(),
 		newBundleCmd(),
+		newAdminCmd(),
 	)
 
 	return root

--- a/internal/scheduler/workspace.go
+++ b/internal/scheduler/workspace.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -200,29 +199,12 @@ func (l *Loop) poststageWorkspaceOutputs(ctx context.Context, affected map[strin
 }
 
 // uploadOutputManifest writes the submission outputs as a JSON manifest file
-// to the workspace destination. This gives users a machine-readable record of
-// what each output file represents (workflow output IDs, types, ws:// locations).
+// to the workspace destination (see staging.UploadOutputManifest, shared with
+// the admin re-delivery endpoint).
 func (l *Loop) uploadOutputManifest(ctx context.Context, stager *staging.WorkspaceStager, sub *model.Submission, baseDest string) error {
-	manifest := map[string]any{
-		"submission_id": sub.ID,
-		"workflow_id":   sub.WorkflowID,
-		"workflow_name": sub.WorkflowName,
-		"state":         string(sub.State),
-		"outputs":       sub.Outputs,
-	}
-	if sub.CompletedAt != nil {
-		manifest["completed_at"] = sub.CompletedAt.Format(time.RFC3339)
-	}
-
-	data, err := json.MarshalIndent(manifest, "", "  ")
+	destPath, err := staging.UploadOutputManifest(ctx, stager, sub, baseDest)
 	if err != nil {
-		return fmt.Errorf("marshal manifest: %w", err)
-	}
-
-	destPath := strings.TrimRight(baseDest, "/") + "/_gowe_outputs.json"
-	_, err = stager.UploadContent(ctx, destPath, string(data), staging.StageOptions{})
-	if err != nil {
-		return fmt.Errorf("upload manifest: %w", err)
+		return err
 	}
 
 	l.logger.Info("uploaded output manifest",

--- a/internal/server/handler_admin_outputs.go
+++ b/internal/server/handler_admin_outputs.go
@@ -1,0 +1,954 @@
+package server
+
+// Admin output verification and re-delivery.
+//
+// Outputs delivered to the BV-BRC Workspace before #174 went through the
+// inline JSON path, which corrupts every binary file. The worker records
+// `checksum` ("sha1$<hex>") and `size` on each output File before any upload,
+// so the recorded values are the ground truth for what SHOULD be in the
+// workspace, and the task rows keep `file://` locations of the originals on
+// the shared stage-out directory. These endpoints let an admin:
+//
+//   - verify-outputs: download every ws:// output and compare it to the
+//     recorded checksum and size (read-only);
+//   - redeliver: for every output that does not verify, find the local
+//     original by checksum+size in the task outputs (basenames are not unique
+//     across scatter tasks), re-upload it through the verified streaming path
+//     to the same workspace path, re-verify, and update the submission.
+//
+// Both use the submission's STORED token: the admin's own token has no write
+// permission in another user's home, so it is deliberately not a fallback.
+// Child submissions (sub-workflow fan-out) are included at every depth.
+//
+// Local originals are only ever read from under --redeliver-source-dirs
+// (symlinks resolved, segment-aware prefix), only when they are regular files
+// of the recorded size, and never from FIFOs or devices.
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/me/gowe/pkg/bvbrc"
+	"github.com/me/gowe/pkg/model"
+	"github.com/me/gowe/pkg/staging"
+)
+
+const (
+	outputStateDelivered    = "delivered"
+	outputStateUploadFailed = "upload_failed"
+	outputStateUploading    = "uploading"
+	outputStagingFailedCode = "OUTPUT_STAGING_FAILED"
+
+	// verifyDownloadTimeout bounds one verification download end to end.
+	// The verifier streams into a hasher, so a healthy download of any size
+	// finishes long before this; it only catches a Shock that stalls
+	// mid-body, which ResponseHeaderTimeout alone cannot see.
+	verifyDownloadTimeout = time.Hour
+	// verifyResponseHeaderTimeout bounds the wait for the download's headers.
+	verifyResponseHeaderTimeout = 5 * time.Minute
+)
+
+// Per-file actions reported by redeliver.
+const (
+	outputActionVerified        = "verified"         // already matched the recorded checksum
+	outputActionReuploaded      = "reuploaded"       // re-uploaded and re-verified OK
+	outputActionWouldReupload   = "would_reupload"   // dry run: original found, nothing changed
+	outputActionOriginalMissing = "original_missing" // no usable local original with that checksum+size
+	outputActionFailed          = "failed"           // re-upload or re-verify failed, or not recoverable
+)
+
+// outputFileReport is the per-file result of a verification or re-delivery.
+type outputFileReport struct {
+	SubmissionID     string `json:"submission_id"`
+	Location         string `json:"location"`
+	ExpectedChecksum string `json:"expected_checksum,omitempty"`
+	ActualChecksum   string `json:"actual_checksum,omitempty"`
+	ExpectedSize     int64  `json:"expected_size"`
+	ActualSize       int64  `json:"actual_size"`
+	OK               bool   `json:"ok"`
+	Error            string `json:"error,omitempty"`
+
+	// Redeliver-only fields.
+	Action string `json:"action,omitempty"`
+	Source string `json:"source,omitempty"` // local original used (or that would be used)
+
+	ref *outputFileRef // internal
+}
+
+// outputReportSummary aggregates the per-file outcomes.
+type outputReportSummary struct {
+	Total           int `json:"total"`
+	OK              int `json:"ok"`
+	Mismatched      int `json:"mismatched"`
+	Errors          int `json:"errors"`
+	Reuploaded      int `json:"reuploaded,omitempty"`
+	WouldReupload   int `json:"would_reupload,omitempty"`
+	OriginalMissing int `json:"original_missing,omitempty"`
+	Failed          int `json:"failed,omitempty"`
+}
+
+// outputReport is the response body of both endpoints.
+type outputReport struct {
+	SubmissionID     string              `json:"submission_id"`
+	State            string              `json:"state"`
+	OutputState      string              `json:"output_state"`
+	DryRun           bool                `json:"dry_run,omitempty"`
+	Submissions      []string            `json:"submissions"` // root + descendants examined
+	Files            []outputFileReport  `json:"files"`
+	Summary          outputReportSummary `json:"summary"`
+	Updated          bool                `json:"updated,omitempty"`           // submission row(s) written
+	StateRestored    bool                `json:"state_restored,omitempty"`    // FAILED(OUTPUT_STAGING_FAILED) → COMPLETED
+	ManifestUploaded bool                `json:"manifest_uploaded,omitempty"` // _gowe_outputs.json rewritten
+	ManifestError    string              `json:"manifest_error,omitempty"`
+}
+
+// outputFileRef is one File object found in a submission's output tree.
+type outputFileRef struct {
+	sub      *model.Submission
+	obj      map[string]any
+	location string
+	subPath  string // Directory nesting below the output destination
+	base     string // workspace path every re-upload for this file must stay under
+}
+
+// subExpect is the (state, output_state) pair a submission had when the
+// request loaded it; every write is compare-and-set against it.
+type subExpect struct {
+	state       model.SubmissionState
+	outputState string
+}
+
+// handleAdminVerifyOutputs downloads every ws:// output File of the submission
+// (and its descendants) and compares it to the recorded checksum and size.
+// POST /api/v1/admin/submissions/{id}/verify-outputs
+func (s *Server) handleAdminVerifyOutputs(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+	ctx := r.Context()
+
+	root, token, ok := s.loadOutputRecoveryTarget(w, r)
+	if !ok {
+		return
+	}
+
+	subs, err := s.collectOutputTree(ctx, root)
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+	refs := collectOutputFileRefs(root, subs)
+
+	files := s.verifyOutputFiles(ctx, token, refs)
+	respondOK(w, reqID, buildOutputReport(root, subs, files, false))
+}
+
+// handleAdminRedeliverOutputs re-uploads every output that does not verify
+// from its local original and re-verifies it.
+// POST /api/v1/admin/submissions/{id}/redeliver?dry_run=true
+func (s *Server) handleAdminRedeliverOutputs(w http.ResponseWriter, r *http.Request) {
+	reqID := RequestIDFromContext(r.Context())
+	ctx := r.Context()
+	dryRun := r.URL.Query().Get("dry_run") == "true"
+	id := chi.URLParam(r, "id")
+
+	// One re-delivery per submission at a time; the lock is in-memory so a
+	// crash mid-request never leaves a stuck marker in the database.
+	if _, busy := s.redeliverLocks.LoadOrStore(id, struct{}{}); busy {
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code:    model.ErrConflict,
+			Message: "re-delivery in progress for this submission",
+		})
+		return
+	}
+	defer s.redeliverLocks.Delete(id)
+
+	root, token, ok := s.loadOutputRecoveryTarget(w, r)
+	if !ok {
+		return
+	}
+
+	subs, err := s.collectOutputTree(ctx, root)
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return
+	}
+	// Snapshot the loaded states before anything below mutates them.
+	expect := map[string]subExpect{}
+	for _, sub := range subs {
+		expect[sub.ID] = subExpect{state: sub.State, outputState: sub.OutputState}
+	}
+	refs := collectOutputFileRefs(root, subs)
+
+	files := s.verifyOutputFiles(ctx, token, refs)
+
+	// Local originals, keyed by checksum+size, from every task in the tree.
+	index := s.buildOriginalIndex(ctx, subs)
+
+	changed := map[string]*model.Submission{}
+	for i := range files {
+		f := &files[i]
+		if f.OK {
+			f.Action = outputActionVerified
+			continue
+		}
+		s.redeliverOutputFile(ctx, token, f, index, dryRun, changed)
+	}
+
+	report := buildOutputReport(root, subs, files, dryRun)
+	if dryRun {
+		respondOK(w, reqID, report)
+		return
+	}
+
+	allOK := report.Summary.Total > 0 && report.Summary.OK == report.Summary.Total
+	rootDirty := changed[root.ID] != nil
+	if allOK && root.OutputState != outputStateDelivered {
+		root.OutputState = outputStateDelivered
+		rootDirty = true
+		// The scheduler fails a submission whose delivery failed; the work
+		// itself completed, so a successful re-delivery restores it.
+		if root.State == model.SubmissionStateFailed && root.Error != nil && root.Error.Code == outputStagingFailedCode {
+			root.State = model.SubmissionStateCompleted
+			root.Error = nil
+			report.StateRestored = true
+		}
+	}
+
+	// Persist: children first, root last, each compare-and-set against the
+	// state it had when this request loaded it.
+	for _, sub := range subs {
+		if sub.ID == root.ID {
+			continue
+		}
+		if changed[sub.ID] == nil {
+			continue
+		}
+		if !s.persistRedelivered(w, reqID, ctx, sub, expect[sub.ID]) {
+			return
+		}
+		report.Updated = true
+	}
+	if rootDirty {
+		if !s.persistRedelivered(w, reqID, ctx, root, expect[root.ID]) {
+			return
+		}
+		report.Updated = true
+		s.logger.Info("redeliver: submission updated",
+			"submission_id", root.ID,
+			"output_state", root.OutputState,
+			"state", root.State,
+			"reuploaded", report.Summary.Reuploaded,
+		)
+
+		// The manifest names every output with its location; rewrite it so it
+		// reflects the re-delivered tree. Non-fatal: the files are already
+		// verified in place.
+		if base, ok := wsPathOf(root.OutputDestination); ok {
+			stager := s.wsStager.WithToken(token)
+			if dest, err := staging.UploadOutputManifest(ctx, stager, root, base); err != nil {
+				s.logger.Warn("redeliver: upload output manifest failed", "submission_id", root.ID, "error", err)
+				report.ManifestError = err.Error()
+			} else {
+				s.logger.Info("redeliver: uploaded output manifest", "submission_id", root.ID, "path", dest)
+				report.ManifestUploaded = true
+			}
+		}
+	}
+	report.State = string(root.State)
+	report.OutputState = root.OutputState
+
+	respondOK(w, reqID, report)
+}
+
+// persistRedelivered writes sub with compare-and-set against expect and
+// answers 409 (returning false) when the row moved on since it was loaded.
+func (s *Server) persistRedelivered(w http.ResponseWriter, reqID string, ctx context.Context, sub *model.Submission, expect subExpect) bool {
+	applied, err := s.store.UpdateSubmissionIfState(ctx, sub, expect.state, expect.outputState)
+	if err != nil {
+		s.logger.Error("redeliver: update submission", "submission_id", sub.ID, "error", err)
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return false
+	}
+	if !applied {
+		s.logger.Warn("redeliver: submission changed concurrently; not written",
+			"submission_id", sub.ID, "expected_state", expect.state, "expected_output_state", expect.outputState)
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code:    model.ErrConflict,
+			Message: fmt.Sprintf("submission %s changed concurrently (expected state=%s output_state=%q); nothing written, re-run to retry", sub.ID, expect.state, expect.outputState),
+		})
+		return false
+	}
+	return true
+}
+
+// loadOutputRecoveryTarget resolves the submission and its stored token,
+// writing the error response itself when the request cannot proceed. Both
+// endpoints accept only submissions whose delivery already ran to an outcome
+// (output_state delivered or upload_failed): anything else has either not
+// been delivered by this server or is being delivered right now.
+func (s *Server) loadOutputRecoveryTarget(w http.ResponseWriter, r *http.Request) (*model.Submission, string, bool) {
+	reqID := RequestIDFromContext(r.Context())
+	id := chi.URLParam(r, "id")
+
+	if s.wsStager == nil {
+		respondError(w, reqID, http.StatusServiceUnavailable, &model.APIError{
+			Code:    model.ErrInternal,
+			Message: "workspace staging not configured on this server",
+		})
+		return nil, "", false
+	}
+
+	sub, err := s.store.GetSubmission(r.Context(), id)
+	if err != nil {
+		respondError(w, reqID, http.StatusInternalServerError, model.NewInternalError(err.Error()))
+		return nil, "", false
+	}
+	if sub == nil {
+		respondError(w, reqID, http.StatusNotFound, model.NewNotFoundError("submission", id))
+		return nil, "", false
+	}
+
+	switch sub.OutputState {
+	case outputStateDelivered, outputStateUploadFailed:
+	case outputStateUploading:
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code:    model.ErrConflict,
+			Message: "submission outputs are currently being uploaded by the scheduler; retry later",
+		})
+		return nil, "", false
+	default:
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code:    model.ErrConflict,
+			Message: fmt.Sprintf("submission output_state is %q; only \"delivered\" or \"upload_failed\" submissions can be verified or re-delivered", sub.OutputState),
+		})
+		return nil, "", false
+	}
+	if !sub.State.IsTerminal() {
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code:    model.ErrConflict,
+			Message: fmt.Sprintf("submission is %s; outputs can only be verified or re-delivered once it is terminal", sub.State),
+		})
+		return nil, "", false
+	}
+
+	// The stored submission token is the only credential that can read and
+	// write the owner's workspace; the admin's own token is not a fallback.
+	if sub.UserToken == "" {
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code:    model.ErrConflict,
+			Message: "submission has no stored user token; the workspace cannot be accessed on the owner's behalf",
+		})
+		return nil, "", false
+	}
+	if !sub.TokenExpiry.IsZero() && time.Now().After(sub.TokenExpiry) {
+		respondError(w, reqID, http.StatusConflict, &model.APIError{
+			Code: model.ErrConflict,
+			Message: fmt.Sprintf("stored user token expired at %s; the owner must re-submit (or re-authenticate) before outputs can be verified or re-delivered",
+				sub.TokenExpiry.UTC().Format(time.RFC3339)),
+		})
+		return nil, "", false
+	}
+
+	return sub, sub.UserToken, true
+}
+
+// collectOutputTree returns the root submission followed by every descendant
+// child submission (spawned via sub-workflow proxy tasks), each loaded in
+// full through GetSubmission. The visited set guards against cycles.
+func (s *Server) collectOutputTree(ctx context.Context, root *model.Submission) ([]*model.Submission, error) {
+	visited := map[string]bool{root.ID: true}
+	out := []*model.Submission{root}
+
+	var walk func(sub *model.Submission) error
+	walk = func(sub *model.Submission) error {
+		tasks, err := s.store.ListTasksBySubmission(ctx, sub.ID)
+		if err != nil {
+			return fmt.Errorf("list tasks for %s: %w", sub.ID, err)
+		}
+		for _, task := range tasks {
+			if task.ExecutorType != model.ExecutorTypeSubworkflow {
+				continue
+			}
+			children, err := s.store.GetChildSubmissions(ctx, task.ID)
+			if err != nil {
+				return fmt.Errorf("list children of task %s: %w", task.ID, err)
+			}
+			for _, child := range children {
+				if visited[child.ID] {
+					continue
+				}
+				visited[child.ID] = true
+				// GetChildSubmissions returns a partial row; load the full one
+				// so a later UpdateSubmission writes every column faithfully.
+				full, err := s.store.GetSubmission(ctx, child.ID)
+				if err != nil {
+					return fmt.Errorf("load child submission %s: %w", child.ID, err)
+				}
+				if full == nil {
+					continue
+				}
+				out = append(out, full)
+				if err := walk(full); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	if err := walk(root); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// collectOutputFileRefs walks every submission's output tree and returns the
+// File objects that matter for delivery: every ws:// File, plus file:// Files
+// on submissions that have an output destination (those were never delivered).
+// Child submissions carry no destination, so their file:// outputs — which the
+// parent gathers and delivers — are not reported twice. Each ref records the
+// workspace base every re-upload must stay under: the submission's own
+// destination, or the root's for children.
+func collectOutputFileRefs(root *model.Submission, subs []*model.Submission) []*outputFileRef {
+	rootBase, _ := wsPathOf(root.OutputDestination)
+	var refs []*outputFileRef
+	for _, sub := range subs {
+		base := rootBase
+		if b, ok := wsPathOf(sub.OutputDestination); ok {
+			base = b
+		}
+		walkOutputFiles(sub.Outputs, "", func(obj map[string]any, subPath string) {
+			loc, _ := obj["location"].(string)
+			switch {
+			case strings.HasPrefix(loc, "ws://"):
+			case strings.HasPrefix(loc, "file://") && sub.OutputDestination != "":
+			default:
+				return
+			}
+			refs = append(refs, &outputFileRef{sub: sub, obj: obj, location: loc, subPath: subPath, base: base})
+		})
+	}
+	return refs
+}
+
+// walkOutputFiles visits every File object in a CWL output value at any
+// nesting (maps, arrays, Directory listings), tracking the Directory path
+// below the destination the same way the scheduler's stage-out does, so a
+// re-upload lands where the original delivery did. Like the scheduler's
+// stageFileInTree it does NOT descend into secondaryFiles: those are never
+// delivered on their own, so reporting them would only produce noise.
+func walkOutputFiles(v any, subPath string, fn func(obj map[string]any, subPath string)) {
+	switch val := v.(type) {
+	case map[string]any:
+		class, _ := val["class"].(string)
+		switch class {
+		case "File":
+			fn(val, subPath)
+		case "Directory":
+			childSubPath := subPath
+			if basename, ok := val["basename"].(string); ok && basename != "" {
+				if childSubPath != "" {
+					childSubPath += "/" + basename
+				} else {
+					childSubPath = basename
+				}
+			}
+			if listing, ok := val["listing"]; ok {
+				walkOutputFiles(listing, childSubPath, fn)
+			}
+		default:
+			for _, item := range val {
+				walkOutputFiles(item, subPath, fn)
+			}
+		}
+	case []any:
+		for _, item := range val {
+			walkOutputFiles(item, subPath, fn)
+		}
+	}
+}
+
+// wsVerifier downloads workspace objects on behalf of the submission owner.
+type wsVerifier struct {
+	client *bvbrc.Client
+	http   *http.Client
+	token  string
+}
+
+var (
+	verifyTransportOnce   sync.Once
+	sharedVerifyTransport *http.Transport
+)
+
+// verifyTransport is the process-wide download transport: the default
+// transport with a bounded wait for response headers, shared so verifier
+// instances (one per request) pool connections.
+func verifyTransport() *http.Transport {
+	verifyTransportOnce.Do(func() {
+		tr, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			tr = &http.Transport{Proxy: http.ProxyFromEnvironment}
+		}
+		tr = tr.Clone()
+		tr.ResponseHeaderTimeout = verifyResponseHeaderTimeout
+		tr.IdleConnTimeout = 90 * time.Second
+		sharedVerifyTransport = tr
+	})
+	return sharedVerifyTransport
+}
+
+func (s *Server) newWSVerifier(token string) *wsVerifier {
+	cfg := s.wsStager.Config()
+	return &wsVerifier{
+		client: bvbrc.NewClient(bvbrc.Config{
+			WorkspaceURL: cfg.WorkspaceURL,
+			Token:        token,
+			Timeout:      cfg.Timeout,
+		}, s.logger),
+		// No total client timeout: the body streams into a hasher for as
+		// long as it takes. Headers are bounded by the transport and the
+		// whole download by the per-request deadline in hashDownload.
+		http:  &http.Client{Transport: verifyTransport()},
+		token: token,
+	}
+}
+
+// downloadURLs resolves download URLs for the given workspace paths in one
+// RPC; a missing object or a folder yields "".
+func (v *wsVerifier) downloadURLs(ctx context.Context, paths []string) (map[string]string, error) {
+	if len(paths) == 0 {
+		return map[string]string{}, nil
+	}
+	return v.client.WorkspaceGetDownloadURL(ctx, paths)
+}
+
+// hashDownload streams the object at url through a SHA-1 hasher and returns
+// the CWL-style checksum and the byte count.
+func (v *wsVerifier) hashDownload(ctx context.Context, url string) (string, int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, verifyDownloadTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", 0, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "OAuth "+v.token)
+
+	resp, err := v.http.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", 0, fmt.Errorf("download HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	h := sha1.New()
+	n, err := io.Copy(h, resp.Body)
+	if err != nil {
+		return "", n, fmt.Errorf("read body: %w", err)
+	}
+	return "sha1$" + hex.EncodeToString(h.Sum(nil)), n, nil
+}
+
+// verifyOutputFiles compares each referenced File to its recorded checksum
+// and size. It is read-only.
+func (s *Server) verifyOutputFiles(ctx context.Context, token string, refs []*outputFileRef) []outputFileReport {
+	verifier := s.newWSVerifier(token)
+
+	var wsPaths []string
+	for _, ref := range refs {
+		if p, ok := wsPathOf(ref.location); ok {
+			wsPaths = append(wsPaths, p)
+		}
+	}
+	urls, urlErr := verifier.downloadURLs(ctx, wsPaths)
+
+	files := make([]outputFileReport, 0, len(refs))
+	for _, ref := range refs {
+		f := outputFileReport{
+			SubmissionID:     ref.sub.ID,
+			Location:         ref.location,
+			ExpectedChecksum: stringField(ref.obj, "checksum"),
+			ExpectedSize:     int64Field(ref.obj, "size"),
+			ref:              ref,
+		}
+		s.verifyOne(ctx, verifier, &f, urls, urlErr)
+		files = append(files, f)
+	}
+	return files
+}
+
+// verifyOne fills in the actual checksum/size and the ok/error outcome of f.
+// urls/urlErr are the batched get_download_url result for all ws:// refs.
+func (s *Server) verifyOne(ctx context.Context, verifier *wsVerifier, f *outputFileReport, urls map[string]string, urlErr error) {
+	f.OK = false
+	f.ActualChecksum = ""
+	f.ActualSize = 0
+	f.Error = ""
+
+	wsPath, isWS := wsPathOf(f.Location)
+	if !isWS {
+		if strings.HasPrefix(f.Location, "file://") {
+			f.Error = "not delivered: output still has a local file:// location"
+		} else {
+			f.Error = "unsupported location scheme"
+		}
+		return
+	}
+	if f.ExpectedChecksum == "" {
+		f.Error = "no recorded checksum to compare against"
+		return
+	}
+	if urlErr != nil {
+		f.Error = "get download URL: " + urlErr.Error()
+		return
+	}
+	url := urls[wsPath]
+	if url == "" {
+		f.Error = "no download URL: object is missing from the workspace (or is a folder)"
+		return
+	}
+
+	sum, n, err := verifier.hashDownload(ctx, url)
+	if err != nil {
+		f.Error = err.Error()
+		return
+	}
+	f.ActualChecksum = sum
+	f.ActualSize = n
+
+	switch {
+	case sum != f.ExpectedChecksum:
+		f.Error = "checksum mismatch"
+	case f.ExpectedSize > 0 && n != f.ExpectedSize:
+		f.Error = fmt.Sprintf("size mismatch: workspace holds %d bytes, expected %d", n, f.ExpectedSize)
+	default:
+		f.OK = true
+	}
+}
+
+// originalKey keys local originals by the recorded checksum and size.
+func originalKey(checksum string, size int64) string {
+	return checksum + "|" + fmt.Sprint(size)
+}
+
+// checkCandidate decides, without opening it, whether a local path may be
+// read as an original: it must resolve inside --redeliver-source-dirs, be a
+// regular file (never a FIFO, device or directory, which could block or leak)
+// and have the recorded size. Returns a reason when it must be skipped.
+func (s *Server) checkCandidate(p string, expectedSize int64) string {
+	if len(s.redeliverSourceDirs) == 0 {
+		return "file:// recovery refused: the server has no --redeliver-source-dirs configured"
+	}
+	if !pathUnderAny(p, s.redeliverSourceDirs) {
+		return fmt.Sprintf("%s is outside --redeliver-source-dirs", p)
+	}
+	st, err := os.Stat(p)
+	if err != nil {
+		return err.Error()
+	}
+	if !st.Mode().IsRegular() {
+		return fmt.Sprintf("%s is not a regular file (%s)", p, st.Mode().Type())
+	}
+	if expectedSize > 0 && st.Size() != expectedSize {
+		return fmt.Sprintf("%s has size %d, expected %d", p, st.Size(), expectedSize)
+	}
+	return ""
+}
+
+// originalIndex maps checksum+size → an admissible local path, and keeps
+// the reasons candidates for a key were rejected so a per-file "original
+// missing" outcome can say why.
+type originalIndex struct {
+	paths   map[string]string
+	skipped map[string][]string
+}
+
+// buildOriginalIndex indexes every file:// output File recorded on any task
+// of the given submissions by checksum+size (scatter shards share basenames,
+// so the name is never used for matching). Sub-workflow proxy tasks mirror
+// their child's outputs, so a file may be seen twice; the first admissible
+// path wins. Only candidates that pass checkCandidate are indexed.
+func (s *Server) buildOriginalIndex(ctx context.Context, subs []*model.Submission) *originalIndex {
+	index := &originalIndex{paths: map[string]string{}, skipped: map[string][]string{}}
+	if len(s.redeliverSourceDirs) == 0 {
+		return index
+	}
+	for _, sub := range subs {
+		tasks, err := s.store.ListTasksBySubmission(ctx, sub.ID)
+		if err != nil {
+			s.logger.Warn("redeliver: list tasks for original index", "submission_id", sub.ID, "error", err)
+			continue
+		}
+		for _, task := range tasks {
+			walkOutputFiles(task.Outputs, "", func(obj map[string]any, _ string) {
+				local := localPathOf(obj)
+				if local == "" {
+					return
+				}
+				checksum := stringField(obj, "checksum")
+				if checksum == "" {
+					return
+				}
+				size := int64Field(obj, "size")
+				key := originalKey(checksum, size)
+				if _, seen := index.paths[key]; seen {
+					return
+				}
+				if reason := s.checkCandidate(local, size); reason != "" {
+					s.logger.Debug("redeliver: candidate skipped", "task_id", task.ID, "path", local, "reason", reason)
+					index.skipped[key] = append(index.skipped[key], reason)
+					return
+				}
+				index.paths[key] = local
+			})
+		}
+	}
+	return index
+}
+
+// redeliverOutputFile recovers one failed output: locate the original, verify
+// it locally, re-upload it to the same workspace path, and re-verify.
+func (s *Server) redeliverOutputFile(ctx context.Context, token string, f *outputFileReport, index *originalIndex, dryRun bool, changed map[string]*model.Submission) {
+	ref := f.ref
+	if f.ExpectedChecksum == "" {
+		f.Action = outputActionFailed
+		f.Error = "no recorded checksum; cannot re-deliver safely"
+		return
+	}
+
+	// Where the object must live — always inside the workspace base.
+	var destDir, name string
+	if wsPath, ok := wsPathOf(f.Location); ok {
+		wsPath = path.Clean(wsPath)
+		destDir, name = path.Dir(wsPath), path.Base(wsPath)
+	} else if strings.HasPrefix(f.Location, "file://") {
+		if ref.base == "" {
+			f.Action = outputActionFailed
+			f.Error = "submission has no ws:// output destination"
+			return
+		}
+		name = stringField(ref.obj, "basename")
+		if name == "" {
+			name = filepath.Base(strings.TrimPrefix(f.Location, "file://"))
+		}
+		destDir = path.Clean(strings.TrimRight(ref.base, "/") + "/" + ref.subPath)
+	} else {
+		f.Action = outputActionFailed
+		return // error already set by verify
+	}
+	if ref.base == "" || !wsPathUnder(path.Join(destDir, name), ref.base) {
+		f.Action = outputActionFailed
+		f.Error = fmt.Sprintf("workspace path %s is outside the submission's output destination %s", path.Join(destDir, name), ref.base)
+		return
+	}
+
+	// Locate a local original: the File's own file:// path first, then any
+	// task output with the same checksum+size. Every candidate is admitted by
+	// checkCandidate before it is opened.
+	key := originalKey(f.ExpectedChecksum, f.ExpectedSize)
+	var candidates []string
+	if strings.HasPrefix(f.Location, "file://") {
+		candidates = append(candidates, strings.TrimPrefix(f.Location, "file://"))
+	}
+	if local, ok := index.paths[key]; ok && (len(candidates) == 0 || candidates[0] != local) {
+		candidates = append(candidates, local)
+	}
+	original := ""
+	reasons := append([]string(nil), index.skipped[key]...)
+	if len(s.redeliverSourceDirs) == 0 && len(candidates) == 0 {
+		reasons = append(reasons, s.checkCandidate("", 0))
+	}
+	for _, c := range candidates {
+		if reason := s.checkCandidate(c, f.ExpectedSize); reason != "" {
+			reasons = append(reasons, reason)
+			continue
+		}
+		sum, n, err := sha1File(c)
+		switch {
+		case err != nil:
+			reasons = append(reasons, err.Error())
+		case sum != f.ExpectedChecksum || (f.ExpectedSize > 0 && n != f.ExpectedSize):
+			reasons = append(reasons, fmt.Sprintf("%s does not match the recorded checksum/size", c))
+		default:
+			original = c
+		}
+		if original != "" {
+			break
+		}
+	}
+	if original == "" {
+		f.Action = outputActionOriginalMissing
+		f.Error = fmt.Sprintf("no usable local original with checksum %s and size %d found in task outputs", f.ExpectedChecksum, f.ExpectedSize)
+		if len(reasons) > 0 {
+			f.Error += " (" + strings.Join(reasons, "; ") + ")"
+		}
+		return
+	}
+	f.Source = original
+
+	// StageOut names the object after the local file; the original was staged
+	// by that same code, so the names agree unless something rewrote them.
+	if filepath.Base(original) != name {
+		f.Action = outputActionFailed
+		f.Error = fmt.Sprintf("basename mismatch: original %q vs workspace object %q", filepath.Base(original), name)
+		return
+	}
+
+	if dryRun {
+		f.Action = outputActionWouldReupload
+		return
+	}
+
+	stager := s.wsStager.WithToken(token)
+	s.logger.Info("redeliver: re-uploading output",
+		"submission_id", ref.sub.ID, "source", original, "dest", destDir+"/"+name)
+	newLoc, err := stager.StageOut(ctx, original, ref.sub.ID, staging.StageOptions{
+		Metadata: map[string]string{"destination": destDir},
+	})
+	if err != nil {
+		f.Action = outputActionFailed
+		f.Error = "re-upload: " + err.Error()
+		return
+	}
+
+	// Re-verify what the workspace now serves.
+	verifier := s.newWSVerifier(token)
+	newPath, _ := wsPathOf(newLoc)
+	urls, urlErr := verifier.downloadURLs(ctx, []string{newPath})
+	prev := f.Location
+	f.Location = newLoc
+	s.verifyOne(ctx, verifier, f, urls, urlErr)
+	if !f.OK {
+		f.Action = outputActionFailed
+		f.Error = "re-verify after upload: " + f.Error
+		return
+	}
+	f.Action = outputActionReuploaded
+
+	if newLoc != prev {
+		ref.obj["location"] = newLoc
+		changed[ref.sub.ID] = ref.sub
+	}
+}
+
+// buildOutputReport assembles the response and tallies the summary.
+func buildOutputReport(root *model.Submission, subs []*model.Submission, files []outputFileReport, dryRun bool) outputReport {
+	report := outputReport{
+		SubmissionID: root.ID,
+		State:        string(root.State),
+		OutputState:  root.OutputState,
+		DryRun:       dryRun,
+		Submissions:  make([]string, 0, len(subs)),
+		Files:        files,
+	}
+	for _, sub := range subs {
+		report.Submissions = append(report.Submissions, sub.ID)
+	}
+	sum := &report.Summary
+	sum.Total = len(files)
+	for i := range files {
+		f := &files[i]
+		f.ref = nil
+		switch {
+		case f.OK:
+			sum.OK++
+		case f.ActualChecksum != "":
+			sum.Mismatched++
+		default:
+			sum.Errors++
+		}
+		switch f.Action {
+		case outputActionReuploaded:
+			sum.Reuploaded++
+		case outputActionWouldReupload:
+			sum.WouldReupload++
+		case outputActionOriginalMissing:
+			sum.OriginalMissing++
+		case outputActionFailed:
+			sum.Failed++
+		}
+	}
+	return report
+}
+
+// wsPathOf extracts the workspace path from a ws:// URI or destination.
+// ws:///user@bvbrc/home/x → /user@bvbrc/home/x
+func wsPathOf(location string) (string, bool) {
+	if !strings.HasPrefix(location, "ws://") {
+		return "", false
+	}
+	p := strings.TrimPrefix(location, "ws://")
+	p = "/" + strings.TrimLeft(p, "/")
+	if p == "/" {
+		return "", false
+	}
+	return p, true
+}
+
+// wsPathUnder reports whether workspace path p lies at or below base
+// (segment-aware, both cleaned).
+func wsPathUnder(p, base string) bool {
+	p = path.Clean(p)
+	base = path.Clean(base)
+	return p == base || strings.HasPrefix(p, base+"/")
+}
+
+// localPathOf returns the local filesystem path of a task output File: its
+// file:// location, or its bare "path" when no location was recorded.
+func localPathOf(obj map[string]any) string {
+	if loc := stringField(obj, "location"); loc != "" {
+		if strings.HasPrefix(loc, "file://") {
+			return strings.TrimPrefix(loc, "file://")
+		}
+		return ""
+	}
+	return stringField(obj, "path")
+}
+
+// sha1File returns the CWL-style checksum and size of a local file. Callers
+// admit the path with checkCandidate first.
+func sha1File(p string) (string, int64, error) {
+	f, err := os.Open(p)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+	h := sha1.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return "sha1$" + hex.EncodeToString(h.Sum(nil)), n, nil
+}
+
+func stringField(m map[string]any, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+// int64Field reads a numeric field that may arrive as float64 (JSON round
+// trip through the store), int, or int64.
+func int64Field(m map[string]any, key string) int64 {
+	switch v := m[key].(type) {
+	case float64:
+		return int64(v)
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	}
+	return 0
+}

--- a/internal/server/handler_admin_outputs_test.go
+++ b/internal/server/handler_admin_outputs_test.go
@@ -1,0 +1,1052 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/me/gowe/pkg/bvbrc"
+	"github.com/me/gowe/pkg/bvbrc/bvbrctest"
+	"github.com/me/gowe/pkg/model"
+	"github.com/me/gowe/pkg/staging"
+)
+
+// Tokens in the BV-BRC pipe-delimited format; expiry is 2100-01-01.
+const (
+	adminAuthToken = "un=admin|tokenid=t-admin|expiry=4102444800|sig=x"
+	userAuthToken  = "un=tester|tokenid=t-user|expiry=4102444800|sig=y"
+	ownerToken     = "un=tester@bvbrc|tokenid=t-owner|expiry=4102444800|sig=z"
+	wsHome         = "/tester@bvbrc/home/results"
+)
+
+// adminOutputsServer builds a server wired to the fake Workspace, with
+// "admin" granted the admin role through the CLI-admins source and the given
+// directories allowed as re-delivery sources.
+func adminOutputsServer(t *testing.T, withStager bool, sourceDirs ...string) (*Server, *bvbrctest.Server) {
+	t.Helper()
+	f := bvbrctest.New(t)
+	adminCfg := NewAdminConfig(nil, "GOWE_TEST_ADMINS_UNSET_VAR", "")
+	adminCfg.WithCLIAdmins([]string{"admin"})
+	opts := []Option{WithAdminConfig(adminCfg), WithRedeliverSourceDirs(sourceDirs)}
+	if withStager {
+		stager := staging.NewWorkspaceStager(staging.WorkspaceConfig{
+			WorkspaceURL: f.WorkspaceURL(),
+			MaxRetries:   1,
+		}, nil)
+		opts = append(opts, WithWorkspaceStager(stager))
+	}
+	return testServer(opts...), f
+}
+
+func postAs(t *testing.T, srv *Server, path, token string) (*httptest.ResponseRecorder, envelope) {
+	t.Helper()
+	req := httptest.NewRequest("POST", path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	var env envelope
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	return w, env
+}
+
+func decodeReport(t *testing.T, env envelope) outputReport {
+	t.Helper()
+	var rep outputReport
+	if err := json.Unmarshal(env.Data, &rep); err != nil {
+		t.Fatalf("decode report: %v (data=%s)", err, string(env.Data))
+	}
+	return rep
+}
+
+func sha1Sum(b []byte) string {
+	h := sha1.Sum(b)
+	return "sha1$" + hex.EncodeToString(h[:])
+}
+
+// binaryPayload is a payload with every byte value, which the pre-#174 inline
+// JSON path corrupts.
+func binaryPayload(reps int) []byte {
+	out := make([]byte, 0, 256*reps)
+	for r := 0; r < reps; r++ {
+		for i := 0; i < 256; i++ {
+			out = append(out, byte(i))
+		}
+	}
+	return out
+}
+
+// corruptedOf mimics the damage: every non-ASCII byte replaced by U+FFFD.
+func corruptedOf(good []byte) []byte {
+	var out []byte
+	for _, b := range good {
+		if b < 0x80 {
+			out = append(out, b)
+		} else {
+			out = append(out, []byte("�")...)
+		}
+	}
+	return out
+}
+
+// uploadToFake stores content at wsPath through the real protocol so the fake
+// mints a Shock node the download path can serve.
+func uploadToFake(t *testing.T, f *bvbrctest.Server, wsPath string, content []byte) {
+	t.Helper()
+	c := bvbrc.NewClient(bvbrc.Config{WorkspaceURL: f.WorkspaceURL(), Token: ownerToken}, nil)
+	if _, err := c.WorkspaceUploadFile(context.Background(), wsPath, content, bvbrc.WorkspaceTypeUnspecified); err != nil {
+		t.Fatalf("seed upload %s: %v", wsPath, err)
+	}
+}
+
+// fileObj builds a CWL File output object the way the worker records it.
+func fileObj(location, basename string, content []byte) map[string]any {
+	return map[string]any{
+		"class":    "File",
+		"location": location,
+		"basename": basename,
+		"checksum": sha1Sum(content),
+		"size":     len(content),
+	}
+}
+
+// writeOriginal writes the staged original as <stageDir>/<taskID>/<name> and
+// returns its file:// location.
+func writeOriginal(t *testing.T, stageDir, taskID, name string, content []byte) string {
+	t.Helper()
+	dir := filepath.Join(stageDir, taskID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return "file://" + p
+}
+
+// seedSubmission stores a terminal submission owned by the fake's user. An
+// upload_failed one is FAILED with the scheduler's error code, as in prod.
+func seedSubmission(t *testing.T, srv *Server, wfID, id string, outputs map[string]any, outputState string) *model.Submission {
+	t.Helper()
+	sub := &model.Submission{
+		ID:                id,
+		WorkflowID:        wfID,
+		WorkflowName:      "test-workflow",
+		State:             model.SubmissionStateCompleted,
+		Inputs:            map[string]any{},
+		Outputs:           outputs,
+		SubmittedBy:       "tester@bvbrc",
+		OutputDestination: "ws://" + wsHome,
+		OutputState:       outputState,
+		UserToken:         ownerToken,
+		TokenExpiry:       time.Now().Add(24 * time.Hour),
+		CreatedAt:         time.Now().UTC(),
+	}
+	if outputState == outputStateUploadFailed {
+		sub.State = model.SubmissionStateFailed
+		sub.Error = &model.SubmissionError{Code: outputStagingFailedCode, Message: "workspace output upload failed"}
+	}
+	if err := srv.store.CreateSubmission(context.Background(), sub); err != nil {
+		t.Fatalf("seed submission %s: %v", id, err)
+	}
+	// The INSERT does not carry the error column (the scheduler sets it on
+	// update); persist it the same way so the row looks like prod's.
+	if sub.Error != nil {
+		if err := srv.store.UpdateSubmission(context.Background(), sub); err != nil {
+			t.Fatalf("seed submission error %s: %v", id, err)
+		}
+	}
+	return sub
+}
+
+func seedTask(t *testing.T, srv *Server, subID, taskID string, execType model.ExecutorType, outputs map[string]any) {
+	t.Helper()
+	task := &model.Task{
+		ID:           taskID,
+		SubmissionID: subID,
+		StepID:       "work",
+		State:        model.TaskStateSuccess,
+		ExecutorType: execType,
+		Inputs:       map[string]any{},
+		Outputs:      outputs,
+		Job:          map[string]any{},
+		ScatterIndex: -1,
+	}
+	if err := srv.store.CreateTask(context.Background(), task); err != nil {
+		t.Fatalf("seed task %s: %v", taskID, err)
+	}
+}
+
+// deliveredFixture is a submission whose single ws:// output holds corrupted
+// bytes while the recorded checksum/size describe the good ones, and a task
+// row pointing at the intact original on the stage-out dir.
+type deliveredFixture struct {
+	sub      *model.Submission
+	wsPath   string
+	good     []byte
+	original string // local path
+}
+
+func seedDelivered(t *testing.T, srv *Server, f *bvbrctest.Server, stage, outputState string) deliveredFixture {
+	t.Helper()
+	wfID := createTestWorkflow(t, srv)
+	good := binaryPayload(8)
+	wsPath := wsHome + "/chunks.bin"
+	uploadToFake(t, f, wsPath, corruptedOf(good))
+
+	loc := writeOriginal(t, stage, "task_a", "chunks.bin", good)
+	sub := seedSubmission(t, srv, wfID, "sub_delivered_"+outputState, map[string]any{
+		"result": fileObj("ws://"+wsPath, "chunks.bin", good),
+	}, outputState)
+	seedTask(t, srv, sub.ID, "task_a", model.ExecutorTypeWorker, map[string]any{
+		"result": fileObj(loc, "chunks.bin", good),
+	})
+	return deliveredFixture{sub: sub, wsPath: wsPath, good: good, original: loc[len("file://"):]}
+}
+
+// manifestCreates returns the Workspace.create calls that targeted the
+// output manifest.
+func manifestCreates(t *testing.T, f *bvbrctest.Server) []string {
+	t.Helper()
+	var out []string
+	for _, c := range f.CallsTo("Workspace.create") {
+		var p struct {
+			Objects [][]any `json:"objects"`
+		}
+		if err := json.Unmarshal(c.Params, &p); err != nil {
+			t.Fatal(err)
+		}
+		for _, spec := range p.Objects {
+			if path, _ := spec[0].(string); strings.HasSuffix(path, "/"+staging.OutputManifestName) {
+				out = append(out, path)
+			}
+		}
+	}
+	return out
+}
+
+func TestAdminVerifyOutputs_ReportsMismatch(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	fx := seedDelivered(t, srv, f, stage, "delivered")
+
+	w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/verify-outputs", adminAuthToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	rep := decodeReport(t, env)
+
+	if rep.Summary.Total != 1 || rep.Summary.Mismatched != 1 || rep.Summary.OK != 0 {
+		t.Fatalf("summary = %+v, want 1 mismatched", rep.Summary)
+	}
+	got := rep.Files[0]
+	if got.OK || got.Error != "checksum mismatch" {
+		t.Errorf("file = %+v, want checksum mismatch", got)
+	}
+	if got.ExpectedChecksum != sha1Sum(fx.good) || got.ActualChecksum == "" || got.ActualChecksum == got.ExpectedChecksum {
+		t.Errorf("checksums: expected=%s actual=%s", got.ExpectedChecksum, got.ActualChecksum)
+	}
+	if got.ExpectedSize != int64(len(fx.good)) || got.ActualSize != int64(len(corruptedOf(fx.good))) {
+		t.Errorf("sizes: expected=%d actual=%d", got.ExpectedSize, got.ActualSize)
+	}
+	if got.Location != "ws://"+fx.wsPath || got.SubmissionID != fx.sub.ID {
+		t.Errorf("location/submission = %s/%s", got.Location, got.SubmissionID)
+	}
+
+	// Verify is read-only: nothing in the store or the workspace changed.
+	after, _ := srv.store.GetSubmission(context.Background(), fx.sub.ID)
+	if after.OutputState != "delivered" {
+		t.Errorf("output_state changed to %q", after.OutputState)
+	}
+	if bytes.Equal(f.Bytes(fx.wsPath), fx.good) {
+		t.Errorf("verify must not upload")
+	}
+}
+
+func TestAdminRedeliver_ReuploadsAndVerifies(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	fx := seedDelivered(t, srv, f, stage, "delivered")
+
+	w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	rep := decodeReport(t, env)
+
+	if rep.Summary.Total != 1 || rep.Summary.OK != 1 || rep.Summary.Reuploaded != 1 {
+		t.Fatalf("summary = %+v, want 1 reuploaded+ok", rep.Summary)
+	}
+	got := rep.Files[0]
+	if !got.OK || got.Action != outputActionReuploaded || got.Source != fx.original {
+		t.Errorf("file = %+v", got)
+	}
+	if got.ActualChecksum != sha1Sum(fx.good) || got.ActualSize != int64(len(fx.good)) {
+		t.Errorf("re-verify recorded %s/%d", got.ActualChecksum, got.ActualSize)
+	}
+	if !bytes.Equal(f.Bytes(fx.wsPath), fx.good) {
+		t.Errorf("workspace does not hold the good bytes after redeliver")
+	}
+	if rep.OutputState != "delivered" || rep.StateRestored {
+		t.Errorf("report state = %s/%s restored=%v", rep.State, rep.OutputState, rep.StateRestored)
+	}
+	// Same path and already delivered: no row write, no manifest rewrite.
+	if rep.Updated || rep.ManifestUploaded {
+		t.Errorf("updated=%v manifest=%v, but location and output_state were unchanged", rep.Updated, rep.ManifestUploaded)
+	}
+	if m := manifestCreates(t, f); len(m) != 0 {
+		t.Errorf("manifest written without a submission change: %v", m)
+	}
+
+	// A second verify is clean.
+	_, env = postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/verify-outputs", adminAuthToken)
+	if rep := decodeReport(t, env); rep.Summary.OK != 1 {
+		t.Errorf("post-redeliver verify summary = %+v", rep.Summary)
+	}
+}
+
+func TestAdminRedeliver_DryRunChangesNothing(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	fx := seedDelivered(t, srv, f, stage, "upload_failed")
+	putsBefore := len(f.Puts())
+
+	w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver?dry_run=true", adminAuthToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	rep := decodeReport(t, env)
+	if !rep.DryRun || rep.Summary.WouldReupload != 1 || rep.Summary.Reuploaded != 0 || rep.Updated {
+		t.Fatalf("report = %+v", rep)
+	}
+	if got := rep.Files[0]; got.Action != outputActionWouldReupload || got.Source != fx.original || got.OK {
+		t.Errorf("file = %+v", got)
+	}
+	if len(f.Puts()) != putsBefore {
+		t.Errorf("dry run performed %d uploads", len(f.Puts())-putsBefore)
+	}
+	if bytes.Equal(f.Bytes(fx.wsPath), fx.good) {
+		t.Errorf("dry run changed workspace content")
+	}
+	after, _ := srv.store.GetSubmission(context.Background(), fx.sub.ID)
+	if after.OutputState != "upload_failed" || after.State != model.SubmissionStateFailed {
+		t.Errorf("dry run changed submission: state=%s output_state=%q", after.State, after.OutputState)
+	}
+}
+
+func TestAdminRedeliver_OriginalMissing(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	fx := seedDelivered(t, srv, f, stage, "upload_failed")
+	if err := os.Remove(fx.original); err != nil {
+		t.Fatal(err)
+	}
+
+	w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	rep := decodeReport(t, env)
+	if rep.Summary.OriginalMissing != 1 || rep.Summary.OK != 0 {
+		t.Fatalf("summary = %+v", rep.Summary)
+	}
+	if got := rep.Files[0]; got.Action != outputActionOriginalMissing || got.OK || got.Error == "" {
+		t.Errorf("file = %+v", got)
+	}
+	// Not every file verified, so the state must not flip.
+	after, _ := srv.store.GetSubmission(context.Background(), fx.sub.ID)
+	if after.OutputState != "upload_failed" || after.State != model.SubmissionStateFailed {
+		t.Errorf("submission changed: state=%s output_state=%q", after.State, after.OutputState)
+	}
+}
+
+// M1: candidates are admitted by stat only — a FIFO (which would block an
+// open forever) and a regular file of the wrong size are skipped without
+// being opened, and the handler returns promptly.
+func TestAdminRedeliver_SkipsFifoAndWrongSizeCandidates(t *testing.T) {
+	stage := t.TempDir()
+	srv, _ := adminOutputsServer(t, true, stage)
+	wfID := createTestWorkflow(t, srv)
+	good := binaryPayload(4)
+
+	// The output's own file:// location is a FIFO: the self-candidate.
+	fifoDir := filepath.Join(stage, "task_fifo")
+	if err := os.MkdirAll(fifoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(fifoDir, "out.bin")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+	// The index candidate: right checksum key, wrong on-disk size.
+	wrongSize := writeOriginal(t, stage, "task_wrong", "out.bin", append(good, 'x'))
+
+	sub := seedSubmission(t, srv, wfID, "sub_fifo", map[string]any{
+		"result": fileObj("file://"+fifo, "out.bin", good),
+	}, "upload_failed")
+	seedTask(t, srv, sub.ID, "task_wrong", model.ExecutorTypeWorker, map[string]any{
+		"result": fileObj(wrongSize, "out.bin", good), // lies about size: says len(good)
+	})
+
+	done := make(chan outputReport, 1)
+	go func() {
+		w, env := postAs(t, srv, "/api/v1/admin/submissions/"+sub.ID+"/redeliver", adminAuthToken)
+		if w.Code != http.StatusOK {
+			t.Errorf("status=%d body=%s", w.Code, w.Body.String())
+		}
+		done <- decodeReport(t, env)
+	}()
+	var rep outputReport
+	select {
+	case rep = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("redeliver hung: a candidate was opened instead of being skipped by stat")
+	}
+
+	if rep.Summary.OriginalMissing != 1 {
+		t.Fatalf("summary = %+v files=%+v", rep.Summary, rep.Files)
+	}
+	got := rep.Files[0]
+	if got.Action != outputActionOriginalMissing {
+		t.Errorf("action = %s", got.Action)
+	}
+	if !strings.Contains(got.Error, "not a regular file") {
+		t.Errorf("FIFO not reported as skipped: %s", got.Error)
+	}
+	if !strings.Contains(got.Error, "has size") {
+		t.Errorf("wrong-size candidate not reported as skipped: %s", got.Error)
+	}
+}
+
+// M2(b): the persist step is compare-and-set against the state loaded at the
+// start of the request; a concurrent change → 409 and nothing written.
+func TestAdminRedeliver_ConcurrentChangeIs409(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	fx := seedDelivered(t, srv, f, stage, "upload_failed")
+
+	// Between the re-upload and the write (the second get_download_url is
+	// the post-upload re-verify), another writer flips output_state.
+	var calls atomic.Int32
+	f.Intercept = func(method string, _ json.RawMessage) (int, string) {
+		if method != "Workspace.get_download_url" || calls.Add(1) != 2 {
+			return 0, ""
+		}
+		cur, err := srv.store.GetSubmission(context.Background(), fx.sub.ID)
+		if err != nil {
+			t.Errorf("load for concurrent write: %v", err)
+			return 0, ""
+		}
+		cur.OutputState = "delivered"
+		if err := srv.store.UpdateSubmission(context.Background(), cur); err != nil {
+			t.Errorf("concurrent write: %v", err)
+		}
+		return 0, ""
+	}
+
+	w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status=%d, want 409; body=%s", w.Code, w.Body.String())
+	}
+	if env.Error == nil || !strings.Contains(env.Error.Message, "changed concurrently") {
+		t.Errorf("error = %+v", env.Error)
+	}
+	// The concurrent writer's row survives untouched: state FAILED and the
+	// error record were not restored by the losing request.
+	after, _ := srv.store.GetSubmission(context.Background(), fx.sub.ID)
+	if after.OutputState != "delivered" || after.State != model.SubmissionStateFailed || after.Error == nil {
+		t.Errorf("row overwritten: state=%s output_state=%q error=%v", after.State, after.OutputState, after.Error)
+	}
+}
+
+// S1: originals are only read from under --redeliver-source-dirs.
+func TestAdminRedeliver_SourceDirAllowlist(t *testing.T) {
+	t.Run("outside allowlist is denied", func(t *testing.T) {
+		stage := t.TempDir()
+		srv, f := adminOutputsServer(t, true, t.TempDir()) // a different dir
+		fx := seedDelivered(t, srv, f, stage, "upload_failed")
+
+		_, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken)
+		rep := decodeReport(t, env)
+		if got := rep.Files[0]; got.Action != outputActionOriginalMissing || !strings.Contains(got.Error, "outside --redeliver-source-dirs") {
+			t.Errorf("file = %+v", got)
+		}
+		if bytes.Equal(f.Bytes(fx.wsPath), fx.good) {
+			t.Errorf("uploaded from a denied path")
+		}
+	})
+
+	t.Run("no allowlist refuses local recovery", func(t *testing.T) {
+		stage := t.TempDir()
+		srv, f := adminOutputsServer(t, true) // none configured
+		fx := seedDelivered(t, srv, f, stage, "upload_failed")
+
+		_, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken)
+		rep := decodeReport(t, env)
+		if got := rep.Files[0]; got.Action != outputActionOriginalMissing || !strings.Contains(got.Error, "no --redeliver-source-dirs") {
+			t.Errorf("file = %+v", got)
+		}
+		after, _ := srv.store.GetSubmission(context.Background(), fx.sub.ID)
+		if after.OutputState != "upload_failed" {
+			t.Errorf("output_state = %q", after.OutputState)
+		}
+	})
+
+	t.Run("symlink escaping the allowlist is denied", func(t *testing.T) {
+		stage := t.TempDir()
+		outside := t.TempDir()
+		srv, f := adminOutputsServer(t, true, stage)
+		wfID := createTestWorkflow(t, srv)
+		good := binaryPayload(4)
+		wsPath := wsHome + "/esc.bin"
+		uploadToFake(t, f, wsPath, corruptedOf(good))
+
+		real := writeOriginal(t, outside, "task_x", "esc.bin", good)
+		linkDir := filepath.Join(stage, "task_x")
+		if err := os.MkdirAll(linkDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(linkDir, "esc.bin")
+		if err := os.Symlink(real[len("file://"):], link); err != nil {
+			t.Fatal(err)
+		}
+		sub := seedSubmission(t, srv, wfID, "sub_esc", map[string]any{
+			"result": fileObj("ws://"+wsPath, "esc.bin", good),
+		}, "delivered")
+		seedTask(t, srv, sub.ID, "task_x", model.ExecutorTypeWorker, map[string]any{
+			"result": fileObj("file://"+link, "esc.bin", good),
+		})
+
+		_, env := postAs(t, srv, "/api/v1/admin/submissions/"+sub.ID+"/redeliver", adminAuthToken)
+		rep := decodeReport(t, env)
+		if got := rep.Files[0]; got.Action != outputActionOriginalMissing {
+			t.Errorf("symlink escape was followed: %+v", got)
+		}
+		if bytes.Equal(f.Bytes(wsPath), good) {
+			t.Errorf("uploaded through an escaping symlink")
+		}
+	})
+}
+
+// An upload_failed submission still carries file:// outputs (never uploaded)
+// and was FAILED by the scheduler; redeliver uploads them under the
+// destination, rewrites the locations, restores COMPLETED, and rewrites the
+// output manifest (S2).
+func TestAdminRedeliver_UploadFailedRestoresState(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	wfID := createTestWorkflow(t, srv)
+	good := binaryPayload(4)
+	loc := writeOriginal(t, stage, "task_b", "model.pdb", good)
+
+	sub := seedSubmission(t, srv, wfID, "sub_failed", map[string]any{
+		"structures": map[string]any{
+			"class":    "Directory",
+			"basename": "models",
+			"listing":  []any{fileObj(loc, "model.pdb", good)},
+		},
+	}, "upload_failed")
+	seedTask(t, srv, sub.ID, "task_b", model.ExecutorTypeWorker, map[string]any{
+		"structures": map[string]any{"class": "Directory", "basename": "models", "listing": []any{fileObj(loc, "model.pdb", good)}},
+	})
+
+	// Verify first: the file:// output is reported as not delivered.
+	_, env := postAs(t, srv, "/api/v1/admin/submissions/"+sub.ID+"/verify-outputs", adminAuthToken)
+	if rep := decodeReport(t, env); rep.Summary.Errors != 1 || rep.Files[0].Error == "" {
+		t.Fatalf("verify report = %+v", rep)
+	}
+
+	w, env := postAs(t, srv, "/api/v1/admin/submissions/"+sub.ID+"/redeliver", adminAuthToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	rep := decodeReport(t, env)
+	wantPath := wsHome + "/models/model.pdb"
+	if rep.Summary.Reuploaded != 1 || rep.Summary.OK != 1 || !rep.Updated || !rep.StateRestored {
+		t.Fatalf("report = %+v", rep)
+	}
+	if got := rep.Files[0]; got.Location != "ws://"+wantPath || got.Action != outputActionReuploaded {
+		t.Errorf("file = %+v", got)
+	}
+	if !bytes.Equal(f.Bytes(wantPath), good) {
+		t.Errorf("workspace bytes at %s do not match", wantPath)
+	}
+
+	after, _ := srv.store.GetSubmission(context.Background(), sub.ID)
+	if after.State != model.SubmissionStateCompleted || after.OutputState != "delivered" || after.Error != nil {
+		t.Errorf("after = state=%s output_state=%s error=%v", after.State, after.OutputState, after.Error)
+	}
+	listing := after.Outputs["structures"].(map[string]any)["listing"].([]any)
+	if loc := listing[0].(map[string]any)["location"]; loc != "ws://"+wantPath {
+		t.Errorf("location not rewritten: %v", loc)
+	}
+
+	// S2: the manifest was rewritten with the ws:// tree.
+	if !rep.ManifestUploaded || rep.ManifestError != "" {
+		t.Errorf("manifest_uploaded=%v error=%q", rep.ManifestUploaded, rep.ManifestError)
+	}
+	manifestPath := wsHome + "/" + staging.OutputManifestName
+	if m := manifestCreates(t, f); len(m) != 1 || m[0] != manifestPath {
+		t.Errorf("manifest creates = %v, want [%s]", m, manifestPath)
+	}
+	var manifest struct {
+		SubmissionID string         `json:"submission_id"`
+		State        string         `json:"state"`
+		Outputs      map[string]any `json:"outputs"`
+	}
+	if err := json.Unmarshal(f.Bytes(manifestPath), &manifest); err != nil {
+		t.Fatalf("manifest not readable: %v", err)
+	}
+	if manifest.SubmissionID != sub.ID || manifest.State != "COMPLETED" || !strings.Contains(string(f.Bytes(manifestPath)), "ws://"+wantPath) {
+		t.Errorf("manifest content = %+v", manifest)
+	}
+}
+
+// S3: one re-delivery per submission at a time.
+func TestAdminRedeliver_InFlightLock(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	fx := seedDelivered(t, srv, f, stage, "upload_failed")
+
+	parked := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	f.HoldShockBody = func(string) <-chan struct{} {
+		var ch <-chan struct{}
+		once.Do(func() {
+			close(parked)
+			ch = release
+		})
+		return ch
+	}
+
+	type result struct {
+		code int
+		rep  outputReport
+	}
+	first := make(chan result, 1)
+	go func() {
+		w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken)
+		var rep outputReport
+		_ = json.Unmarshal(env.Data, &rep)
+		first <- result{w.Code, rep}
+	}()
+
+	select {
+	case <-parked:
+	case <-time.After(10 * time.Second):
+		close(release)
+		t.Fatal("first redeliver never reached the Shock PUT")
+	}
+
+	w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken)
+	if w.Code != http.StatusConflict || env.Error == nil || !strings.Contains(env.Error.Message, "re-delivery in progress") {
+		t.Errorf("second call: status=%d error=%+v, want 409 in progress", w.Code, env.Error)
+	}
+	// The lock is in-memory only: the row never says "uploading".
+	if cur, _ := srv.store.GetSubmission(context.Background(), fx.sub.ID); cur.OutputState != "upload_failed" {
+		t.Errorf("output_state persisted as %q during re-delivery", cur.OutputState)
+	}
+
+	close(release)
+	r := <-first
+	if r.code != http.StatusOK || r.rep.Summary.Failed != 1 {
+		t.Errorf("first call: status=%d summary=%+v (abandoned upload must fail the file)", r.code, r.rep.Summary)
+	}
+
+	// Lock released: a third call is admitted (and fails the same way, since
+	// MaxRetries is 1 and the fake now serves the PUT normally).
+	if w, _ := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken); w.Code == http.StatusConflict {
+		t.Errorf("lock not released after the first request finished")
+	}
+}
+
+// S5: a workspace that serves different bytes after a successful PUT fails
+// the file at re-verification and leaves the submission untouched.
+func TestAdminRedeliver_ReverifyMismatchFails(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	fx := seedDelivered(t, srv, f, stage, "upload_failed")
+	oldNode := f.Object(fx.wsPath).NodeID
+
+	// On the post-upload re-verify, point the object back at the corrupted
+	// node (overwritten nodes are never deleted, as in Shock).
+	var calls atomic.Int32
+	f.Intercept = func(method string, _ json.RawMessage) (int, string) {
+		if method == "Workspace.get_download_url" && calls.Add(1) == 2 {
+			o := f.Object(fx.wsPath)
+			o.NodeID = oldNode
+			f.Put(*o)
+		}
+		return 0, ""
+	}
+
+	w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", adminAuthToken)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	rep := decodeReport(t, env)
+	got := rep.Files[0]
+	if got.Action != outputActionFailed || got.OK || !strings.HasPrefix(got.Error, "re-verify after upload") {
+		t.Errorf("file = %+v", got)
+	}
+	if rep.Summary.Failed != 1 || rep.Summary.Reuploaded != 0 || rep.Updated {
+		t.Errorf("report = %+v", rep)
+	}
+	after, _ := srv.store.GetSubmission(context.Background(), fx.sub.ID)
+	if after.OutputState != "upload_failed" || after.State != model.SubmissionStateFailed {
+		t.Errorf("submission changed: state=%s output_state=%q", after.State, after.OutputState)
+	}
+}
+
+// Child submissions are included: their ws:// outputs are verified and their
+// task rows are searched for originals (checksum+size, not basename).
+func TestAdminOutputs_ChildSubmissionsIncluded(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	wfID := createTestWorkflow(t, srv)
+
+	good := binaryPayload(6)
+	parentWS := wsHome + "/shard.bin"
+	uploadToFake(t, f, parentWS, corruptedOf(good))
+
+	childGood := []byte("child text output\n")
+	childWS := wsHome + "/child/child.txt"
+	uploadToFake(t, f, childWS, childGood)
+
+	parent := seedSubmission(t, srv, wfID, "sub_parent", map[string]any{
+		"gathered": []any{fileObj("ws://"+parentWS, "shard.bin", good)},
+	}, "delivered")
+	// Proxy task: mirrors the child's outputs, as the scheduler does, but a
+	// decoy with the same basename and a different checksum must not match.
+	decoy := writeOriginal(t, stage, "task_decoy", "shard.bin", []byte("not the same bytes"))
+	seedTask(t, srv, parent.ID, "task_proxy", model.ExecutorTypeSubworkflow, map[string]any{})
+	seedTask(t, srv, parent.ID, "task_decoy", model.ExecutorTypeWorker, map[string]any{
+		"x": fileObj(decoy, "shard.bin", []byte("not the same bytes")),
+	})
+
+	child := &model.Submission{
+		ID:           "sub_child",
+		WorkflowID:   wfID,
+		State:        model.SubmissionStateCompleted,
+		Inputs:       map[string]any{},
+		Outputs:      map[string]any{"note": fileObj("ws://"+childWS, "child.txt", childGood)},
+		SubmittedBy:  "tester@bvbrc",
+		ParentTaskID: "task_proxy",
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := srv.store.CreateSubmission(context.Background(), child); err != nil {
+		t.Fatal(err)
+	}
+	original := writeOriginal(t, stage, "task_child", "shard.bin", good)
+	seedTask(t, srv, child.ID, "task_child", model.ExecutorTypeWorker, map[string]any{
+		"shard": fileObj(original, "shard.bin", good),
+	})
+
+	_, env := postAs(t, srv, "/api/v1/admin/submissions/"+parent.ID+"/verify-outputs", adminAuthToken)
+	rep := decodeReport(t, env)
+	if len(rep.Submissions) != 2 || rep.Submissions[1] != child.ID {
+		t.Errorf("submissions = %v", rep.Submissions)
+	}
+	if rep.Summary.Total != 2 || rep.Summary.OK != 1 || rep.Summary.Mismatched != 1 {
+		t.Fatalf("verify summary = %+v", rep.Summary)
+	}
+	bySub := map[string]outputFileReport{}
+	for _, fr := range rep.Files {
+		bySub[fr.SubmissionID] = fr
+	}
+	if !bySub[child.ID].OK || bySub[parent.ID].OK {
+		t.Errorf("files = %+v", rep.Files)
+	}
+
+	_, env = postAs(t, srv, "/api/v1/admin/submissions/"+parent.ID+"/redeliver", adminAuthToken)
+	rep = decodeReport(t, env)
+	if rep.Summary.OK != 2 || rep.Summary.Reuploaded != 1 {
+		t.Fatalf("redeliver summary = %+v files=%+v", rep.Summary, rep.Files)
+	}
+	for _, fr := range rep.Files {
+		if fr.SubmissionID == parent.ID && fr.Source != original[len("file://"):] {
+			t.Errorf("parent output re-uploaded from %q, want the child's original", fr.Source)
+		}
+	}
+	if !bytes.Equal(f.Bytes(parentWS), good) {
+		t.Errorf("parent output not repaired")
+	}
+}
+
+// A ws:// output outside the submission's destination is never re-uploaded.
+func TestAdminRedeliver_LocationOutsideDestination(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	wfID := createTestWorkflow(t, srv)
+	good := binaryPayload(2)
+	elsewhere := "/tester@bvbrc/home/results-evil/x.bin" // shares a name prefix with the base
+	uploadToFake(t, f, elsewhere, corruptedOf(good))
+	loc := writeOriginal(t, stage, "task_e", "x.bin", good)
+	sub := seedSubmission(t, srv, wfID, "sub_outside", map[string]any{
+		"result": fileObj("ws://"+elsewhere, "x.bin", good),
+	}, "delivered")
+	seedTask(t, srv, sub.ID, "task_e", model.ExecutorTypeWorker, map[string]any{"result": fileObj(loc, "x.bin", good)})
+
+	_, env := postAs(t, srv, "/api/v1/admin/submissions/"+sub.ID+"/redeliver", adminAuthToken)
+	rep := decodeReport(t, env)
+	if got := rep.Files[0]; got.Action != outputActionFailed || !strings.Contains(got.Error, "outside the submission's output destination") {
+		t.Errorf("file = %+v", got)
+	}
+	if bytes.Equal(f.Bytes(elsewhere), good) {
+		t.Errorf("uploaded outside the destination")
+	}
+}
+
+func TestAdminVerifyOutputs_ExpiredToken(t *testing.T) {
+	stage := t.TempDir()
+	srv, f := adminOutputsServer(t, true, stage)
+	fx := seedDelivered(t, srv, f, stage, "delivered")
+	fx.sub.TokenExpiry = time.Now().Add(-time.Hour)
+	// TokenExpiry is written on create only; re-create with the past expiry.
+	if err := srv.store.DeleteSubmission(context.Background(), fx.sub.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.store.CreateSubmission(context.Background(), fx.sub); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, ep := range []string{"verify-outputs", "redeliver"} {
+		w, env := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/"+ep, adminAuthToken)
+		if w.Code != http.StatusConflict {
+			t.Errorf("%s: status=%d, want 409; body=%s", ep, w.Code, w.Body.String())
+		}
+		if env.Error == nil || env.Error.Code != model.ErrConflict || !strings.Contains(env.Error.Message, "expired") {
+			t.Errorf("%s: error = %+v", ep, env.Error)
+		}
+	}
+}
+
+func TestAdminOutputs_AccessAndAvailability(t *testing.T) {
+	t.Run("non-admin is forbidden", func(t *testing.T) {
+		stage := t.TempDir()
+		srv, f := adminOutputsServer(t, true, stage)
+		fx := seedDelivered(t, srv, f, stage, "delivered")
+		w, _ := postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/verify-outputs", userAuthToken)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status=%d, want 403", w.Code)
+		}
+		w, _ = postAs(t, srv, "/api/v1/admin/submissions/"+fx.sub.ID+"/redeliver", userAuthToken)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status=%d, want 403", w.Code)
+		}
+	})
+
+	t.Run("unauthenticated is 401", func(t *testing.T) {
+		// Later options win: disable the anonymous access testServer enables.
+		srv := testServer(WithAnonymousConfig(&AnonymousConfig{Enabled: false}))
+		req := httptest.NewRequest("POST", "/api/v1/admin/submissions/sub_x/verify-outputs", nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status=%d, want 401", w.Code)
+		}
+	})
+
+	t.Run("no stager configured", func(t *testing.T) {
+		srv, _ := adminOutputsServer(t, false)
+		w, env := postAs(t, srv, "/api/v1/admin/submissions/sub_x/verify-outputs", adminAuthToken)
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("status=%d, want 503", w.Code)
+		}
+		if env.Error == nil || !strings.Contains(env.Error.Message, "workspace staging not configured") {
+			t.Errorf("error = %+v", env.Error)
+		}
+	})
+
+	t.Run("unknown submission", func(t *testing.T) {
+		srv, _ := adminOutputsServer(t, true)
+		w, _ := postAs(t, srv, "/api/v1/admin/submissions/sub_missing/verify-outputs", adminAuthToken)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("status=%d, want 404", w.Code)
+		}
+	})
+
+	t.Run("no stored token", func(t *testing.T) {
+		srv, _ := adminOutputsServer(t, true)
+		wfID := createTestWorkflow(t, srv)
+		sub := seedSubmission(t, srv, wfID, "sub_notoken", map[string]any{}, "delivered")
+		sub.UserToken = ""
+		_ = srv.store.DeleteSubmission(context.Background(), sub.ID)
+		if err := srv.store.CreateSubmission(context.Background(), sub); err != nil {
+			t.Fatal(err)
+		}
+		w, _ := postAs(t, srv, "/api/v1/admin/submissions/"+sub.ID+"/verify-outputs", adminAuthToken)
+		if w.Code != http.StatusConflict {
+			t.Errorf("status=%d, want 409", w.Code)
+		}
+	})
+
+	// M2(a): only delivered / upload_failed submissions are accepted, by
+	// both endpoints.
+	t.Run("output_state not deliverable", func(t *testing.T) {
+		srv, _ := adminOutputsServer(t, true)
+		wfID := createTestWorkflow(t, srv)
+		for _, st := range []string{"", "skipped", "uploading"} {
+			sub := seedSubmission(t, srv, wfID, "sub_state_"+st, map[string]any{}, st)
+			for _, ep := range []string{"verify-outputs", "redeliver"} {
+				w, env := postAs(t, srv, "/api/v1/admin/submissions/"+sub.ID+"/"+ep, adminAuthToken)
+				if w.Code != http.StatusConflict || env.Error == nil {
+					t.Errorf("%s output_state=%q: status=%d, want 409", ep, st, w.Code)
+					continue
+				}
+				want := "only \"delivered\" or \"upload_failed\""
+				if st == "uploading" {
+					want = "currently being uploaded"
+				}
+				if !strings.Contains(env.Error.Message, want) {
+					t.Errorf("%s output_state=%q: message %q, want containing %q", ep, st, env.Error.Message, want)
+				}
+			}
+		}
+	})
+
+	t.Run("non-terminal is refused", func(t *testing.T) {
+		srv, _ := adminOutputsServer(t, true)
+		wfID := createTestWorkflow(t, srv)
+		sub := seedSubmission(t, srv, wfID, "sub_running", map[string]any{}, "delivered")
+		sub.State = model.SubmissionStateRunning
+		if err := srv.store.UpdateSubmission(context.Background(), sub); err != nil {
+			t.Fatal(err)
+		}
+		w, env := postAs(t, srv, "/api/v1/admin/submissions/"+sub.ID+"/redeliver", adminAuthToken)
+		if w.Code != http.StatusConflict || env.Error == nil || !strings.Contains(env.Error.Message, "terminal") {
+			t.Errorf("status=%d error=%+v, want 409 terminal", w.Code, env.Error)
+		}
+	})
+}
+
+func TestListSubmissions_OutputStateQuery(t *testing.T) {
+	srv, _ := adminOutputsServer(t, true)
+	wfID := createTestWorkflow(t, srv)
+	seedSubmission(t, srv, wfID, "sub_q_delivered", map[string]any{}, "delivered")
+	seedSubmission(t, srv, wfID, "sub_q_failed", map[string]any{}, "upload_failed")
+	seedSubmission(t, srv, wfID, "sub_q_none", map[string]any{}, "")
+
+	req := httptest.NewRequest("GET", "/api/v1/submissions/?output_state=delivered,upload_failed", nil)
+	req.Header.Set("Authorization", "Bearer "+adminAuthToken)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var env envelope
+	_ = json.Unmarshal(w.Body.Bytes(), &env)
+	var subs []map[string]any
+	_ = json.Unmarshal(env.Data, &subs)
+	if len(subs) != 2 || env.Pagination.Total != 2 {
+		t.Fatalf("got %d submissions (total %d), want 2", len(subs), env.Pagination.Total)
+	}
+	for _, s := range subs {
+		if st := s["output_state"]; st != "delivered" && st != "upload_failed" {
+			t.Errorf("unexpected output_state %v", st)
+		}
+	}
+}
+
+// S4: like the scheduler's stage-out walker, secondaryFiles are not visited.
+func TestWalkOutputFiles(t *testing.T) {
+	tree := map[string]any{
+		"single": map[string]any{"class": "File", "location": "ws:///a/one", "secondaryFiles": []any{
+			map[string]any{"class": "File", "location": "ws:///a/one.idx"},
+		}},
+		"array": []any{
+			map[string]any{"class": "File", "location": "ws:///a/two"},
+			[]any{map[string]any{"class": "File", "location": "ws:///a/three"}},
+		},
+		"dir": map[string]any{"class": "Directory", "basename": "top", "listing": []any{
+			map[string]any{"class": "File", "location": "ws:///a/top/four"},
+			map[string]any{"class": "Directory", "basename": "inner", "listing": []any{
+				map[string]any{"class": "File", "location": "ws:///a/top/inner/five"},
+			}},
+		}},
+		"record": map[string]any{"nested": map[string]any{"class": "File", "location": "file:///six"}},
+		"scalar": 42,
+		"null":   nil,
+	}
+	got := map[string]string{}
+	walkOutputFiles(tree, "", func(obj map[string]any, subPath string) {
+		got[obj["location"].(string)] = subPath
+	})
+	want := map[string]string{
+		"ws:///a/one":            "",
+		"ws:///a/two":            "",
+		"ws:///a/three":          "",
+		"ws:///a/top/four":       "top",
+		"ws:///a/top/inner/five": "top/inner",
+		"file:///six":            "",
+	}
+	if _, visited := got["ws:///a/one.idx"]; visited {
+		t.Errorf("secondaryFiles must not be visited")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("visited %v, want %v", got, want)
+	}
+	for loc, sp := range want {
+		if g, ok := got[loc]; !ok || g != sp {
+			t.Errorf("%s: subPath = %q (visited=%v), want %q", loc, g, ok, sp)
+		}
+	}
+}
+
+func TestPathUnderAny(t *testing.T) {
+	base := t.TempDir()
+	inside := filepath.Join(base, "sub", "f.txt")
+	if err := os.MkdirAll(filepath.Dir(inside), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(inside, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sibling := base + "-evil"
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	evil := filepath.Join(sibling, "f.txt")
+	if err := os.WriteFile(evil, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "link.txt")
+	if err := os.Symlink(evil, link); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		p    string
+		dirs []string
+		want bool
+	}{
+		{"inside", inside, []string{base}, true},
+		{"the dir itself", base, []string{base}, true},
+		{"sibling with shared prefix", evil, []string{base}, false},
+		{"symlink escaping", link, []string{base}, false},
+		{"no dirs", inside, nil, false},
+		{"missing path", filepath.Join(base, "nope"), []string{base}, false},
+		{"second dir matches", evil, []string{base, sibling}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathUnderAny(tt.p, tt.dirs); got != tt.want {
+				t.Errorf("pathUnderAny(%s) = %v, want %v", tt.p, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/handler_files.go
+++ b/internal/server/handler_files.go
@@ -365,7 +365,18 @@ func (s *Server) serveDirectoryListing(w http.ResponseWriter, reqID string, dirP
 
 // isPathAllowed checks if a file path is under one of the allowed download directories.
 func (s *Server) isPathAllowed(filePath string) bool {
-	if s.fileUploadConfig == nil || len(s.fileUploadConfig.AllowedDownloadDirs) == 0 {
+	if s.fileUploadConfig == nil {
+		return false
+	}
+	return pathUnderAny(filePath, s.fileUploadConfig.AllowedDownloadDirs)
+}
+
+// pathUnderAny reports whether filePath, with symlinks resolved, lies under
+// one of dirs (also symlink-resolved; prefix + separator check, so a sibling
+// with a shared name prefix never matches). An empty dirs allows nothing;
+// a path that does not exist is never allowed.
+func pathUnderAny(filePath string, dirs []string) bool {
+	if len(dirs) == 0 {
 		return false
 	}
 
@@ -374,7 +385,7 @@ func (s *Server) isPathAllowed(filePath string) bool {
 		return false
 	}
 	cleanPath := filepath.Clean(resolved)
-	for _, dir := range s.fileUploadConfig.AllowedDownloadDirs {
+	for _, dir := range dirs {
 		resolvedDir, err := filepath.EvalSymlinks(dir)
 		if err != nil {
 			continue

--- a/internal/server/handler_helpers.go
+++ b/internal/server/handler_helpers.go
@@ -51,6 +51,9 @@ func parseListOptions(r *http.Request) model.ListOptions {
 	opts.DateStart = q.Get("date_start")
 	opts.DateEnd = q.Get("date_end")
 	opts.WorkflowID = q.Get("workflow_id")
+	// Output delivery state is lowercase ("delivered", "upload_failed") and
+	// may be a comma-separated list; never upper-cased like State.
+	opts.OutputState = strings.TrimSpace(q.Get("output_state"))
 
 	if labels := q["label"]; len(labels) > 0 {
 		opts.Labels = labels

--- a/internal/server/resolve_refs_test.go
+++ b/internal/server/resolve_refs_test.go
@@ -50,7 +50,10 @@ func (m *mockStore) FinalizeSubmission(context.Context, *model.Submission) (bool
 	return true, nil
 }
 func (m *mockStore) ActivateSubmission(context.Context, string) (bool, error) { return true, nil }
-func (m *mockStore) DeleteSubmission(context.Context, string) error           { return nil }
+func (m *mockStore) UpdateSubmissionIfState(context.Context, *model.Submission, model.SubmissionState, string) (bool, error) {
+	return true, nil
+}
+func (m *mockStore) DeleteSubmission(context.Context, string) error { return nil }
 func (m *mockStore) UpdateSubmissionInputs(context.Context, string, map[string]any) error {
 	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -15,6 +17,7 @@ import (
 	"github.com/me/gowe/internal/scheduler"
 	"github.com/me/gowe/internal/store"
 	"github.com/me/gowe/internal/ui"
+	"github.com/me/gowe/pkg/staging"
 )
 
 // Server is the GoWe REST API server.
@@ -27,17 +30,26 @@ type Server struct {
 	validator        *parser.Validator
 	store            store.Store
 	scheduler        scheduler.Scheduler
-	registry         *executor.Registry      // optional; used by dry-run to check executor availability
-	bvbrcCaller      bvbrc.RPCCaller         // optional; AppService caller, nil when no BV-BRC token
-	workspaceURL     string                  // optional; BV-BRC Workspace endpoint for the UI (empty = production)
-	uiUploadMaxSize  int64                   // optional; cap on UI workspace upload bodies (0 = ui default)
-	testApps         []map[string]any        // optional; static app list for testing without BV-BRC
-	ui               *ui.UI                  // UI handler for web interface
-	adminConfig      *AdminConfig            // optional; admin role configuration
-	anonConfig       *AnonymousConfig        // optional; anonymous access configuration
-	workerKeyConfig  *WorkerKeyConfig        // optional; static worker keys (file/env)
-	workerAuth       *WorkerKeyAuthenticator // validates static + DB-backed worker keys
-	fileUploadConfig *FileUploadConfig       // optional; file upload proxy configuration
+	registry         *executor.Registry       // optional; used by dry-run to check executor availability
+	bvbrcCaller      bvbrc.RPCCaller          // optional; AppService caller, nil when no BV-BRC token
+	workspaceURL     string                   // optional; BV-BRC Workspace endpoint for the UI (empty = production)
+	uiUploadMaxSize  int64                    // optional; cap on UI workspace upload bodies (0 = ui default)
+	testApps         []map[string]any         // optional; static app list for testing without BV-BRC
+	ui               *ui.UI                   // UI handler for web interface
+	adminConfig      *AdminConfig             // optional; admin role configuration
+	anonConfig       *AnonymousConfig         // optional; anonymous access configuration
+	workerKeyConfig  *WorkerKeyConfig         // optional; static worker keys (file/env)
+	workerAuth       *WorkerKeyAuthenticator  // validates static + DB-backed worker keys
+	fileUploadConfig *FileUploadConfig        // optional; file upload proxy configuration
+	wsStager         *staging.WorkspaceStager // optional; BV-BRC Workspace stager for admin output verification/re-delivery
+
+	// redeliverSourceDirs is the allowlist of local directories the admin
+	// re-delivery endpoint may read originals from; empty refuses file://
+	// recovery entirely.
+	redeliverSourceDirs []string
+	// redeliverLocks holds one entry per submission with a re-delivery in
+	// flight (in-memory: a crash never leaves a stuck marker behind).
+	redeliverLocks sync.Map
 }
 
 // Option configures optional Server dependencies.
@@ -72,6 +84,29 @@ func WithWorkspaceURL(url string) Option {
 func WithUIUploadMaxSize(n int64) Option {
 	return func(s *Server) {
 		s.uiUploadMaxSize = n
+	}
+}
+
+// WithWorkspaceStager sets the BV-BRC Workspace stager used by the admin
+// output verification and re-delivery endpoints. Without it those endpoints
+// answer 503.
+func WithWorkspaceStager(ws *staging.WorkspaceStager) Option {
+	return func(s *Server) {
+		s.wsStager = ws
+	}
+}
+
+// WithRedeliverSourceDirs sets the directories the admin re-delivery endpoint
+// may read local originals from (symlinks resolved, segment-aware prefix).
+// Without it, re-delivery never opens a local file.
+func WithRedeliverSourceDirs(dirs []string) Option {
+	return func(s *Server) {
+		s.redeliverSourceDirs = nil
+		for _, d := range dirs {
+			if d = strings.TrimSpace(d); d != "" {
+				s.redeliverSourceDirs = append(s.redeliverSourceDirs, d)
+			}
+		}
 	}
 }
 
@@ -307,6 +342,10 @@ func (s *Server) routes() {
 				r.Use(requireAdmin(s.logger))
 				r.Get("/tasks/active", s.handleListActiveTasks)
 				r.Put("/tasks/{tid}/priority", s.handleSetTaskPriority)
+				r.Route("/submissions/{id}", func(r chi.Router) {
+					r.Post("/verify-outputs", s.handleAdminVerifyOutputs)
+					r.Post("/redeliver", s.handleAdminRedeliverOutputs)
+				})
 				r.Get("/users", s.handleListUsers)
 				r.Route("/users/{username}", func(r chi.Router) {
 					r.Put("/role", s.handleSetUserRole)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -608,6 +608,14 @@ func (s *SQLiteStore) ListSubmissions(ctx context.Context, opts model.ListOption
 	if opts.ExcludeChildren {
 		whereClauses = append(whereClauses, "(parent_task_id = '' OR parent_task_id IS NULL)")
 	}
+	if states := opts.OutputStates(); len(states) > 0 {
+		placeholders := make([]string, len(states))
+		for i, st := range states {
+			placeholders[i] = "?"
+			countArgs = append(countArgs, st)
+		}
+		whereClauses = append(whereClauses, "output_state IN ("+strings.Join(placeholders, ",")+")")
+	}
 
 	whereSQL := ""
 	if len(whereClauses) > 0 {
@@ -830,6 +838,20 @@ func (s *SQLiteStore) FinalizeSubmission(ctx context.Context, sub *model.Submiss
 		string(model.SubmissionStateCancelled), string(model.SubmissionStateCompleted), string(model.SubmissionStateFailed))
 	if err != nil {
 		return false, fmt.Errorf("finalize submission %s: %w", sub.ID, err)
+	}
+	return n > 0, nil
+}
+
+// UpdateSubmissionIfState writes the submission only while the row still
+// carries the expected (state, output_state) pair — see store.Store.
+func (s *SQLiteStore) UpdateSubmissionIfState(ctx context.Context, sub *model.Submission, expectState model.SubmissionState, expectOutputState string) (bool, error) {
+	s.logger.Debug("sql", "op", "update_if_state", "table", "submissions", "id", sub.ID,
+		"expect_state", expectState, "expect_output_state", expectOutputState)
+
+	n, err := s.execSubmissionUpdate(ctx, sub, ` WHERE id=? AND state=? AND output_state=?`,
+		sub.ID, string(expectState), expectOutputState)
+	if err != nil {
+		return false, fmt.Errorf("update submission %s if state: %w", sub.ID, err)
 	}
 	return n > 0, nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1822,3 +1822,167 @@ func TestCancelNonTerminalTasks(t *testing.T) {
 		t.Errorf("task_skipped state = %q, want SKIPPED", stateMap["task_skipped"])
 	}
 }
+
+func TestListSubmissions_OutputStateFilter(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	st.CreateWorkflow(ctx, wf)
+
+	seed := func(id, outputState string) {
+		sub := sampleSubmission(wf.ID)
+		sub.ID = id
+		sub.State = model.SubmissionStateCompleted
+		sub.OutputDestination = "ws:///user@bvbrc/home/results"
+		sub.OutputState = outputState
+		if err := st.CreateSubmission(ctx, sub); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	seed("sub_delivered-1", "delivered")
+	seed("sub_delivered-2", "delivered")
+	seed("sub_failed-1", "upload_failed")
+	seed("sub_skipped-1", "skipped")
+	seed("sub_none-1", "")
+
+	ids := func(subs []*model.Submission) map[string]bool {
+		out := map[string]bool{}
+		for _, s := range subs {
+			out[s.ID] = true
+		}
+		return out
+	}
+
+	tests := []struct {
+		name        string
+		outputState string
+		wantTotal   int
+		wantIDs     []string
+	}{
+		{"no filter", "", 5, nil},
+		{"delivered", "delivered", 2, []string{"sub_delivered-1", "sub_delivered-2"}},
+		{"upload_failed", "upload_failed", 1, []string{"sub_failed-1"}},
+		{"comma list", "delivered,upload_failed", 3, []string{"sub_delivered-1", "sub_delivered-2", "sub_failed-1"}},
+		{"comma list with spaces", " delivered , upload_failed ", 3, []string{"sub_delivered-1", "sub_delivered-2", "sub_failed-1"}},
+		{"unknown state", "bogus", 0, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := model.DefaultListOptions()
+			opts.OutputState = tt.outputState
+			subs, total, err := st.ListSubmissions(ctx, opts)
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if total != tt.wantTotal {
+				t.Errorf("total = %d, want %d", total, tt.wantTotal)
+			}
+			if len(subs) != tt.wantTotal {
+				t.Errorf("len = %d, want %d", len(subs), tt.wantTotal)
+			}
+			got := ids(subs)
+			for _, id := range tt.wantIDs {
+				if !got[id] {
+					t.Errorf("missing %s in results %v", id, got)
+				}
+			}
+			// OutputState must round-trip in list results.
+			for _, s := range subs {
+				if tt.outputState != "" && !strings.Contains(tt.outputState, s.OutputState) {
+					t.Errorf("submission %s has output_state %q, not in filter %q", s.ID, s.OutputState, tt.outputState)
+				}
+			}
+		})
+	}
+
+	t.Run("combines with state and exclude_children", func(t *testing.T) {
+		child := sampleSubmission(wf.ID)
+		child.ID = "sub_child-delivered"
+		child.State = model.SubmissionStateCompleted
+		child.OutputState = "delivered"
+		child.ParentTaskID = "task_proxy-1"
+		if err := st.CreateSubmission(ctx, child); err != nil {
+			t.Fatalf("create child: %v", err)
+		}
+		opts := model.DefaultListOptions()
+		opts.OutputState = "delivered"
+		opts.State = "COMPLETED"
+		opts.ExcludeChildren = true
+		_, total, err := st.ListSubmissions(ctx, opts)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if total != 2 {
+			t.Errorf("total = %d, want 2 (children excluded)", total)
+		}
+	})
+}
+
+func TestUpdateSubmissionIfState(t *testing.T) {
+	st := testStore(t)
+	ctx := context.Background()
+
+	wf := sampleWorkflow()
+	st.CreateWorkflow(ctx, wf)
+
+	sub := sampleSubmission(wf.ID)
+	sub.State = model.SubmissionStateFailed
+	sub.OutputState = "upload_failed"
+	sub.OutputDestination = "ws:///user@bvbrc/home/results"
+	if err := st.CreateSubmission(ctx, sub); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	tests := []struct {
+		name              string
+		expectState       model.SubmissionState
+		expectOutputState string
+		wantApplied       bool
+	}{
+		{"state differs", model.SubmissionStateCompleted, "upload_failed", false},
+		{"output_state differs", model.SubmissionStateFailed, "delivered", false},
+		{"both differ", model.SubmissionStateRunning, "", false},
+		{"matches", model.SubmissionStateFailed, "upload_failed", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cur, err := st.GetSubmission(ctx, sub.ID)
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			cur.State = model.SubmissionStateCompleted
+			cur.OutputState = "delivered"
+			cur.Outputs = map[string]any{"written_by": tt.name}
+
+			applied, err := st.UpdateSubmissionIfState(ctx, cur, tt.expectState, tt.expectOutputState)
+			if err != nil {
+				t.Fatalf("update if state: %v", err)
+			}
+			if applied != tt.wantApplied {
+				t.Fatalf("applied = %v, want %v", applied, tt.wantApplied)
+			}
+
+			after, _ := st.GetSubmission(ctx, sub.ID)
+			if !tt.wantApplied {
+				// Row untouched.
+				if after.State != model.SubmissionStateFailed || after.OutputState != "upload_failed" || len(after.Outputs) != 0 {
+					t.Errorf("row changed on applied=false: state=%s output_state=%s outputs=%v", after.State, after.OutputState, after.Outputs)
+				}
+				return
+			}
+			if after.State != model.SubmissionStateCompleted || after.OutputState != "delivered" || after.Outputs["written_by"] != tt.name {
+				t.Errorf("row not written: state=%s output_state=%s outputs=%v", after.State, after.OutputState, after.Outputs)
+			}
+		})
+	}
+
+	t.Run("unknown id", func(t *testing.T) {
+		ghost := sampleSubmission(wf.ID)
+		ghost.ID = "sub_ghost"
+		applied, err := st.UpdateSubmissionIfState(ctx, ghost, model.SubmissionStatePending, "")
+		if err != nil || applied {
+			t.Errorf("applied=%v err=%v, want false/nil", applied, err)
+		}
+	})
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,6 +32,12 @@ type Store interface {
 	// the write is skipped (applied=false, no error) when the submission is
 	// already terminal.
 	FinalizeSubmission(ctx context.Context, sub *model.Submission) (bool, error)
+	// UpdateSubmissionIfState is UpdateSubmission guarded by a compare-and-set
+	// on (state, output_state): the write is skipped (applied=false, no
+	// error) unless the row still holds exactly expectState and
+	// expectOutputState, so a caller that loaded the submission earlier can
+	// never overwrite a concurrent transition.
+	UpdateSubmissionIfState(ctx context.Context, sub *model.Submission, expectState model.SubmissionState, expectOutputState string) (bool, error)
 	// ActivateSubmission moves a submission PENDING→RUNNING; applied=false
 	// (no error) when it is no longer PENDING.
 	ActivateSubmission(ctx context.Context, id string) (bool, error)

--- a/pkg/model/api.go
+++ b/pkg/model/api.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // Response is the standard API response envelope.
 type Response struct {
@@ -43,6 +46,22 @@ type ListOptions struct {
 	// the view; the scheduler must leave it unset because children need
 	// scheduling like any other submission.
 	ExcludeChildren bool
+	// OutputState filters submissions by output delivery state ("delivered",
+	// "upload_failed", ...). A comma-separated list matches any of the given
+	// states. Empty means no filter.
+	OutputState string
+}
+
+// OutputStates splits the OutputState filter into its individual values,
+// trimming whitespace and dropping empties.
+func (o ListOptions) OutputStates() []string {
+	var out []string
+	for _, v := range strings.Split(o.OutputState, ",") {
+		if v = strings.TrimSpace(v); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // DefaultListOptions returns sensible defaults.

--- a/pkg/staging/manifest.go
+++ b/pkg/staging/manifest.go
@@ -1,0 +1,44 @@
+package staging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/me/gowe/pkg/model"
+)
+
+// OutputManifestName is the file written next to a submission's delivered
+// outputs describing them.
+const OutputManifestName = "_gowe_outputs.json"
+
+// UploadOutputManifest writes the submission's outputs as a JSON manifest
+// (workflow output IDs, types, ws:// locations) into baseDest in the
+// workspace, giving users a machine-readable record of what each delivered
+// file is. Shared by the scheduler's post-stage and the admin re-delivery
+// endpoint so both write the same document. Returns the manifest path.
+func UploadOutputManifest(ctx context.Context, stager *WorkspaceStager, sub *model.Submission, baseDest string) (string, error) {
+	manifest := map[string]any{
+		"submission_id": sub.ID,
+		"workflow_id":   sub.WorkflowID,
+		"workflow_name": sub.WorkflowName,
+		"state":         string(sub.State),
+		"outputs":       sub.Outputs,
+	}
+	if sub.CompletedAt != nil {
+		manifest["completed_at"] = sub.CompletedAt.Format(time.RFC3339)
+	}
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	destPath := strings.TrimRight(baseDest, "/") + "/" + OutputManifestName
+	if _, err := stager.UploadContent(ctx, destPath, string(data), StageOptions{}); err != nil {
+		return "", fmt.Errorf("upload manifest: %w", err)
+	}
+	return destPath, nil
+}


### PR DESCRIPTION
## Summary

**PR C of #175** — operational recovery for the production submissions whose Workspace outputs were corrupted before #174 (36 `delivered` + 5 `upload_failed`).

## Endpoints (admin-only, under the existing `requireAdmin` group)

- `POST /api/v1/admin/submissions/{id}/verify-outputs` — strictly read-only: walks the output tree (ws://-aware), streams each Shock-backed file through sha1 and compares to the **checksum the worker recorded before upload**; per-file report + summary. Recurses into child submissions.
- `POST /api/v1/admin/submissions/{id}/redeliver[?dry_run=true]` — finds each local original by **checksum+size** (never basename — scatter siblings share names) across the submission's and descendants' task outputs, re-uploads via the verified streaming stager to the same path, re-verifies by download, rewrites the manifest, and sets `delivered` only when every file verifies (`OUTPUT_STAGING_FAILED` → `COMPLETED` restore). Uses the **stored submission token only** (expired → 409; the admin's own token has no write access to another user's home).
- `ListOptions.OutputState` filter + `gowe admin verify-outputs <id>|--all [--output-state …] [--since …]` and `gowe admin redeliver <id> [--dry-run]`.

## Safety (from adversarial review)

- Worker-reported `file://` paths are **stat-only admitted** (regular file + recorded size) before any open/hash — a reported `/dev/zero` or FIFO cannot hang the handler; plus a `--redeliver-source-dirs` allowlist (`EvalSymlinks` + prefix; recovery refused when unset).
- Final write is **compare-and-set** on the state/output_state loaded at request start (409 on concurrent change) and only allowed from `delivered`/`upload_failed`, so it cannot race the scheduler's poststage or the retry endpoint; per-submission in-flight lock (409).
- Walker matches the scheduler (no `secondaryFiles` descent); ws:// destinations checked against the base; download/header timeouts; token never logged or returned.

20 handler/store/CLI tests incl. the FIFO/size guard, CAS 409, allowlist + symlink escape, in-flight lock, post-upload divergence, child inclusion, 401/403/503/409 matrix. `docs/API_GUIDE.md` §10 documents both endpoints.

## Next (operational, after merge + deploy)

`gowe admin verify-outputs --all --output-state delivered,upload_failed` against production, then `redeliver` per affected submission with `--redeliver-source-dirs /scout/wf/data` on the server.

Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg