### PR TITLE
docs: v0.15.0 updates — upgrade guide, spec draft-9, status, production, dossier

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A CWL v1.2 workflow engine written in Go. GoWe parses Common Workflow Language d
 - **Multiple executor backends** — local processes, Docker/Apptainer containers, distributed workers, BV-BRC remote jobs
 - **Distributed execution** — pull-based worker pools with group routing, dataset affinity, and GPU scheduling
 - **Async scheduler** — tick-based with dependency resolution, scatter/gather, retry logic, and three-level state machines
+- **Non-blocking scatter over sub-workflows** — each scatter combination runs as a child submission paired with a proxy task; children run in parallel, survive restarts, and cancel cascades to every nesting level
+- **Automatic task-directory cleanup** — workers delete a task's working data after success; retain per job with `gowe submit --debug` or per worker with `--keep-task-dirs`
+- **Verified Workspace uploads + admin recovery** — BV-BRC Workspace stage-out streams through Shock upload nodes with size/md5 verification; `gowe admin verify-outputs` / `redeliver` audit and repair delivered outputs
 - **Web UI** — dashboard, submission management, real-time SSE updates, workflow browsing
 - **REST API** — JSON endpoints for workflows, submissions, tasks, workers, and file management
 - **CLI client** — `gowe` command for login, submit, status, logs, cancel, and more
@@ -308,6 +311,7 @@ Commands:
   cancel    Cancel a submission
   logs      Fetch task/submission logs
   apps      List/query BV-BRC apps
+  admin     Verify / re-deliver Workspace outputs (admin role)
 
 Flags:
   --server      Server URL (default http://localhost:8080)
@@ -327,6 +331,18 @@ gowe run --server http://localhost:8080 workflow.cwl job.json
 ```
 
 Flags: `--outdir`, `--no-upload`, `--timeout` (default 5m), `-q/--quiet`.
+
+### Submit and admin flags
+
+```bash
+gowe submit workflow.cwl -i job.json --debug        # workers keep this job's task dirs
+gowe submit workflow.cwl -i job.json --group gpu    # target a worker group
+gowe submit workflow.cwl -i job.json --workspace-upload --workspace-url https://p3.theseed.org/services/Workspace
+
+gowe admin verify-outputs sub_abc                   # read-only checksum audit of ws:// outputs
+gowe admin verify-outputs --all --output-state delivered,upload_failed
+gowe admin redeliver sub_abc --dry-run              # plan a repair; drop --dry-run to run it
+```
 
 ## API
 
@@ -355,10 +371,11 @@ All endpoints are prefixed with `/api/v1`. Responses use a standard envelope:
 | `DELETE` | `/workflows/{id}` | Delete workflow |
 | `POST` | `/workflows/{id}/validate` | Validate workflow |
 | **Submissions** | | |
-| `GET` | `/submissions` | List submissions (`?workflow_id=&state=&search=&sort=&limit=&offset=`) |
+| `GET` | `/submissions` | List submissions (`?workflow_id=&state=&output_state=&search=&sort=&limit=&offset=`; child submissions of scatter/sub-workflow steps are hidden unless `include_children=true`) |
 | `POST` | `/submissions` | Create submission (`workflow_id` accepts ID or name; `?dry_run=true` for validation) |
 | `GET` | `/submissions/{id}` | Get submission |
-| `PUT` | `/submissions/{id}/cancel` | Cancel submission |
+| `PUT` | `/submissions/{id}/cancel` | Cancel submission (cascades to child submissions; returns `children_cancelled`) |
+| `DELETE` | `/submissions/{id}` | Delete submission (`409` while child submissions are active) |
 | `GET` | `/submissions/{id}/tasks` | List tasks |
 | `GET` | `/submissions/{id}/tasks/{tid}` | Get task |
 | `GET` | `/submissions/{id}/tasks/{tid}/logs` | Task logs |
@@ -380,6 +397,8 @@ All endpoints are prefixed with `/api/v1`. Responses use a standard envelope:
 | **Admin** | | |
 | `GET` | `/admin/users` | List users |
 | `PUT` | `/admin/users/{username}/role` | Set user role |
+| `POST` | `/admin/submissions/{id}/verify-outputs` | Verify delivered `ws://` outputs against recorded checksums (read-only) |
+| `POST` | `/admin/submissions/{id}/redeliver` | Re-upload outputs that fail verification from local originals (`?dry_run=true` to plan) |
 
 ## Configuration
 
@@ -401,6 +420,11 @@ All endpoints are prefixed with `/api/v1`. Responses use a standard envelope:
 | `--upload-backend` | `""` | `shock`, `s3`, or `local` |
 | `--upload-local-dir` | `""` | Local directory for file uploads |
 | `--upload-download-dirs` | `""` | Directories allowed for downloads |
+| `--upload-max-size` | `1073741824` | Max upload size in bytes for the file proxy and web UI workspace uploads |
+| `--workspace-staging` | `""` | `server` to pre/post-stage `ws://` inputs and outputs on the server |
+| `--workspace-url` | `""` | BV-BRC Workspace URL for server-side staging and the web UI (default: production) |
+| `--redeliver-source-dirs` | `""` | Directories the admin `redeliver` endpoint may read staged originals from (empty refuses re-upload) |
+| `--token-key-file` | `""` | File holding the token-encryption key (or `GOWE_TOKEN_KEY`) |
 
 ### Worker Flags
 
@@ -422,12 +446,15 @@ All endpoints are prefixed with `/api/v1`. Responses use a standard envelope:
 | `--gpu-id` | `""` | Specific GPU device IDs |
 | `--secret` | `""` | Secret env var `NAME=value` (repeatable, never sent to server) |
 | `--secret-file` | `""` | Load secrets from file |
+| `--keep-task-dirs` | `false` | Retain task working directories after success (failed tasks are always kept) |
 
 ### Environment Variables
 
 | Variable | Used By | Description |
 |----------|---------|-------------|
 | `GOWE_ADMINS` | Server | Comma-separated admin usernames |
+| `GOWE_TOKEN_KEY` | Server | Token-encryption key (32 bytes, base64/hex); `--token-key-file` overrides |
+| `GOWE_WORKSPACE_URL` | CLI | BV-BRC Workspace URL for `gowe submit --workspace-upload` |
 | `BVBRC_TOKEN` | Server | BV-BRC authentication token |
 | `AWS_ACCESS_KEY_ID` | Server/Worker | S3 access key |
 | `AWS_SECRET_ACCESS_KEY` | Server/Worker | S3 secret key |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # GoWe Specification
 
-> **Status**: Living specification · **Version**: draft-8 (2026-08-09)
+> **Status**: Living specification · **Version**: draft-9 (2026-08-26)
 > **Applies to**: GoWe server, worker, CLI, and `cwl-runner`
 > **Companion documents**: [`docs/adr/`](docs/adr/) (why), [`docs/cwl-hints.md`](docs/cwl-hints.md)
 > (hint reference), [`docs/GoWe-Vocabulary.md`](docs/GoWe-Vocabulary.md) (concepts),
@@ -473,10 +473,12 @@ Staging supports **copy**, **symlink**, and **reference** modes.
 
 > **`ws://` (BV-BRC Workspace)** is *defined* — implemented end to end (submission, output
 > mapping, the stager, and server-side pre/post-staging) but not CI-verified, since it requires
-> a live BV-BRC service and a real user token. See
+> a live BV-BRC service and a real user token. Stage-out follows the upload protocol in §10.6
+> (streamed, size- and md5-verified; validated against the live service by the
+> `-tags=integration` tests in `pkg/bvbrc`, not by CI). See
 > [`docs/BVBRC-Workspace-Deep-Dive.md`](docs/BVBRC-Workspace-Deep-Dive.md) for the full
-> submission/result round-trip and the specific gaps (wildcard-glob resolution, large-file
-> streaming, recursive directory download).
+> submission/result round-trip and the remaining gaps (wildcard-glob resolution in the BV-BRC
+> output fallback, recursive `Directory` download on stage-in).
 
 ### 10.3 Server-side staging and upload proxy
 
@@ -505,6 +507,48 @@ inputs. They are declared with the `gowe:ResourceData` hint (§5.2) and matched 
 affinity (§9.2): `prestage` requires a worker advertising the dataset, `cache` prefers one.
 Workers advertise datasets via `--pre-stage-dir` or `--dataset id=path`.
 
+### 10.6 Workspace upload protocol
+
+Every file GoWe writes to a BV-BRC Workspace — scheduler post-staging, the CLI's
+`--workspace-upload`, the web UI's workspace upload, the `_gowe_outputs.json` manifest, and
+admin re-delivery — MUST go through the Workspace service's own Shock-backed upload protocol
+(`pkg/bvbrc.Client.WorkspaceUploadReader`). File bytes MUST NOT be placed in the inline
+`Content` field of `Workspace.create`: it is a JSON string, and JSON encoding replaces every
+byte that is not valid UTF-8 with U+FFFD, silently corrupting binary data (issue #172). The
+only exception is a **zero-byte** payload, which MAY be stored as an empty inline text object.
+
+An upload of `size` bytes proceeds as follows; each step MUST succeed before the next:
+
+1. **Create** — `Workspace.create` the destination path with `createUploadNodes` and
+   `overwrite` set and no inline content. The service allocates a Shock node and returns its
+   URL in `ObjectMeta` slot 11 (`shockurl`; the object's directory is slot 2 and its name
+   slot 0 — parsers MUST tolerate the 12-slot tuple the service emits). Overwrite is
+   destructive-first: the previous object is gone once this call has started. The reply's
+   `ObjectID` is recorded. An empty or malformed node URL is a hard error, never a fallback
+   to inline content.
+2. **Upload** — `PUT` the bytes to that URL as multipart form field `upload` with a
+   non-empty filename, under an `Authorization: OAuth <token>` header, with an exact
+   `Content-Length` (never chunked transfer encoding). A node's file is immutable, so a
+   failed PUT MUST NOT be retried against the same node; a retry starts again at step 1 with
+   a fresh reader. The PUT SHOULD be bounded by a progress watchdog (default 5 min without a
+   byte read or a reply) rather than a total timeout.
+3. **Verify the Shock reply** — the envelope MUST report no error and a success status, the
+   stored `data.file.size` MUST equal `size`, and when the reply carries an md5 checksum it
+   MUST equal the md5 of the bytes sent.
+4. **Refresh metadata** — `Workspace.update_auto_meta` on the object. The returned
+   `ObjectMeta` MUST carry the `ObjectID` recorded in step 1 (a different ID means a
+   concurrent writer replaced the object; the upload MUST fail without deleting anything)
+   and MUST echo `size` as the object size. The refreshed metadata is the result.
+
+On any failure after step 1 the implementation MUST attempt to delete the placeholder object
+it created, guarded by `ObjectID` so that an object written concurrently by another writer
+(e.g. a scatter sibling sharing a path) is never deleted. A placeholder whose create reply
+carried no ID is left in place and the error reported.
+
+Callers own retries: the stager retries the whole sequence per attempt with a fresh reader,
+while transient JSON-RPC failures inside steps 1 and 4 are retried at the RPC level so a good
+PUT is not thrown away.
+
 ---
 
 ## 11. Persistence (normative)
@@ -529,11 +573,11 @@ middleware; worker endpoints via `X-Worker-Key`; admin endpoints require the adm
 |-------|--------------------------|
 | Health | `GET /health` |
 | Workflows | `GET/POST /workflows`, `GET/PUT/DELETE /workflows/{id}`, `GET …/inputs`, `GET …/outputs`, `POST …/validate` |
-| Submissions | `GET/POST /submissions`, `GET /submissions/{id}`, `DELETE /submissions/{id}`, `PUT …/cancel`, `PUT …/retry`, `GET …/tasks`, `GET …/tasks/{tid}/logs` |
+| Submissions | `GET/POST /submissions` (list excludes child submissions unless `include_children=true`), `GET /submissions/{id}`, `DELETE /submissions/{id}`, `PUT …/cancel`, `PUT …/retry`, `GET …/tasks`, `GET …/tasks/{tid}/logs` |
 | Workers | `POST /workers`, `GET /workers`, `GET /workers/{id}/work`, `PUT /workers/{id}/heartbeat`, `PUT …/tasks/{tid}/status`, `PUT …/tasks/{tid}/complete`, `DELETE /workers/{id}` |
 | BV-BRC proxy | `GET /apps`, `GET /apps/{id}`, `GET /apps/{id}/cwl-tool`, `GET /workspace`, file up/download |
 | Streaming | `GET /sse/submissions/{id}` (server-sent events) |
-| Admin | `GET /admin/tasks/active`, `PUT /admin/tasks/{tid}/priority`, user/role and label management |
+| Admin | `GET /admin/tasks/active`, `PUT /admin/tasks/{tid}/priority`, `POST /admin/submissions/{id}/verify-outputs`, `POST /admin/submissions/{id}/redeliver[?dry_run=true]` (§10.6, §13.5), worker-key, user/role and label management |
 
 The full route table is defined in `internal/server/`.
 
@@ -633,6 +677,13 @@ external providers — GoWe stores no user passwords. Rationale for the auth mod
   therefore cannot expose the credential in stored logs.
 - Response bodies MUST NOT expose stored tokens: submission token fields are serialized with
   `json:"-"`.
+- Web UI workspace operations (browse, list, upload) MUST run under the session's own
+  provider token; the server's service-account token MUST NOT be used to read or write a
+  user's Workspace data, and a session without a token MUST be refused (`401` / redirect to
+  login) rather than served under another identity.
+- Admin output verification and re-delivery (§12) MUST act with the submission's stored
+  token only — never the administrator's own token — and MUST refuse (`409`) when that token
+  is missing or expired; the token is never logged or returned.
 - Provider tokens MUST be encrypted at rest. A server-held key (`GOWE_TOKEN_KEY`, or
   `--token-key-file`) enables AES-256-GCM envelope encryption of the submitter's token in
   `submissions.user_token` and of any bearer credential embedded in `tasks.runtime_hints`.

--- a/docs/BVBRC-Workspace-Deep-Dive.md
+++ b/docs/BVBRC-Workspace-Deep-Dive.md
@@ -169,7 +169,7 @@ Beyond the verification gap, these edges only surface against real infrastructur
 | Edge | Detail | Location |
 |------|--------|----------|
 | **Wildcard globs unresolved (fallback)** | When an app does not populate `output_files` **and** an output is a wildcard (`*.fasta`), the glob fallback deliberately skips it — resolving it would require a `WorkspaceLs` of the result folder, which the fallback does not do. The primary `output_files` path is unaffected. | `bvbrc.go:316` |
-| **Whole-file-in-memory staging** | `StageOut` does `os.ReadFile` and buffers the multipart body in memory — memory-bound for multi-GB genomics files. Streaming with a computed `Content-Length` is the fix, but Shock is not verified to accept a chunked body, so it needs a live service to land. | `workspace.go:156` |
+| ~~**Whole-file-in-memory staging**~~ (resolved, PR #177) | `StageOut` now streams the file from disk through `WorkspaceUploadReader` with an exact `Content-Length` (never chunked), a progress watchdog, and size/md5 verification against the Shock reply; verified against the live service by the `pkg/bvbrc` integration tests. See [`SPECIFICATION.md`](../SPECIFICATION.md) §10.6. | `pkg/staging/workspace.go` `uploadFile` |
 | **No recursive directory download** | `StageIn` is single-file; a `ws://` `Directory` output that a local step needs is not recursively listed and downloaded. | `workspace.go:83` |
 | **No submit-time schema validation** | `query_app_description` exists but is not called; bad params fail at BV-BRC, not pre-flight. | `bvbrc.go:95` |
 

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -38,12 +38,12 @@ GoWe production setup on `coconut`, an 8x NVIDIA H200 NVL workstation.
     │   ├── pids/              # PID files for start/stop scripts
     │   ├── uploads/           # File upload storage (local backend)
     │   ├── workdir/           # Per-worker working directories
+    │   │   ├── cpu-worker-1/      # task dirs are deleted after SUCCESS (see --keep-task-dirs)
     │   │   ├── worker-1/
-    │   │   ├── worker-2/
-    │   │   ├── worker-3/
-    │   │   └── worker-gpu/
-    │   └── secrets.env        # HuggingFace tokens (mode 600)
-    └── data/                  # Staged output files
+    │   │   └── ragstack-oa-1/
+    │   ├── secrets.env        # HuggingFace tokens (mode 600)
+    │   └── token.key          # Token-encryption key (--token-key-file, mode 600)
+    └── data/                  # Staged output files (also the --redeliver-source-dirs allowlist)
 
 /local_databases/              # Pre-staged reference datasets
 ├── alphafold/                 # AlphaFold model weights + databases
@@ -231,9 +231,72 @@ GPU 0 is reserved for interactive/other use. The start script assigns workers to
 
 Up to 7 GPU workers can run simultaneously (GPUs 1-7).
 
-## Building Binaries
+## Deploying a Release
 
-Go is not installed natively. All builds run through Apptainer:
+Production runs **tagged releases**, not local builds. Each `vX.Y.Z` tag is built by
+GoReleaser into per-binary archives named `<binary>_<X.Y.Z>_linux_amd64.tar.gz` (plus
+`checksums.txt`) on the [GitHub release](https://github.com/wilke/GoWe/releases). Binaries
+live in `bin/` as `<name>-vX.Y.Z`; the unversioned names (`gowe`, `gowe-server`,
+`gowe-worker`, `cwl-runner`) are symlinks, so rolling back is repointing four links.
+
+```bash
+cd /scout/Experiments/GoWe
+VER=0.15.0
+
+# 1. Download the linux_amd64 archives and install them as versioned binaries
+mkdir -p /tmp/gowe-release-$VER && cd /tmp/gowe-release-$VER
+gh release download v$VER --repo wilke/GoWe --pattern '*_linux_amd64.tar.gz' --pattern checksums.txt
+sha256sum -c --ignore-missing checksums.txt
+for b in gowe gowe-server gowe-worker cwl-runner; do
+  tar -xzf "${b}_${VER}_linux_amd64.tar.gz" "$b"
+  install -m 755 "$b" /scout/Experiments/GoWe/bin/${b}-v$VER
+done
+
+# 2. Repoint the symlinks
+cd /scout/Experiments/GoWe/bin
+for b in gowe gowe-server gowe-worker cwl-runner; do ln -sfn "${b}-v$VER" "$b"; done
+ls -l gowe gowe-server gowe-worker cwl-runner
+
+# 3. Restart the server first, then the workers
+cd /scout/Experiments/GoWe
+SERVER_PID=$(pgrep -f "gowe-server --addr :8091")
+tr '\0' ' ' < /proc/$SERVER_PID/cmdline > /tmp/server_cmdline   # keep the exact flags
+kill -TERM $SERVER_PID && sleep 3
+nohup $(cat /tmp/server_cmdline) > /scout/wf/gowe/logs/server-v$VER.log 2>&1 &
+until curl -sf http://localhost:8091/api/v1/health > /dev/null; do sleep 1; done
+# then SIGTERM each gowe-worker (it finishes its current task) and relaunch it with its
+# previous cmdline — capture it from /proc the same way; per-worker flags are in docs/STATUS.md
+
+# 4. Verify: every worker registers with the new version
+curl -s http://localhost:8091/api/v1/workers | python3 -c \
+  "import sys,json; [print(w['name'], w['state'], w.get('version')) for w in json.load(sys.stdin)['data']]"
+```
+
+Restart the server before the workers: the server owns the schema migrations and the API
+surface. A restarted worker re-registers on start; any task it was running is requeued by
+the server (it no longer appears in the worker's heartbeat) and re-dispatched from scratch.
+
+### Server flags added in 0.15.0
+
+| Flag | Purpose |
+|------|---------|
+| `--redeliver-source-dirs <dir>[,<dir>]` | Allowlist of local directories the admin re-delivery endpoint may read staged originals from — the shared stage-out directory (`/scout/wf/data` here). Without it `redeliver` refuses every local re-upload. The live server passes it; `scripts/start-server.sh` does not yet. |
+| `--workspace-url` | Now also configures the web UI's workspace browser/uploads, which run under the logged-in user's session token only (no server service-account fallback). |
+| `--upload-max-size` | Now also caps web UI workspace uploads (`413` when exceeded; default 1 GB). |
+
+### Recovering Workspace outputs delivered before 0.15.0
+
+Every binary output post-staged to a BV-BRC Workspace by a pre-0.15.0 server is corrupt in
+the stored copy (issue #172). After deploying 0.15.0 with `--redeliver-source-dirs
+/scout/wf/data`, run `gowe admin verify-outputs --all --output-state delivered,upload_failed`,
+then `gowe admin redeliver <id> --dry-run` and `gowe admin redeliver <id>` per affected
+submission. Procedure, requirements, and limits:
+[`upgrading.md`](upgrading.md#admin-recovery-of-workspace-outputs-180).
+
+## Building Binaries (development builds)
+
+Go is not installed natively. All builds run through Apptainer. Dev builds are for testing
+against a scratch database; production is deployed from releases (above).
 
 ```bash
 # Build all binaries with version tags

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,20 +1,57 @@
 # GoWe Project Status
 
-Last updated: 2026-06-16
+Last updated: 2026-08-26
 
 ## Production Deployment
 
 | Item | Value |
 |------|-------|
-| Host | `coconut` |
-| Binary | `ba3bc5e` (dev tag `ba3bc5e-prod-20260616-131431`) — `main` tip |
-| Branch | `main` (PR #115 and this session's PRs #119/#121/#122/#124/#125/#126 all merged) |
-| Server | Port 8091, `--default-executor worker`, `--workspace-staging server` |
-| Workers | 4 total: `cpu-worker-1`, `cpu-worker-2` (no GPU) + `worker-1` (GPU 1), `worker-2` (GPU 2) |
-| GPUs | H200 NVL, IDs 1-2 used by `worker-1`/`worker-2`; GPU 0 reserved |
+| Host | `coconut` (8× NVIDIA H200 NVL) |
+| Binary | **v0.15.0** — tagged [GitHub release](https://github.com/wilke/GoWe/releases/tag/v0.15.0) (`linux_amd64` archives); installed as `bin/<name>-v0.15.0` with the `bin/gowe`, `gowe-server`, `gowe-worker`, `cwl-runner` symlinks pointing at them. Previous release binaries (`*-v0.14.0`, `*-v0.13.2`) retained for rollback |
+| Branch | `main` at `b3d51d1` (release 0.15.0; PRs #165–#170, #174, #177–#180 merged) |
+| Server | Port 8091: `--db /scout/wf/gowe/gowe.db --default-executor worker --scheduler-poll 1s --upload-backend local --upload-local-dir /scout/wf/gowe/uploads --upload-download-dirs ... --admins ... --workspace-staging server --token-key-file /scout/wf/gowe/token.key --redeliver-source-dirs /scout/wf/data` |
+| Workers | 9 total, all reporting `version 0.15.0`: `cpu-worker-1`, `cpu-worker-2` (default group, apptainer, no GPU); `worker-1` (GPU 1), `worker-2` (GPU 2) (default group, apptainer); `ragstack-cpu-1` (group `ragstack-cpu`, `--runtime none`); `ragstack-oa-1..4` (group `ragstack`, apptainer, `--extra-bind /rag`, `--env-file /scout/wf/gowe/ragstack-worker-env.env --secret-file /scout/wf/gowe/ragstack-worker-secrets.env`) |
+| GPUs | 8× H200 NVL on the host; IDs 1-2 used by `worker-1`/`worker-2`; GPU 0 reserved; 3-7 free |
 | URL | https://gowe.software-smithy.org |
 
-> Redeployed 2026-06-16 from `ba3bc5e` (all 5 processes + 4 symlinks consistent). Rollback binary `gowe-server-772f1ab-prod-*` retained in `bin/`. Exact launch commands captured from `/proc` at deploy time (server flags above; workers use `--runtime apptainer --poll 500ms --image-dir /scout/containers --pre-stage-dir /local_databases --extra-bind /scout/data --secret-file ... --env-file ... --workspace-stager`, GPU workers add `--gpu --gpu-id N`).
+> Redeployed 2026-08-26 from the v0.15.0 release (server restarted first, then all 9 workers;
+> `GET /api/v1/workers` shows every worker at `0.15.0`). Launch commands captured from `/proc`
+> at deploy time: the server flags above are the live cmdline — `scripts/start-server.sh` does
+> **not** yet pass `--redeliver-source-dirs`, so a script restart must add it. Default-group
+> workers use `--runtime apptainer --poll 500ms --image-dir /scout/containers --pre-stage-dir
+> /local_databases --extra-bind /scout/data --stage-out file:///scout/wf/data --secret-file
+> /scout/wf/gowe/secrets.env --env-file /scout/wf/gowe/worker-env.env --workspace-stager`;
+> GPU workers add `--gpu --gpu-id N`. Release-based deploy procedure:
+> [`PRODUCTION.md`](PRODUCTION.md#deploying-a-release).
+
+### Recent changes — 0.15.0 (2026-08-26)
+
+Full list in [`CHANGELOG.md`](../CHANGELOG.md); operator notes in [`upgrading.md`](upgrading.md).
+
+- **Scatter over sub-workflows is non-blocking and cancellable** — persisted `subworkflow`
+  proxy tasks paired 1:1 with child submissions ([#167](https://github.com/wilke/GoWe/pull/167),
+  [ADR-0011](adr/0011-scatter-subworkflow-proxy-tasks.md)); CAS submission finalize/activate
+  and bounded list pagination ([#165](https://github.com/wilke/GoWe/pull/165)); synchronous
+  cancel fan-out to all descendants ([#168](https://github.com/wilke/GoWe/pull/168)); child
+  submissions hidden from listings unless `include_children=true`
+  ([#169](https://github.com/wilke/GoWe/pull/169)); spec §7.4 + upgrade guide
+  ([#170](https://github.com/wilke/GoWe/pull/170)).
+- **Workspace stage-out no longer corrupts binary files** — bytes go through Shock upload
+  nodes instead of `Workspace.create`'s inline JSON field; `ObjectMeta` slot layout fixed
+  ([#174](https://github.com/wilke/GoWe/pull/174), issues #171/#172). Uploads are streamed
+  with exact `Content-Length`, verified against the Shock reply and `update_auto_meta`, and
+  placeholders are cleaned up on failure ([#177](https://github.com/wilke/GoWe/pull/177)).
+  Recorded Workspace fixtures and Python/TypeScript MCP parity
+  ([#178](https://github.com/wilke/GoWe/pull/178)). The web UI uses a typed Workspace client
+  under the session token only, with seekable uploads and the `--upload-max-size` cap
+  ([#179](https://github.com/wilke/GoWe/pull/179)).
+- **Admin output recovery** — `POST /api/v1/admin/submissions/{id}/verify-outputs` and
+  `.../redeliver`, `gowe admin verify-outputs|redeliver`, server `--redeliver-source-dirs`
+  ([#180](https://github.com/wilke/GoWe/pull/180)). Production had 36 `delivered` + 5
+  `upload_failed` submissions with pre-#174 outputs to verify/re-deliver.
+- Since 0.14.0 (deployed for the first time here): workers delete task directories after
+  SUCCESS; retention via `gowe submit --debug` or worker `--keep-task-dirs`
+  ([#158](https://github.com/wilke/GoWe/pull/158)).
 
 ### Start/Stop
 

--- a/docs/architecture-dossier.html
+++ b/docs/architecture-dossier.html
@@ -20,7 +20,7 @@
   }
   @media (prefers-reduced-motion:reduce){:root{scroll-behavior:auto}}
   *{box-sizing:border-box}
-  body{margin:0}
+  body{margin:0;background:#F4F4F1;color:#1C1C18}
   .page{background:var(--paper); color:var(--ink); font-family:var(--serif);
     -webkit-font-smoothing:antialiased; line-height:1.5;
     padding:clamp(22px,4vw,60px) clamp(16px,4vw,44px) 90px;}
@@ -288,7 +288,7 @@
 <div class="wrap">
 
   <header>
-    <div class="eyebrow">GoWe · Architecture Dossier</div>
+    <div class="eyebrow">GoWe · Architecture Dossier · v0.15.0 · 2026-08-26</div>
     <h1>Parsing, Scheduling&nbsp;&amp; Placement</h1>
     <p class="lede">A per-layer deep dive into the CWL&nbsp;v1.2 workflow engine — how a
       workflow parses into a DAG, ticks through a scheduler, and lands on one of five
@@ -422,7 +422,7 @@
             </div>
           </div>
           <div class="card track">
-            <div class="track-lab"><b>StepInstance</b><code>step_instance.go</code><span class="lvl">Level 2 · per step · scatter = N</span></div>
+            <div class="track-lab"><b>StepInstance</b><code>step_instance.go</code><span class="lvl">Level 2 · per step · scatter = 1 instance, N indexed tasks</span></div>
             <div class="states">
               <span class="st wait">WAITING</span><span class="arw">→</span>
               <span class="st ready">READY</span><span class="arw">→</span>
@@ -444,8 +444,16 @@
               <span class="st wait">PENDING</span><span class="arw dash">╌╌╌╌╌►</span><span class="st flight">QUEUED</span>
               <span class="note">worker-bound tasks skip <code>SCHEDULED</code> and enqueue directly for checkout</span>
             </div>
+            <div class="shortcut">
+              <span class="st run">RUNNING</span><span class="arw dash">╌╌╌╌╌►</span><span class="fork"><span class="st ok">SUCCESS</span><span class="st bad">FAILED</span></span>
+              <span class="note"><b>proxy task</b> (<code>executor_type: subworkflow</code>) — born <code>RUNNING</code>, never queued; paired 1:1 with a <b>child Submission</b> (<code>parent_task_id</code>) and advanced from the child's terminal state. A cancelled child surfaces as <code>FAILED</code>, never <code>SKIPPED</code>.</span>
+            </div>
           </div>
         </div>
+        <p class="snote"><b>Sub-workflows are submissions.</b> A scatter over a sub-workflow creates one proxy
+          task per combination and one child submission each; children flow through the same tick as
+          top-level runs and the parent fans in by <code>ScatterIndex</code>. Nothing executes inline in the
+          scheduler any more (<code>docs/adr/0011</code>).</p>
       </section>
 
       <section id="s3">
@@ -456,13 +464,17 @@
             <li><span class="k">1</span><span class="t"><b>Advance waiting</b> — <code>WAITING → READY</code> once every dependency is met.
               <p>1.5 · pre-stage workspace inputs for pending submissions (server mode).</p></span></li>
             <li><span class="k">2</span><span class="t"><b>Dispatch</b> — resolve inputs, create <code>Task</code>s, submit to executors.
-              <p>2.5 · re-submit <code>RETRYING</code> tasks.</p></span></li>
+              <p>Sub-workflow steps: all proxy tasks + the <code>DISPATCHED</code> transition in one transaction, then one child submission per task — non-blocking.</p>
+              <p>2.5 · re-submit <code>RETRYING</code> tasks (claimed by compare-and-set; a concurrent cancel wins).</p></span></li>
             <li><span class="k">3</span><span class="t"><b>Poll</b> — query <code>QUEUED</code>/<code>RUNNING</code> async tasks for status.
+              <p>Proxy tasks advance from their child's state instead; a proxy whose parent was cancelled cancels its child (one nesting level per tick), and a proxy without a child re-creates it from <code>task.Job</code> after a crash.</p>
               <p>3.5 · detect stuck queued worker tasks by progress.</p></span></li>
           </ol>
           <ol class="ladder card">
-            <li><span class="k">4</span><span class="t"><b>Advance steps</b> — move <code>DISPATCHED</code>/<code>RUNNING</code> instances forward when all their tasks are terminal.</span></li>
+            <li><span class="k">4</span><span class="t"><b>Advance steps</b> — move <code>DISPATCHED</code>/<code>RUNNING</code> instances forward when all their tasks are terminal.
+              <p>Scatter fan-in waits for the full <code>ScatterIndex</code> set; any <code>SKIPPED</code> task makes the step <code>SKIPPED</code>, never <code>COMPLETED</code>.</p></span></li>
             <li><span class="k">5</span><span class="t"><b>Finalize</b> — settle submissions once every step instance is terminal.
+              <p>Terminal writes are compare-and-set — the loop never overwrites a submission a concurrent cancel already settled.</p>
               <p>5.5 · post-stage outputs to the workspace (server mode).</p></span></li>
             <li><span class="k">6</span><span class="t"><b>Retries</b> — send newly-<code>FAILED</code> tasks to <code>RETRYING</code> while attempts remain.</span></li>
           </ol>
@@ -507,8 +519,11 @@
             <div class="lp">Stages outputs, then posts status and the final result back to the server.</div>
             <span class="lep">PUT …/status · PUT …/complete</span></div>
           <div class="lstep"><div class="ln">04 · heartbeat</div><div class="lt">Stay alive</div>
-            <div class="lp">Periodic heartbeat keeps the worker registered; the scheduler flags stalled claims.</div>
+            <div class="lp">Periodic heartbeat keeps the worker registered, carries cancel signals back, and lets the scheduler flag stalled claims.</div>
             <span class="lep">PUT /workers/{id}/heartbeat</span></div>
+          <div class="lstep"><div class="ln">05 · cleanup</div><div class="lt">Forget it</div>
+            <div class="lp">Once the server accepts a <code>SUCCESS</code>, the task directory is deleted. Kept for failed or cancelled tasks, <code>gowe submit --debug</code> jobs, <code>--keep-task-dirs</code> workers, and outputs staged in place.</div>
+            <span class="lep">internal/worker · cleanupTaskDir</span></div>
         </div></div>
         <p class="snote">Dataset affinity: <code>prestage</code> = require a match · <code>cache</code> = prefer one.
           Container capability and worker group must match before a task is handed out.</p>
@@ -562,7 +577,7 @@
               <div class="pt"><span class="glyph" style="background:var(--accent-wash);color:var(--accent-deep)">◆</span>Server</div>
               <div class="pk">auth middleware · store</div>
               <div class="pd">Validates the token, applies roles, persists the run. No passwords at rest.</div>
-              <ul><li>roles: user · admin · anon</li><li>worker-key registry</li><li>user_token in submissions</li></ul>
+              <ul><li>roles: user · admin · anon</li><li>per-worker keys (hashed)</li><li>user_token encrypted at rest</li></ul>
             </div>
             <div class="link"><div class="ll">worker-key + task</div><div class="bar"></div><div class="lw">may carry deleg. token</div></div>
             <div class="proc zone">
@@ -575,13 +590,15 @@
           <p class="noreturn">◀ &nbsp;<b>Return path carries results only</b> — injected secrets and container env never flow back to the server.</p>
         </div>
 
-        <div class="callout warn">
-          <b>Current-state caveats.</b> The design is sound, but a few things are worth knowing before
-          production: the submitter's BV-BRC token is persisted <b>plaintext</b> in
-          <code>submissions.user_token</code> (SQLite); the worker key is a <b>shared</b> secret with no
-          per-worker rotation; and server TLS is <b>not enforced by default</b>
-          (<code>Secure:false</code>, a standing TODO) — front the server with a TLS terminator. Anonymous
-          access is opt-in and should always be scoped with <code>--anonymous-executors</code>.
+        <div class="callout">
+          <b>Hardened since the first edition.</b> Provider tokens are encrypted at rest
+          (AES-256-GCM, bound to their row; <code>--token-key-file</code> / <code>GOWE_TOKEN_KEY</code> — a
+          server without a key refuses to persist tokens unless <code>--allow-plaintext-tokens</code>);
+          worker keys are per-worker, hashed, and admin-issued; the server terminates TLS natively when
+          configured. Two identity rules were added in 0.15: user Workspace operations from the UI use the
+          <b>session's own token</b> only — the server never acts on user data with a service account — and
+          admin output recovery re-uploads with the <b>stored submission token</b>, never the admin's.
+          Anonymous access remains opt-in and should be scoped with <code>--anonymous-executors</code>.
         </div>
       </section>
 
@@ -721,17 +738,37 @@
             <tr><td class="pkg">shock://</td><td><code>shock.go</code></td>
               <td class="role">Shock data service — <code>shock://host/node/{id}</code>.</td><td><span class="spill def">defined</span></td></tr>
             <tr><td class="pkg">ws://</td><td><code>workspace.go</code></td>
-              <td class="role">BV-BRC Workspace — the default for BV-BRC runs.</td><td><span class="spill def">defined</span></td></tr>
+              <td class="role">BV-BRC Workspace — the default for BV-BRC runs. Uploads go through Shock upload nodes and are verified.</td><td><span class="spill def">defined</span></td></tr>
             <tr><td class="pkg">s3://</td><td><code>s3.go</code></td>
-              <td class="role">S3-compatible object storage.</td><td><span class="spill plan">planned</span></td></tr>
+              <td class="role">S3-compatible object storage (<code>--s3-*</code> worker flags).</td><td><span class="spill def">defined</span></td></tr>
           </tbody>
         </table></div>
         <p class="snote"><b>Why <code>ws://</code> is "defined", not "supported".</b> The BV-BRC path is
           built end to end — submit, poll, output mapping, and server-side pre/post-staging — but it
           can't run in the conformance suite (it needs a live BV-BRC service and a real token), and it
-          carries edges only visible against real infrastructure: wildcard-glob outputs, large-file
-          streaming, and recursive directory download. Full round-trip in
+          carries edges only visible against real infrastructure: wildcard-glob outputs and recursive
+          directory download. Large-file streaming landed in 0.15 (below). Full round-trip in
           <code>docs/BVBRC-Workspace-Deep-Dive.md</code>.</p>
+
+        <div class="card subcard" style="margin-top:20px">
+          <div class="eyebrow">Verified Workspace uploads · 0.15</div>
+          <p class="snote" style="margin-top:10px">Before 0.15 the stager pushed file bytes through a JSON
+            string field, which silently rewrote every non-UTF-8 byte — every gzip and binary output landed
+            corrupt while reporting <code>delivered</code>. Stage-out now follows the Workspace's own client
+            protocol and verifies what was stored:</p>
+<pre><span class="c"># one output file</span>
+<span class="k">Workspace.create</span>   <span class="v">createUploadNodes + overwrite</span>   <span class="c">→ Shock node URL (slot 11)</span>
+<span class="k">PUT</span> <span class="v">&lt;node&gt;</span>            multipart <span class="v">upload</span>, exact Content-Length, <span class="v">OAuth &lt;token&gt;</span>, stall watchdog
+<span class="k">verify</span>             Shock reply: error · status · <span class="v">file.size</span> · md5 when present
+<span class="k">Workspace.update_auto_meta</span>  reply size <span class="v">MUST</span> equal the bytes sent
+<span class="c"># any failure after create → placeholder deleted (only if still ours) → caller retries with a fresh node</span></pre>
+          <p class="snote" style="margin-top:10px"><b>Recovery.</b> Workers record each output's size and
+            <code>sha1</code> before upload, and keep the originals in their stage-out directory. Admins can
+            audit and repair delivered runs: <code>gowe admin verify-outputs</code> downloads and re-hashes;
+            <code>gowe admin redeliver</code> re-uploads mismatches from originals matched by
+            checksum + size (server flag <code>--redeliver-source-dirs</code>), re-verifies, and rewrites the
+            manifest — compare-and-set, never destructive.</p>
+        </div>
 
         <div class="cols" style="margin-top:20px">
           <div class="card subcard">
@@ -766,7 +803,7 @@ gowe submit workflow.cwl <span class="k">--inputs</span> <span class="v">job.yam
   </div>
 
   <footer class="foot">
-    <span>GoWe · CWL v1.2 workflow engine · Go</span>
+    <span>GoWe · CWL v1.2 workflow engine · Go · dossier refreshed for v0.15.0</span>
     <span>parser → scheduler → executor · <a href="https://github.com/wilke/GoWe">github.com/wilke/GoWe</a></span>
   </footer>
 

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -69,6 +69,9 @@ gowe submit --workflow <id-or-name> [flags]
 - `--output-destination` - Target URI for uploading outputs (e.g., `ws:///user@bvbrc/home/results/`)
 - `--group` - Target worker group for task scheduling
 - `--no-upload` - Disable file upload; assume files are accessible on workers
+- `--workspace-upload` - Upload input files to the BV-BRC Workspace instead of the server (for the `bvbrc` executor)
+- `--workspace-url` - Workspace service URL for `--workspace-upload` (or `GOWE_WORKSPACE_URL`; default: production)
+- `--debug` - Debug mode for this submission: workers keep its task working directories instead of deleting them after success (distinct from the global `--debug` logging flag)
 - `--dry-run` - Validate without executing
 
 **Examples:**
@@ -94,6 +97,9 @@ gowe submit pipeline.cwl -i inputs.yaml --group gpu-workers
 
 # Validate without running
 gowe submit pipeline.cwl -i inputs.yaml --dry-run
+
+# Keep every task's working directory on the workers for troubleshooting
+gowe submit pipeline.cwl -i inputs.yaml --debug
 ```
 
 **Input file format (YAML):**
@@ -357,6 +363,44 @@ Parameters:
   output_path        folder    Required   Output folder
   output_file        string    Required   Output filename prefix
 ```
+
+### admin
+
+Administrative operations; the caller must hold the **admin** role.
+
+```bash
+gowe admin verify-outputs <submission_id> | --all [--output-state delivered,upload_failed] [--since YYYY-MM-DD] [--json]
+gowe admin redeliver <submission_id> [--dry-run] [--json]
+```
+
+**verify-outputs** (read-only) downloads every `ws://` output of a submission — including
+sub-workflow child submissions — and compares it to the SHA-1 checksum and size the worker
+recorded before upload. `--all` verifies every submission whose `output_state` matches
+`--output-state` (default `delivered,upload_failed`), optionally created on/after `--since`.
+
+**redeliver** re-uploads each output that fails verification from its local original (found
+by checksum+size among the task outputs, read only from the server's
+`--redeliver-source-dirs`), re-verifies it, rewrites the output manifest, and marks the
+submission `delivered` once every output verifies. `--dry-run` reports the plan
+(`would_reupload` / `original_missing`) without changing anything. Nothing is ever deleted.
+
+Both act with the submission's **stored** token (the admin's own token has no write access
+to another user's workspace) and exit non-zero when any output fails. Server-side errors:
+`503` when workspace staging is not configured, `409` when the submission is not terminal,
+its `output_state` is not `delivered`/`upload_failed`, its stored token is missing or
+expired, or another re-delivery of it is in progress.
+
+```bash
+gowe admin verify-outputs sub_abc
+gowe admin verify-outputs --all --since 2026-06-01 --json > verify.json
+gowe admin redeliver sub_abc --dry-run
+gowe admin redeliver sub_abc
+```
+
+See [API_GUIDE.md §10](../API_GUIDE.md#10-admin-verify-and-re-deliver-workspace-outputs) and
+[upgrading.md](../upgrading.md) for the post-0.15.0 recovery procedure.
+
+---
 
 ## Tutorial: Complete Workflow Submission
 

--- a/docs/tools/worker.md
+++ b/docs/tools/worker.md
@@ -922,15 +922,19 @@ apptainer pull docker://ubuntu:22.04
 
 ### Work directory full
 
-Workers automatically delete a task's working directory (and its `_tmp`
-sibling) once the server accepts the task's SUCCESS result. Directories are
-retained when:
+Workers automatically delete a task's working directory (and its `_tmp` and
+`_staging` siblings) once the server accepts the task's SUCCESS result.
+Directories are retained when:
 
 - the task **failed** or was cancelled (kept for debugging)
 - the submission was run with `gowe submit --debug`
 - the worker runs with `--keep-task-dirs`
 - outputs are staged in place (`--stage-out local`), where downstream tasks
   read directly from the task directory
+
+Staged copies in a shared stage-out directory (`--stage-out file:///...`) or in
+Shock are not cleaned by the worker; submission-level retention of those
+intermediates is tracked in [#159](https://github.com/wilke/GoWe/issues/159).
 
 Clean up retained directories manually:
 ```bash

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,7 +4,15 @@ Version-specific operator guidance. Routine upgrades (stop server, replace binar
 restart) need no special steps — schema migrations run automatically at startup. Entries
 below cover the exceptions.
 
-## 0.14.x → 0.15.0 — scatter over sub-workflows becomes non-blocking
+## 0.14.x → 0.15.0
+
+0.15.0 ([CHANGELOG](../CHANGELOG.md)) changes four things an operator has to know about:
+scatter over sub-workflows becomes non-blocking (#164), worker task directories are cleaned
+up after success (#157, shipped in 0.14.0 and documented here because most deployments
+skipped that release), Workspace stage-out goes through verified Shock uploads (#171, #172,
+#175), and an admin recovery path exists for outputs delivered before the fix (#180).
+
+### Scatter over sub-workflows becomes non-blocking
 
 0.15.0 replaces the inline serial sub-workflow executor with persisted proxy tasks paired
 1:1 with child submissions
@@ -35,3 +43,126 @@ Also note two API behavior changes in 0.15.0:
   `include_children=true` to list them (see [`API_GUIDE.md`](API_GUIDE.md) §7).
 - `DELETE /api/v1/submissions/{id}` returns `409 Conflict` while any descendant child
   submission is active — cancel first and let the cascade finish.
+
+### Worker task-directory cleanup (0.14.0, #157 / PR #158)
+
+Workers now delete `<workdir>/<task-id>` and its `_tmp` and `_staging` siblings as soon as
+the server has accepted the task's **SUCCESS** result. Before 0.14.0 every task's staged
+inputs, scratch space, and output originals stayed on disk forever (production workers had
+accumulated 16–18 GB each).
+
+Directories are **retained** when:
+
+- the task **FAILED** or was cancelled (SKIPPED) — these never reach the cleanup path;
+- the submission was made with `gowe submit --debug` (persisted as the submission label
+  `debug=true` and propagated to every task as `RuntimeHints.Debug`) — per-job retention
+  for troubleshooting;
+- the worker runs with `--keep-task-dirs` — keeps everything that lands on that worker;
+- any reported output location still resolves into the task directory — the guard for
+  in-place stage-out (`--stage-out local`, or a shared-filesystem stager without a
+  stage-out directory) and for a failed `StageOut` that fell back to the local path. In
+  those configurations the task directory *is* the store downstream tasks read from.
+
+With a copying or uploading stage-out (`file:///shared`, `shock://`, `s3://`, `ws://`) the
+staged copy is the inter-task hand-off, so deletion right after the report is safe.
+
+What is **not** cleaned: the staged intermediates themselves. Files copied into the shared
+stage-out directory (`--stage-out file:///...`) or uploaded to Shock stay after the
+submission completes; submission-level retention is tracked in #159. If you relied on
+inspecting a successful task's working directory after the fact, use `gowe submit --debug`
+for that job or `--keep-task-dirs` on the worker.
+
+### Workspace stage-out through verified Shock uploads (#171, #172, #175)
+
+Before 0.15.0 the scheduler's `ws://` post-staging (`--workspace-staging server`) and the
+CLI's Workspace input upload (`gowe submit --workspace-upload`) put the file bytes into the
+inline `Content` field of `Workspace.create`. That field is a JSON string, and
+`encoding/json` replaces every byte that is not valid UTF-8 with U+FFFD (three bytes for
+one), so **every binary output delivered to a Workspace before 0.15.0 is corrupt in the
+stored copy** (gzip, float arrays, PDBs with non-ASCII bytes, ...) while text outputs
+round-tripped intact. The web UI's workspace upload had its own defects, fixed at the same
+time: its small-file branch handed raw bytes to `Workspace.create`, which base64-encoded
+them into the object, and its large-file branch read the Shock URL from the wrong
+`ObjectMeta` slot. The engine recorded the pre-upload size and reported
+`output_state=delivered`, so nothing looked wrong until a downstream sha256 manifest
+failed (#172). The original bytes are not present in the stored copies; recovery needs
+the local originals (see the next subsection). The entangled #171 bug — the engine parsed
+the Workspace `ObjectMeta` tuple with the wrong slot layout (Shock URL is slot 11, not 10)
+— was fixed with it.
+
+0.15.0 uses the Workspace service's own upload protocol for **every** file, with
+verification (normative description in [`SPECIFICATION.md`](../SPECIFICATION.md) §10.6):
+`Workspace.create` with `createUploadNodes` → multipart `PUT` of the bytes to the returned
+Shock node with an exact `Content-Length` → check of the Shock reply (size, md5 when
+present) → `Workspace.update_auto_meta`, whose reply must echo the size. A failed upload
+deletes its own placeholder object; there is no size below which bytes go back through
+the JSON field. Only zero-byte files are stored inline.
+
+What changes for operators:
+
+- **Server `--workspace-url`** now configures both the scheduler's stager and the web UI's
+  workspace browser/uploads (default: the production BV-BRC Workspace).
+- **The web UI acts as the logged-in user only.** The server's service-account
+  (`BVBRC_TOKEN`) path for user workspace operations is gone; every browse, list, and
+  upload uses the session token. A session without a token gets `401` on the UI API and a
+  redirect to `/login` on pages.
+- **`--upload-max-size`** (default 1 GB) now also caps web UI workspace uploads (`413`
+  when exceeded). Uploads larger than 32 MiB spill to disk instead of RAM.
+- **CLI:** `gowe submit --workspace-upload` takes `--workspace-url` (or
+  `GOWE_WORKSPACE_URL`), retries with a fresh node per attempt, and cleans up on Ctrl-C.
+- **Stage-out streams from disk** — no whole-file buffering, so multi-GB outputs no longer
+  need equivalent RAM on the server. The PUT is bounded by a progress watchdog
+  (5 minutes without progress), not a total timeout.
+- **Text outputs are Shock-backed too.** `Workspace.get` on a staged-out object returns
+  the Shock node URL as its `data`, not the content; anything that read `_gowe_outputs.json`
+  inline out of `Workspace.get` must follow the URL (or use `get_download_url`). GoWe's
+  own stage-in path is unaffected.
+
+### Admin recovery of Workspace outputs (#180)
+
+Two admin-only endpoints and matching CLI commands verify and repair Workspace deliveries
+(request/response detail in [`API_GUIDE.md`](API_GUIDE.md) §10):
+
+| Operation | What it does |
+|-----------|--------------|
+| `gowe admin verify-outputs <id>` / `--all [--output-state ...] [--since YYYY-MM-DD]` | `POST /api/v1/admin/submissions/{id}/verify-outputs` — read-only; downloads every `ws://` output (child submissions included) and compares it to the sha1 checksum and size the worker recorded before upload. |
+| `gowe admin redeliver <id> [--dry-run]` | `POST /api/v1/admin/submissions/{id}/redeliver` — locates the local original of each failing file by checksum+size among the task outputs, re-uploads it through the verified stager to the same path, re-verifies, rewrites the manifest, and sets `delivered` (restoring `COMPLETED` for an `OUTPUT_STAGING_FAILED` failure) only when every output verifies. |
+
+Requirements and limits:
+
+- The server must be started with **`--redeliver-source-dirs <dir>[,<dir>...]`**, the
+  allowlist of local directories originals may be read from (typically the shared
+  stage-out directory, e.g. `/scout/wf/data`). Symlinks are resolved and only regular files
+  of the recorded size are opened. Without the flag `redeliver` refuses every local
+  re-upload (originals report `original_missing`).
+- Workspace staging must be configured (`--workspace-staging server`), otherwise `503`.
+- Both operations use the **submission's stored token only** — the admin's token has no
+  write access to another user's home. A missing or expired stored token yields `409`; the
+  owner must re-submit.
+- Only terminal submissions with `output_state` `delivered` or `upload_failed` are
+  accepted (`409` otherwise, including `uploading`). One re-delivery per submission at a
+  time; the final write is compare-and-set (`409` on a concurrent change).
+- Nothing is ever deleted from the Workspace.
+
+**Recommended post-upgrade procedure** for deployments that delivered outputs to a
+Workspace before 0.15.0 — the local originals must still exist in the stage-out
+directory (task-dir cleanup does not touch it):
+
+```bash
+# 1. Restart the server with the allowlist (plus your existing flags)
+gowe-server ... --workspace-staging server --redeliver-source-dirs /scout/wf/data
+
+# 2. Find every affected submission (read-only; exits non-zero when anything mismatches)
+gowe admin verify-outputs --all --output-state delivered,upload_failed
+gowe admin verify-outputs --all --output-state delivered,upload_failed --json > verify.json
+
+# 3. For each submission with mismatches: plan, then repair
+gowe admin redeliver sub_abc --dry-run     # would_reupload / original_missing per file
+gowe admin redeliver sub_abc               # re-upload, re-verify, mark delivered
+
+# 4. Confirm
+gowe admin verify-outputs sub_abc
+```
+
+Outputs whose originals are gone (`original_missing`) cannot be repaired; regenerate them
+by re-running the submission.

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -93,6 +93,8 @@ else
     fi
     chmod 600 "$TOKEN_KEY_FILE" 2>/dev/null || true
     TOKEN_FLAGS=(--token-key-file "$TOKEN_KEY_FILE")
+    # REDELIVER_SOURCE_DIRS: roots the admin re-delivery endpoint may read originals
+    # from (the workers' --stage-out dir). Required for `gowe admin redeliver`.
 fi
 
 ./bin/gowe-server \
@@ -108,6 +110,7 @@ fi
     --log-level "$LOG_LEVEL" \
     --admins "$ADMINS" \
     --workspace-staging server \
+    --redeliver-source-dirs "${REDELIVER_SOURCE_DIRS:-/scout/wf/data}" \
     > "$LOG_DIR/server.log" 2>&1 &
 echo $! > "$PID_DIR/server.pid"
 echo "  server  PID=$(cat "$PID_DIR/server.pid")  port=${GOWE_PORT}"


### PR DESCRIPTION
## Summary

Documentation catch-up for everything that shipped in v0.15.0 (#164 scatter-over-subworkflow, #158 task-dir cleanup, #171/#172/#175 Workspace upload hardening and recovery), plus one operational fix.

- **`docs/upgrading.md`** — full 0.14.x → 0.15.0 operator guidance: task-dir retention rules, Workspace upload changes (session-only UI identity, `--upload-max-size` cap, `--workspace-url` for UI+stager, CLI flags), and the **recovery procedure** (`verify-outputs --all --output-state delivered,upload_failed` → `redeliver --dry-run` → `redeliver`) for deployments that delivered binary outputs before 0.15.0
- **`SPECIFICATION.md` draft-9** — normative **§10.6 Workspace upload protocol**; §10.2 streaming gap resolved; §12 admin endpoints; §13.5 identity rules
- **`docs/STATUS.md` / `docs/PRODUCTION.md`** — release-based deploy procedure (tagged archives → versioned binaries → symlinks), current 9-worker layout, new flags
- **README / `docs/tools/*`** — features, flags, `gowe admin`
- **`docs/architecture-dossier.html`** — refreshed for 0.15.0 and published as an Artifact from this same file (proxy-task sub-workflows, worker cleanup step, credential hardening replacing the stale plaintext-token caveat, verified uploads + recovery, S3 status)
- **`scripts/start-server.sh`** — now passes `--redeliver-source-dirs` (production was launched with it manually; a script restart would have dropped it)

Every claim was written against the merged code/PRs; the writer's uncertainties (manifest is Shock-backed, not inline; #158 shipped in 0.14.0 and is labelled so; UI corruption mechanism differed from the engine's) were resolved from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1c892qK5j9By9H4P1ERgg